### PR TITLE
Fix image link in tracker.md

### DIFF
--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -8,7 +8,7 @@ The position of the TimeTracker (A) can be changed either pressing
 __SHIFT + LEFT MOUSE__ on a certain location of a PlotWidget, or moving 
 the time slider at the bottom of the screen (B).
 
-![plotjuggler terms](images/pj-tracker.png)
+![plotjuggler terms](images/PlotJuggler_tracker.png)
 
 The exact time will be diplayed in the box at the left side of the time slider (C).
 

--- a/include/PlotJuggler/random_color.h
+++ b/include/PlotJuggler/random_color.h
@@ -9,15 +9,15 @@ inline QColor randomColorHint()
     QColor color;
     switch( index%9 )
     {
-    case 0:  color = QColor(Qt::blue) ;break;
-    case 1:  color = QColor(Qt::darkGreen);break;
-    case 2:  color =  QColor(Qt::red); break;
-    case 3:  color =  QColor(Qt::magenta); break;
-    case 4:  color =  QColor(Qt::darkBlue); break;
-    case 5:  color =  QColor(Qt::darkCyan); break;
-    case 6:  color =  QColor(Qt::gray); break;
+    case 0:  color =  QColor(Qt::blue);       break;
+    case 1:  color =  QColor(Qt::darkGreen);  break;
+    case 2:  color =  QColor(Qt::red);        break;
+    case 3:  color =  QColor(Qt::magenta);    break;
+    case 4:  color =  QColor(Qt::darkBlue);   break;
+    case 5:  color =  QColor(Qt::darkCyan);   break;
+    case 6:  color =  QColor(Qt::gray);       break;
     case 7:  color =  QColor(Qt::darkYellow); break;
-    case 8:  color =  QColor(Qt::darkRed); break;
+    case 8:  color =  QColor(Qt::darkRed);    break;
     }
     index++;
     return color;


### PR DESCRIPTION
pj-tracker.png was removed in last documentation upgrade, so I guess PlotJuggler_tracker.png wants to be linked instead (at least for the moment).