### PR TITLE
ulog_parser: fixed parsing of array topics

### DIFF
--- a/plugins/DataLoadULog/ulog_parser.cpp
+++ b/plugins/DataLoadULog/ulog_parser.cpp
@@ -162,6 +162,12 @@ char* ULogParser::parseSimpleDataMessage(Timeseries& timeseries, const Format *f
 {
     for (const auto& field: format->fields)
     {
+        // skip _padding0 messages which are one byte in size
+        if (field.field_name == "_padding0") {
+                message += field.array_size;
+                continue;
+            }
+
         for (int array_pos = 0; array_pos < field.array_size; array_pos++)
         {
             double value = 0;
@@ -573,11 +579,7 @@ bool ULogParser::readFormat(std::ifstream &file, uint16_t msg_size)
             }
         }
 
-        if( field.type == UINT8 && field_name == StringView("_padding0") )
-        {
-            format.padding = field.array_size;
-        }
-        else if( field.type == UINT64 && field_name == StringView("timestamp") )
+        if( field.type == UINT64 && field_name == StringView("timestamp") )
         {
             // skip
         }
@@ -746,6 +748,11 @@ ULogParser::Timeseries ULogParser::createTimeseries(const ULogParser::Format* fo
     {
         for( const auto& field: format.fields)
         {
+            // skip padding messages
+            if (field.field_name == "_padding0") {
+                    continue;
+            }
+
             std::string new_prefix = prefix + "/" + field.field_name;
             for(int i=0; i < field.array_size; i++)
             {

--- a/plugins/DataLoadULog/ulog_parser.cpp
+++ b/plugins/DataLoadULog/ulog_parser.cpp
@@ -218,11 +218,12 @@ char* ULogParser::parseSimpleDataMessage(Timeseries& timeseries, const Format *f
             case OTHER:{
                 //recursion!!!
                 auto child_format = _formats.at( field.other_type_ID );
-                message += 8; // skip timestamp
+                message += sizeof(uint64_t); // skip timestamp
                 message = parseSimpleDataMessage(timeseries, &child_format, message, index );
             }break;
 
             } // end switch
+
             if( field.type != OTHER)
             {
                 timeseries.data[(*index)++].second.push_back( value );
@@ -538,7 +539,23 @@ bool ULogParser::readFormat(std::ifstream &file, uint16_t msg_size)
         }
         else{
             field.type = OTHER;
-            field.other_type_ID = field_type.to_string();
+
+            if (field_type.ends_with("]")) {
+                StringView helper = field_type;
+                while (!helper.ends_with("[")) {
+                    helper.remove_suffix(1);
+                }
+
+                helper.remove_suffix(1);
+                field.other_type_ID = helper.to_string();
+
+                while(!field_type.starts_with("[")) {
+                    field_type.remove_prefix(1);
+                }
+
+            } else {
+                field.other_type_ID = field_type.to_string();
+            }
         }
 
         field.array_size = 1;
@@ -568,13 +585,6 @@ bool ULogParser::readFormat(std::ifstream &file, uint16_t msg_size)
             field.field_name = field_name.to_string();
             format.fields.push_back( field );
         }
-       // if( field.type == OTHER)
-//        {
-
-//            printf("[Format %s]:[%s]  %s %d \n", name.c_str(), field_section.to_string().c_str(),
-//                   field.field_name.c_str(), field.array_size);
-//            std::cout << std::flush;
-//        }
     }
 
     format.name = name;
@@ -739,7 +749,7 @@ ULogParser::Timeseries ULogParser::createTimeseries(const ULogParser::Format* fo
             std::string new_prefix = prefix + "/" + field.field_name;
             for(int i=0; i < field.array_size; i++)
             {
-                std::string array_suffix;
+                std::string array_suffix = "";
                 if( field.array_size > 1)
                 {
                     char buff[10];
@@ -751,7 +761,7 @@ ULogParser::Timeseries ULogParser::createTimeseries(const ULogParser::Format* fo
                     timeseries.data.push_back( {new_prefix + array_suffix, std::vector<double>()} );
                 }
                 else{
-                    appendVector( this->_formats.at( field.other_type_ID ), new_prefix);
+                    appendVector( this->_formats.at( field.other_type_ID ), new_prefix + array_suffix);
                 }
             }
         }

--- a/plugins/DataLoadULog/ulog_parser.cpp
+++ b/plugins/DataLoadULog/ulog_parser.cpp
@@ -162,8 +162,8 @@ char* ULogParser::parseSimpleDataMessage(Timeseries& timeseries, const Format *f
 {
     for (const auto& field: format->fields)
     {
-        // skip _padding0 messages which are one byte in size
-        if (field.field_name == "_padding0") {
+        // skip _padding messages which are one byte in size
+        if (StringView(field.field_name).starts_with("_padding")) {
                 message += field.array_size;
                 continue;
             }


### PR DESCRIPTION
**Problem**
I was not able to open log files which included arrays of nested topics. I think I found the cause why this was not working, however, the data of the nested topics is still not displayed correctly. There seems to be a miss-alignment between labels and data (only for that nested topic).

Unfortunately, I'm currently not able to share a log file that includes nested topics. (The one I was using was from a customer and I cannot share it here :-( ).
I will try to look for a public log. In my case the vehicle was logging the "esc_status" message which contains an array of "esc_report" message.

This is the error message that I saw when trying to parse the log file:
![image](https://user-images.githubusercontent.com/7610489/54393921-bdd95680-46ab-11e9-9433-5451b13adc04.png)

With this PR the log file is parsed and the message label appear, however, the data is not correct yet.
In the plot above I wanted to plot temperature but in fact the graph corresponds to the esc current.
![image](https://user-images.githubusercontent.com/7610489/54394082-245e7480-46ac-11e9-8710-0492ccbd57e6.png)

@facontidavide Maybe you can help me get this right.



Signed-off-by: Roman <bapstroman@gmail.com>