### PR TITLE
Potential fix for precision issue when adding time_offset

### DIFF
--- a/plotter_gui/plotwidget.cpp
+++ b/plotter_gui/plotwidget.cpp
@@ -838,6 +838,8 @@ PlotData::RangeValue  PlotWidget::getMaximumRangeY( PlotData::RangeTime range_X,
         {
             left += _time_offset;
             right += _time_offset;
+            left = std::nextafter(left, right);
+            right = std::nextafter(right, left);
         }
 
         int X0 = series->data()->getIndexFromX(left);


### PR DESCRIPTION
Adding time_offset (which can be a very large number) to the left and right time end points of a data series, we can have precision issues causing errors of the type "invalid X0/X1 range in PlotWidget::maximumRangeY". To prevent this, we shift the left and right values slightly after adding the time_offset so that they are still in the expected range.