### PR TITLE
Prevent compiler warning if compiling under ROS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,9 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 if(COMPILING_WITH_CATKIN)
-    message("---------------------------------------------------------------------")
-    message("PlotJuggler is being built using CATKIN. ROS plugins will be compiled")
-    message("---------------------------------------------------------------------")
+    message(STATUS "---------------------------------------------------------------------")
+    message(STATUS "PlotJuggler is being built using CATKIN. ROS plugins will be compiled")
+    message(STATUS "---------------------------------------------------------------------")
 
     find_package(catkin REQUIRED COMPONENTS
         rosbag


### PR DESCRIPTION
Adding STATUS to the message will still show it with a manual make but will not be seen by the catkin build system as a warning.