### PR TITLE
Save all tab plots as images in a folder.

### DIFF
--- a/plotter_gui/mainwindow.cpp
+++ b/plotter_gui/mainwindow.cpp
@@ -2358,3 +2358,30 @@ void MainWindow::on_actionSupportPlotJuggler_triggered()
 
     dialog->exec();
 }
+
+void MainWindow::on_actionSaveAllPlotTabs_triggered()
+{
+    // Get destination folder
+    QFileDialog saveDialog;
+    saveDialog.setFileMode(QFileDialog::FileMode::Directory);
+    saveDialog.setAcceptMode(QFileDialog::AcceptSave);
+    saveDialog.exec();
+
+    if(saveDialog.result() == QDialog::Accepted && !saveDialog.selectedFiles().empty())
+    {
+        // Save Plots
+        QString folder = saveDialog.selectedFiles().first();
+
+        for(const auto& it: TabbedPlotWidget::instances())
+        {
+            auto tab_widget = it.second->tabWidget();
+            for(int i=0; i< tab_widget->count(); i++)
+            {
+                PlotMatrix* matrix = static_cast<PlotMatrix*>( tab_widget->widget(i) );
+                QString fileName = folder + "/" + matrix->name() + ".png";
+
+                TabbedPlotWidget::saveTabImage(fileName, matrix);
+            }
+        }
+    }
+}

--- a/plotter_gui/mainwindow.h
+++ b/plotter_gui/mainwindow.h
@@ -141,6 +141,8 @@ private slots:
 
     void on_actionSupportPlotJuggler_triggered();
 
+    void on_actionSaveAllPlotTabs_triggered();
+
 private:
 
     Ui::MainWindow *ui;

--- a/plotter_gui/mainwindow.ui
+++ b/plotter_gui/mainwindow.ui
@@ -660,6 +660,7 @@
     <addaction name="separator"/>
     <addaction name="actionFunction_editor"/>
     <addaction name="actionMaximizePlots"/>
+    <addaction name="actionSaveAllPlotTabs"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuStreaming"/>
@@ -745,6 +746,14 @@
    </property>
    <property name="toolTip">
     <string>Maximize plots [F10]</string>
+   </property>
+  </action>
+  <action name="actionSaveAllPlotTabs">
+   <property name="text">
+    <string>Save all plot tabs as images</string>
+   </property>
+   <property name="toolTip">
+    <string>Save each tab as a separate image.</string>
    </property>
   </action>
   <action name="actionLoadDummyData">

--- a/plotter_gui/tabbedplotwidget.cpp
+++ b/plotter_gui/tabbedplotwidget.cpp
@@ -222,6 +222,7 @@ void TabbedPlotWidget::on_savePlotsToFile()
     QFileDialog saveDialog;
     saveDialog.setAcceptMode(QFileDialog::AcceptSave);
     saveDialog.setDefaultSuffix("png");
+    saveDialog.selectFile(currentTab()->name());
 
 #ifndef QWT_NO_SVG
     saveDialog.setNameFilter("Compatible formats (*.jpg *.jpeg *.svg *.png)");

--- a/plotter_gui/tabbedplotwidget.cpp
+++ b/plotter_gui/tabbedplotwidget.cpp
@@ -235,27 +235,32 @@ void TabbedPlotWidget::on_savePlotsToFile()
     {
         QString fileName = saveDialog.selectedFiles().first();
 
-        QPixmap pixmap (1200,900);
-        QPainter * painter = new QPainter(&pixmap);
+        saveTabImage(fileName, matrix);
+    }
+}
 
-        if ( !fileName.isEmpty() )
+void TabbedPlotWidget::saveTabImage(QString fileName, PlotMatrix* matrix)
+{
+    QPixmap pixmap (1200,900);
+    QPainter * painter = new QPainter(&pixmap);
+
+    if ( !fileName.isEmpty() )
+    {
+        QwtPlotRenderer rend;
+
+        int delta_X = pixmap.width() /  matrix->colsCount();
+        int delta_Y = pixmap.height() /  matrix->rowsCount();
+
+        for (unsigned c=0; c< matrix->colsCount(); c++)
         {
-            QwtPlotRenderer rend;
-
-            int delta_X = pixmap.width() /  matrix->colsCount();
-            int delta_Y = pixmap.height() /  matrix->rowsCount();
-
-            for (unsigned c=0; c< matrix->colsCount(); c++)
+            for (unsigned r=0; r< matrix->rowsCount(); r++)
             {
-                for (unsigned r=0; r< matrix->rowsCount(); r++)
-                {
-                    PlotWidget* widget = matrix->plotAt(r,c);
-                    QRect rect(delta_X*c, delta_Y*r, delta_X, delta_Y);
-                    rend.render(widget,painter, rect);
-                }
+                PlotWidget* widget = matrix->plotAt(r,c);
+                QRect rect(delta_X*c, delta_Y*r, delta_X, delta_Y);
+                rend.render(widget,painter, rect);
             }
-            pixmap.save(fileName);
         }
+        pixmap.save(fileName);
     }
 }
 

--- a/plotter_gui/tabbedplotwidget.h
+++ b/plotter_gui/tabbedplotwidget.h
@@ -49,6 +49,8 @@ public slots:
 
     void setStreamingMode(bool streaming_mode);
 
+    static void saveTabImage(QString fileName, PlotMatrix* matrix);
+
 private slots:
 
     void on_renameCurrentTab();


### PR DESCRIPTION
Extends https://github.com/facontidavide/PlotJuggler/pull/136 and closes #128 allowing a user to save all tabs as images in a selected folder.