### PR TITLE
Fix dragging/deletion of hidden items

### DIFF
--- a/plotter_gui/filterablelistwidget.h
+++ b/plotter_gui/filterablelistwidget.h
@@ -88,6 +88,8 @@ private:
     bool eventFilter(QObject *object, QEvent *event);
 
     void updateTreeModel();
+    
+    QModelIndexList getNonHiddenSelectedRows();
 
     bool _completer_need_update;
 


### PR DESCRIPTION
If you have a list with multiple elements:
ABAR
FOO
ZBAR

And you filter by "BAR" you'll get a list of two elements, but if you shift-click on the first and the last, "FOO" will be selected as well, even though it's hidden. 

This patch should prevent FOO from being drag&dropped into the curve display and being deleted if it's hidden.