### PR TITLE
Fix build failures on Archlinux

### DIFF
--- a/backward-cpp/backward.hpp
+++ b/backward-cpp/backward.hpp
@@ -1879,7 +1879,6 @@ public:
 		SIGSEGV,    // Invalid memory reference
 		SIGSYS,     // Bad argument to routine (SVr4)
 		SIGTRAP,    // Trace/breakpoint trap
-		SIGUNUSED,  // Synonymous with SIGSYS
 		SIGXCPU,    // CPU time limit exceeded (4.2BSD)
 		SIGXFSZ,    // File size limit exceeded (4.2BSD)
 	};

--- a/plugins/DataLoadCSV/CMakeLists.txt
+++ b/plugins/DataLoadCSV/CMakeLists.txt
@@ -12,7 +12,7 @@ SET( SRC
     )
 
 add_library(DataLoadCSV SHARED ${SRC} ${UI_SRC}  )
-target_link_libraries(DataLoadCSV  ${Qt5Widgets_LIBRARIES} )
+target_link_libraries(DataLoadCSV  ${Qt5Widgets_LIBRARIES} ${Qt5Xml_LIBRARIES})
 
 
 if(COMPILING_WITH_CATKIN)

--- a/plugins/DataStreamSample/CMakeLists.txt
+++ b/plugins/DataStreamSample/CMakeLists.txt
@@ -16,7 +16,7 @@ SET( SRC
 add_library(DataStreamSample SHARED ${SRC} ${UI_SRC}  )
 
 
-target_link_libraries(DataStreamSample  ${Qt5Widgets_LIBRARIES} )
+target_link_libraries(DataStreamSample  ${Qt5Widgets_LIBRARIES} ${Qt5Xml_LIBRARIES})
 
 if(COMPILING_WITH_CATKIN)
     install(TARGETS DataStreamSample


### PR DESCRIPTION
Mainly caused by newer versions of Qt5 and Glibc. I think these changes are safe even for older versions.