### PR TITLE
Fixed small typos in README.md

### DIFF
--- a/backward-cpp/README.md
+++ b/backward-cpp/README.md
@@ -21,7 +21,7 @@ You can see that for the trace #1 in the example, the function
 `you_shall_not_pass()` was inlined in the function `...read2::do_test()` by the
 compiler.
 
-##Installation
+## Installation
 
 #### Install backward.hpp
 
@@ -39,7 +39,7 @@ errors (segfault, abort, un-handled exception...), simply add a copy of
 The code in `backward.cpp` is trivial anyway, you can simply copy what it's
 doing at your convenience.
 
-##Configuration & Dependencies
+## Configuration & Dependencies
 
 ### Integration with CMake
 


### PR DESCRIPTION
That's it all! Two small typos in the markup for two titles in the README.md file