### PR TITLE
Make default filename for tab image the tab name.

### DIFF
--- a/plotter_gui/tabbedplotwidget.cpp
+++ b/plotter_gui/tabbedplotwidget.cpp
@@ -222,6 +222,7 @@ void TabbedPlotWidget::on_savePlotsToFile()
     QFileDialog saveDialog;
     saveDialog.setAcceptMode(QFileDialog::AcceptSave);
     saveDialog.setDefaultSuffix("png");
+    saveDialog.selectFile(currentTab()->name());
 
 #ifndef QWT_NO_SVG
     saveDialog.setNameFilter("Compatible formats (*.jpg *.jpeg *.svg *.png)");


### PR DESCRIPTION
This helps when saving multiple images of tabs.