### PR TITLE
Read out of array

### DIFF
--- a/plotter_gui/transforms/custom_function.cpp
+++ b/plotter_gui/transforms/custom_function.cpp
@@ -201,7 +201,9 @@ void CustomFunction::calculate(const PlotDataMapRef &plotData, PlotData* dst_dat
             dst_data->pushBack( calculatePoint(calcFct, src_data, channel_data, chan_values, i ) );
         }
     }
-    _last_updated_timestamp = dst_data->back().x;
+    if (dst_data->size() != 0){
+      _last_updated_timestamp = dst_data->back().x;
+    }
 }
 
 const std::string &CustomFunction::name() const


### PR DESCRIPTION
This Pr fix a possible invalid data access with back() on empty vector.
This could be triggered when used custom function in layout and stream in simulation (when layout is load before bag streaming start).