### PR TITLE
CMakeLists.txt add mac homebrew qt5 install directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,14 @@ SET(CMAKE_AUTOUIC ON)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g -fno-omit-frame-pointer")
 
+if(APPLE AND EXISTS /usr/local/opt/qt5)
+	# Homebrew installs Qt5 (up to at least 5.9.1) in
+	# /usr/local/qt5, ensure it can be found by CMake since
+	# it is not in the default /usr/local prefix.
+    # source: https://github.com/Homebrew/homebrew-core/issues/8392#issuecomment-325226494
+	list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt5")
+endif()
+
 find_package(Qt5 REQUIRED COMPONENTS Core Widgets PrintSupport Concurrent Xml)
 find_package(Qt5 QUIET COMPONENTS Svg)
 find_package(Qt5 QUIET COMPONENTS WebSockets)
@@ -100,7 +108,7 @@ if(COMPILING_WITH_CATKIN)
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_LIB_DESTINATION})
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_BIN_DESTINATION})
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_BIN_DESTINATION})
-    
+
     install(DIRECTORY site/       DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/docs )
     install(DIRECTORY docs/images DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/docs )
     add_definitions( -DPJ_DOCUMENTATION_DIR="${CMAKE_INSTALL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/docs" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,8 @@ if(APPLE AND EXISTS /usr/local/opt/qt5)
     # /usr/local/qt5, ensure it can be found by CMake since
     # it is not in the default /usr/local prefix.
     # source: https://github.com/Homebrew/homebrew-core/issues/8392#issuecomment-325226494
-	list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt5")
+    list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt5")
+    set(CMAKE_MACOSX_RPATH 1)
 endif()
 
 find_package(Qt5 REQUIRED COMPONENTS Core Widgets PrintSupport Concurrent Xml)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,9 @@ SET(CMAKE_AUTOUIC ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g -fno-omit-frame-pointer")
 
 if(APPLE AND EXISTS /usr/local/opt/qt5)
-	# Homebrew installs Qt5 (up to at least 5.9.1) in
-	# /usr/local/qt5, ensure it can be found by CMake since
-	# it is not in the default /usr/local prefix.
+    # Homebrew installs Qt5 (up to at least 5.9.1) in
+    # /usr/local/qt5, ensure it can be found by CMake since
+    # it is not in the default /usr/local prefix.
     # source: https://github.com/Homebrew/homebrew-core/issues/8392#issuecomment-325226494
 	list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt5")
 endif()

--- a/plotter_gui/mainwindow.cpp
+++ b/plotter_gui/mainwindow.cpp
@@ -435,7 +435,7 @@ void MainWindow::loadPlugins(QString directory_name)
     for (QString filename: pluginsDir.entryList(QDir::Files))
     {
         QFileInfo fileinfo(filename);
-        if( fileinfo.suffix() != "so" && fileinfo.suffix() != "dll"){
+        if( fileinfo.suffix() != "so" && fileinfo.suffix() != "dll" && fileinfo.suffix() != "dylib"){
             continue;
         }
 


### PR DESCRIPTION
Fixes the build on MacOS, an extra qt path is added to the search path when cmake is run on an apple OS.