### PR TITLE
Add pal_statistics_msgs/Statistics rules

### DIFF
--- a/plugins/ROS/rule_editing.cpp
+++ b/plugins/ROS/rule_editing.cpp
@@ -27,6 +27,9 @@ const char* DEFAULT_RULES =
         "  <rule pattern=\"transforms.#/transform/translation\" alias=\"transforms.#/child_frame_id\"  substitution=\"@/translation\" />\n"
         "</RosType>\n"
         "\n"
+        "<RosType name=\"pal_statistics_msgs/Statistics\">\n"
+        "  <rule pattern=\"statistics.#/value\" alias=\"statistics.#/name\" substitution=\"@\" />\n"
+        "</RosType>\n"
         "</SubstitutionRules>\n"
         ;
 


### PR DESCRIPTION
Adding rules for visualizing properly the messages used by [pal_statistics](https://github.com/pal-robotics/pal_statistics)

I'm in the process of documenting it, you can see some info here: http://rosin-project.eu/ftp/pal-statistics

I'd like to recommend PlotJuggler as one the visualizers for the data, but it needs this rule to display properly.

We are logging over 2.5k variables from TALOS at 1000Hz in a  real time safe way, I'm sure you'll like pal_statistics.