### PR TITLE
Main Menu fix

### DIFF
--- a/plotter_gui/mainwindow.cpp
+++ b/plotter_gui/mainwindow.cpp
@@ -65,6 +65,8 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->horizontalSpacer->changeSize(0,0, QSizePolicy::Fixed, QSizePolicy::Fixed);
     ui->streamingLabel->setHidden(true);
     ui->streamingSpinBox->setHidden(true);
+    ui->menuBar->show();
+    
     this->repaint();
 }
 


### PR DESCRIPTION
For some reason the main window's menu bar does not show up on Ubuntu 14.04 using Gnome Flashback Session.
Adding a simple show() call makes it work...