### PR TITLE
Add dummy returns to function that required it

### DIFF
--- a/plugins/ROS/RosoutPublisher/logs_table_model.cpp
+++ b/plugins/ROS/RosoutPublisher/logs_table_model.cpp
@@ -107,6 +107,7 @@ QVariant LogsTableModel::data(const QModelIndex &index, int role) const
     else{
         return QVariant();
     }
+    return QVariant();
 }
 
 LogsTableModel::LogItem LogsTableModel::convertRosout( const rosgraph_msgs::Log &log)

--- a/plugins/ROS/RosoutPublisher/modelfilter.cpp
+++ b/plugins/ROS/RosoutPublisher/modelfilter.cpp
@@ -205,5 +205,6 @@ bool ModelFilter::applyFilter(const QString& filter,
       int pos = 0;
       return validator->validate( message, pos ) == QValidator::Acceptable;
   }
+  return false;
 }
 


### PR DESCRIPTION
These are just fixes so it doesn't display build warnings, feel free to change them or print errors where they need to be printed.