### PR TITLE
fix small autocomplete typo

### DIFF
--- a/plugins/ROS/shape_shifter_factory.hpp
+++ b/plugins/ROS/shape_shifter_factory.hpp
@@ -7,7 +7,7 @@ class ShapeShifterFactory{
 public:
   static ShapeShifterFactory &getInstance();
 
-  void registerMessage(const std::string& topic_name, const std::__cxx11::string &md5sum, const std::string& datatype, const std::string& definition );
+  void registerMessage(const std::string& topic_name, const std::string &md5sum, const std::string& datatype, const std::string& definition );
 
   boost::optional<RosIntrospection::ShapeShifter *> getMessage(const std::string& topic_name);
 


### PR DESCRIPTION
This looks like a great project.
I just had a small error when compiling.
This std::__cxx11::string probably just slipped in through auto-complete, since it is used nowhere else.
Removing it made it compile for me on Ubuntu 14.04 with gcc 4.8.4.
