### PR TITLE
Fixes #61 -  error with non monotonic time

### DIFF
--- a/plugins/DataLoadCSV/dataload_csv.cpp
+++ b/plugins/DataLoadCSV/dataload_csv.cpp
@@ -169,7 +169,7 @@ PlotDataMap DataLoadCSV::readDataFromFile(const QString &file_name, bool use_pre
             {
                 if( _default_time_axis == qname )
                 {
-                    time_index = valid_field_names.size() ;
+                    time_index = i;
                 }
             }
         }


### PR DESCRIPTION
Vector size was already incremented, so time_index was pointing to `correct_index + 1` column.