### PR TITLE
Allow to build the DataStreamClientSample on Linux

### DIFF
--- a/plugins/DataStreamWebSocket/DataStreamClientSample/client.cpp
+++ b/plugins/DataStreamWebSocket/DataStreamClientSample/client.cpp
@@ -47,14 +47,17 @@
 ** $QT_END_LICENSE$
 **
 ****************************************************************************/
-#include "Client.h"
+#include "client.h"
 #include <QtCore/QDebug>
 #include <QtMath>
 #include <QThread>
 #include <chrono>
 #include <QStringBuilder>
-#include <Windows.h>
 #include <thread>
+
+#ifdef WIN32
+#include <Windows.h>
+#endif
 
 QT_USE_NAMESPACE
 


### PR DESCRIPTION
Note that I am not sure if the `Windows` include is really needed in this file...
But I do not have a Windows machine to test.