### PR TITLE
Remove topic prefix

### DIFF
--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,0 +1,1 @@
+../../build/plotjuggler/compile_commands.json

--- a/plotter_gui/mainwindow.cpp
+++ b/plotter_gui/mainwindow.cpp
@@ -1211,7 +1211,7 @@ bool MainWindow::loadDataFromFile(const FileLoadInfo& info)
 
             if( dataloader->readDataFromFile( &new_info, mapped_data ) )
             {
-                AddPrefixToPlotData( info.prefix.toStdString(), mapped_data.numeric );
+                AddPrefixToPlotData( new_info.prefix.toStdString(), mapped_data.numeric );
 
                 importPlotDataMap(mapped_data, true);     
 

--- a/plotter_gui/transforms/introspect.js
+++ b/plotter_gui/transforms/introspect.js
@@ -1,0 +1,52 @@
+function Dic()
+{
+  this.val = 0.0
+  Number.call(this.val, 0.0);
+  this.current = "";
+  this.level = 0;
+  this.keys = [];
+}
+
+Dic.prototype = Object.create(Number.prototype);
+Dic.prototype.constructor = Dic;
+Dic.prototype.valueOf = function() {
+  return this.val;
+};
+Dic.prototype.toString = function() {
+  return this.keys;
+};
+
+const spy = {
+  get: function(target, prop, receiver) {
+      console.log(prop)
+
+      if (prop in target || typeof prop === 'symbol')
+        return Reflect.get(target,prop,receiver)
+
+      if (receiver.level == 0)
+          target.current = " "
+      target.current = target.current+"/"+prop
+      target.keys.push(target.current)
+
+      r = Object.create(receiver);
+      r.level += 1;
+
+      return r
+    }
+};
+
+dic = new Dic()
+dic1 = new Dic()
+const proxy = new Proxy(dic, spy);
+const proxy1 = new Proxy(dic1, spy);
+console.log(dic + dic)
+console.log(dic.level)
+console.log(proxy +1 )
+
+f = function(o) {return o.pose.x.z + o.pose.y;}
+console.log(proxy1.a.b.valueOf());
+//console.log(typeof proxy1.a.b);
+k = f(proxy)
+//h = f + g
+console.log(dic.toString());
+console.log(dic1.toString());

--- a/plugins/ROS/DataLoadROS/dataload_ros.cpp
+++ b/plugins/ROS/DataLoadROS/dataload_ros.cpp
@@ -126,6 +126,9 @@ bool DataLoadROS::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_map)
     {
         xmlLoadState( info->plugin_config.firstChildElement() );
     }
+    
+    _config.prefix = info->prefix;
+    info->prefix = "";
 
     if( ! info->selected_datasources.empty() )
     {
@@ -145,7 +148,7 @@ bool DataLoadROS::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_map)
 
     _ros_parser.setUseHeaderStamp( _config.use_header_stamp );
     _ros_parser.setMaxArrayPolicy( _config.max_array_size, _config.discard_large_arrays );
-
+    _ros_parser.setTopicTransform( _config.prefix.toStdString(), _config.getRemovePrefixes());
     if( _config.use_renaming_rules )
     {
         _ros_parser.addRules( RuleEditing::getRenamingRules() );

--- a/plugins/ROS/DataLoadROS/dataload_ros.cpp
+++ b/plugins/ROS/DataLoadROS/dataload_ros.cpp
@@ -126,9 +126,11 @@ bool DataLoadROS::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_map)
     {
         xmlLoadState( info->plugin_config.firstChildElement() );
     }
-    
-    _config.prefix = info->prefix;
-    info->prefix = "";
+    if (!info->prefix.isEmpty())
+    {
+      _config.prefix = info->prefix;
+      info->prefix = "";
+    }
 
     if( ! info->selected_datasources.empty() )
     {
@@ -253,6 +255,14 @@ bool DataLoadROS::xmlSaveState(QDomDocument &doc, QDomElement &plugin_elem) cons
     max_elem.setAttribute("value", QString::number(_config.max_array_size));
     plugin_elem.appendChild( max_elem );
 
+    QDomElement prefix_elem = doc.createElement("prefix");
+    prefix_elem.setAttribute("value", _config.prefix);
+    plugin_elem.appendChild( prefix_elem );
+
+    QDomElement remove_prefixes_elem = doc.createElement("remove_prefixes");
+    remove_prefixes_elem.setAttribute("value", _config.rm_prefixes);
+    plugin_elem.appendChild( remove_prefixes_elem );
+
     return true;
 }
 
@@ -270,6 +280,12 @@ bool DataLoadROS::xmlLoadState(const QDomElement &parent_element)
     QDomElement max_elem = parent_element.firstChildElement( "max_array_size" );
     _config.max_array_size = max_elem.attribute("value").toInt();
 
+    QDomElement prefix_elem = parent_element.firstChildElement( "prefix" );
+    _config.prefix = prefix_elem.attribute("value");
+
+    QDomElement remove_prefix_elem = parent_element.firstChildElement( "remove_prefixes" );
+    _config.rm_prefixes = remove_prefix_elem.attribute("value");
+
     return true;
 }
 
@@ -282,6 +298,8 @@ void DataLoadROS::saveDefaultSettings()
     settings.setValue("DataLoadROS/use_header_stamp", _config.use_header_stamp);
     settings.setValue("DataLoadROS/max_array_size", (int)_config.max_array_size);
     settings.setValue("DataLoadROS/discard_large_arrays", _config.discard_large_arrays);
+    settings.setValue("DataLoadROS/prefix", _config.prefix);
+    settings.setValue("DataLoadROS/remove_prefixes", _config.rm_prefixes);
 }
 
 
@@ -289,10 +307,12 @@ void DataLoadROS::loadDefaultSettings()
 {
     QSettings settings;
 
-    _config.selected_topics      = settings.value("DataLoadROS/default_topics", false ).toStringList();
+    _config.selected_topics      = settings.value("DataLoadROS/default_topics" ).toStringList();
     _config.use_header_stamp     = settings.value("DataLoadROS/use_header_stamp", false ).toBool();
     _config.use_renaming_rules   = settings.value("DataLoadROS/use_renaming", true ).toBool();
     _config.max_array_size       = settings.value("DataLoadROS/max_array_size", 100 ).toInt();
     _config.discard_large_arrays = settings.value("DataLoadROS/discard_large_arrays", true ).toBool();
+    _config.prefix               = settings.value("DataLoadROS/prefix", "" ).toString();
+    _config.rm_prefixes          = settings.value("DataLoadROS/remove_prefixes", "" ).toString();
 }
 

--- a/plugins/ROS/DataStreamROS/datastream_ROS.cpp
+++ b/plugins/ROS/DataStreamROS/datastream_ROS.cpp
@@ -423,6 +423,14 @@ bool DataStreamROS::xmlSaveState(QDomDocument &doc, QDomElement &plugin_elem) co
     max_elem.setAttribute("value", QString::number(_config.max_array_size));
     plugin_elem.appendChild( max_elem );
 
+    QDomElement prefix_elem = doc.createElement("prefix");
+    prefix_elem.setAttribute("value", _config.prefix);
+    plugin_elem.appendChild( prefix_elem );
+
+    QDomElement remove_prefixes_elem = doc.createElement("remove_prefixes");
+    remove_prefixes_elem.setAttribute("value", _config.rm_prefixes);
+    plugin_elem.appendChild( remove_prefixes_elem );
+
     return true;
 }
 
@@ -439,6 +447,12 @@ bool DataStreamROS::xmlLoadState(const QDomElement &parent_element)
 
     QDomElement max_elem = parent_element.firstChildElement( "max_array_size" );
     _config.max_array_size = max_elem.attribute("value").toInt();
+
+    QDomElement prefix_elem = parent_element.firstChildElement( "prefix" );
+    _config.prefix = prefix_elem.attribute("value");
+
+    QDomElement remove_prefix_elem = parent_element.firstChildElement( "remove_prefixes" );
+    _config.rm_prefixes = remove_prefix_elem.attribute("value");
 
     return true;
 }
@@ -463,17 +477,21 @@ void DataStreamROS::saveDefaultSettings()
     settings.setValue("DataStreamROS/use_header_stamp", _config.use_header_stamp);
     settings.setValue("DataStreamROS/max_array_size", (int)_config.max_array_size);
     settings.setValue("DataStreamROS/discard_large_arrays", _config.discard_large_arrays);
+    settings.setValue("DataStreamROS/prefix", _config.prefix);
+    settings.setValue("DataStreamROS/remove_prefixes", _config.rm_prefixes);
 }
 
 
 void DataStreamROS::loadDefaultSettings()
 {
     QSettings settings;
-    _config.selected_topics      = settings.value("DataStreamROS/default_topics", false ).toStringList();
+    _config.selected_topics      = settings.value("DataStreamROS/default_topics" ).toStringList();
     _config.use_header_stamp     = settings.value("DataStreamROS/use_header_stamp", false ).toBool();
     _config.use_renaming_rules   = settings.value("DataStreamROS/use_renaming", true ).toBool();
     _config.max_array_size       = settings.value("DataStreamROS/max_array_size", 100 ).toInt();
     _config.discard_large_arrays = settings.value("DataStreamROS/discard_large_arrays", true ).toBool();
+    _config.prefix               = settings.value("DataStreamROS/prefix", "" ).toString();
+    _config.rm_prefixes          = settings.value("DataStreamROS/remove_prefixes", "" ).toString();
 }
 
 

--- a/plugins/ROS/RosMsgParsers/ros_parser.cpp
+++ b/plugins/ROS/RosMsgParsers/ros_parser.cpp
@@ -236,17 +236,17 @@ void RosMessageParser::showWarnings()
     }
 }
 
-void RosMessageParser::extractData(PlotDataMapRef &destination, const std::string &prefix)
+void RosMessageParser::extractData(PlotDataMapRef &destination, const std::string &/*prefix*/)
 {
     for (auto& it: _plot_map.numeric)
     {
-        appendData( destination, prefix + it.first, it.second );
+        appendData( destination, this->_prefixer.apply(it.first), it.second );
     }
     _plot_map.numeric.clear();
 
     for (auto& it: _builtin_parsers)
     {
-        it.second->extractData( destination, prefix + it.first );
+        it.second->extractData( destination, this->_prefixer.apply(it.first) );
     }
 }
 

--- a/plugins/ROS/dialog_select_ros_topics.cpp
+++ b/plugins/ROS/dialog_select_ros_topics.cpp
@@ -45,7 +45,7 @@ DialogSelectRosTopics::DialogSelectRosTopics(const std::vector<std::pair<QString
 
     ui->addPrefix->setText(config.prefix);
     ui->removePrefix->setText(config.rm_prefixes);
-    ui->checkBoxPrefix->setChecked(config.prefix.isEmpty() || config.rm_prefixes.isEmpty());
+    ui->checkBoxPrefix->setChecked(!(config.prefix.isEmpty() && config.rm_prefixes.isEmpty()));
    
 
     QStringList labels;

--- a/plugins/ROS/dialog_select_ros_topics.cpp
+++ b/plugins/ROS/dialog_select_ros_topics.cpp
@@ -43,6 +43,11 @@ DialogSelectRosTopics::DialogSelectRosTopics(const std::vector<std::pair<QString
         ui->radioMaxClamp->setChecked(true);
     }
 
+    ui->addPrefix->setText(config.prefix);
+    ui->removePrefix->setText(config.rm_prefixes);
+    ui->checkBoxPrefix->setChecked(config.prefix.isEmpty() || config.rm_prefixes.isEmpty());
+   
+
     QStringList labels;
     labels.push_back("Topic name");
     labels.push_back("Datatype");
@@ -153,6 +158,11 @@ DialogSelectRosTopics::Configuration DialogSelectRosTopics::getResult() const
     config.use_header_stamp     = ui->checkBoxTimestamp->isChecked();
     config.discard_large_arrays = ui->radioMaxDiscard->isChecked();
     config.use_renaming_rules   = ui->checkBoxEnableRules->isChecked();
+    if (ui->checkBoxPrefix->isChecked())
+    {
+      config.prefix   = ui->addPrefix->text();
+      config.rm_prefixes   = ui->removePrefix->text();
+    }
     return config;
 }
 
@@ -206,6 +216,13 @@ nonstd::optional<double> FlatContainerContainHeaderStamp(const RosIntrospection:
         }
     }
     return nonstd::optional<double>();
+}
+
+
+void DialogSelectRosTopics::on_checkBoxPrefix_toggled(bool checked)
+{
+    ui->addPrefix->setEnabled(checked);
+    ui->removePrefix->setEnabled(checked);
 }
 
 void DialogSelectRosTopics::on_maximumSizeHelp_pressed()

--- a/plugins/ROS/dialog_select_ros_topics.h
+++ b/plugins/ROS/dialog_select_ros_topics.h
@@ -27,6 +27,17 @@ public:
         bool use_header_stamp;
         bool use_renaming_rules;
         bool discard_large_arrays;
+	QString prefix;
+	QString rm_prefixes;
+
+	std::vector<std::string> getRemovePrefixes()
+	{
+       	   std::vector<std::string> std_rm_prefixes;
+           QStringList rmlist = rm_prefixes.split(';', QString::SkipEmptyParts);
+           for (const QString & rm : rmlist)
+              std_rm_prefixes.emplace_back(rm.toStdString());
+           return std_rm_prefixes;  
+	}
     };
 
     explicit DialogSelectRosTopics(const std::vector<std::pair<QString,QString>>& topic_list,
@@ -56,6 +67,8 @@ private slots:
     void on_lineEditFilter_textChanged(const QString &search_string);
 
     void on_spinBoxArraySize_valueChanged(int value);
+
+    void on_checkBoxPrefix_toggled(bool checked);
 
 private:
 

--- a/plugins/ROS/dialog_select_ros_topics.ui
+++ b/plugins/ROS/dialog_select_ros_topics.ui
@@ -48,6 +48,44 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QCheckBox" name="checkBoxPrefix">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add or remove a prefix to the name of each loaded field.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Prefix Add</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="addPrefix">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Remove</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="removePrefix">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QCheckBox" name="checkBoxTimestamp">
      <property name="text">
       <string>If present, use the timestamp in the field [header.stamp]</string>

--- a/test.xml
+++ b/test.xml
@@ -1,0 +1,127 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<root>
+ <tabbed_widget parent="main_window" name="Main Window">
+  <plotmatrix columns="2" rows="2" tab_name="plot">
+   <plot col="0" row="0">
+    <range right="0.020941" bottom="-0.026825" left="-0.033953" top="0.010179"/>
+    <limitY/>
+    <curve R="0" G="128" custom_transform="XYPlot" name="/imu_data/angular_velocity/x" B="0"/>
+    <transform value="XYPlot" axisX="/imu_data/angular_velocity/y"/>
+   </plot>
+   <plot col="0" row="1">
+    <range right="17.748843" bottom="-0.608179" left="0.000000" top="0.016543"/>
+    <limitY/>
+    <curve R="0" G="0" custom_transform="noTransform" name="/imu_data/orientation/x" B="128"/>
+    <curve R="0" G="128" custom_transform="noTransform" name="/imu_data/orientation/y" B="128"/>
+    <curve R="160" G="160" custom_transform="noTransform" name="/imu_data/orientation/z" B="164"/>
+    <transform value="noTransform"/>
+   </plot>
+   <plot col="1" row="0">
+    <range right="0.084508" bottom="9.765777" left="-0.017691" top="9.833351"/>
+    <limitY/>
+    <curve R="255" G="0" custom_transform="XYPlot" name="/imu_data/linear_acceleration/z" B="255"/>
+    <transform value="XYPlot" axisX="/imu_data/linear_acceleration/x"/>
+   </plot>
+   <plot col="1" row="1">
+    <range right="17.748843" bottom="0.804909" left="0.000000" top="0.805870"/>
+    <limitY/>
+    <curve R="128" G="128" custom_transform="noTransform" name="/imu_data/orientation/w" B="0"/>
+    <transform value="noTransform"/>
+   </plot>
+  </plotmatrix>
+  <plotmatrix columns="1" rows="2" tab_name="plot">
+   <plot col="0" row="0">
+    <range right="17.713456" bottom="-0.016337" left="0.011302" top="0.014036"/>
+    <limitY/>
+    <curve R="0" G="0" custom_transform="noTransform" name="/gravity_vector/vector/x" B="255"/>
+    <curve R="128" G="0" custom_transform="noTransform" name="/gravity_vector/vector/y" B="0"/>
+    <transform value="noTransform"/>
+   </plot>
+   <plot col="0" row="1">
+    <range right="17.713456" bottom="-1.270520" left="0.011302" top="-1.267246"/>
+    <limitY/>
+    <curve R="0" G="0" custom_transform="noTransform" name="yaw" B="255"/>
+    <transform value="noTransform"/>
+   </plot>
+  </plotmatrix>
+  <currentPlotMatrix index="1"/>
+ </tabbed_widget>
+ <use_relative_time_offset enabled="1"/>
+ <Plugins>
+  <DataLoad_CSV>
+   <default time_axis=""/>
+  </DataLoad_CSV>
+  <DataLoad_ROS_bags>
+   <selected_topics list="/gravity_vector;/imu_data;/magnetic_vector"/>
+  </DataLoad_ROS_bags>
+  <DataLoad_ULog>
+   <no_params/>
+  </DataLoad_ULog>
+  <ROS_Topic_Streamer>
+   <selected_topics list=""/>
+  </ROS_Topic_Streamer>
+  <WebSocket_Server/>
+  <RosoutPublisherROS/>
+  <TopicPublisherROS/>
+ </Plugins>
+ <customMathEquations>
+  <snippet name="yaw">
+   <linkedPlot>/imu_data/header/stamp</linkedPlot>
+   <global>// source: https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
+
+function quaternionToYaw(x, y, z, w)
+{
+  // yaw (z-axis rotation)
+  t1 = 2.0 * (w * z + x * y);
+  t2 = 1.0 - 2.0 * (y * y + z * z);
+  yaw = Math.atan2(t1, t2);
+
+  return yaw
+}</global>
+   <equation>w = $$/imu_data/orientation/w$$
+x = $$/imu_data/orientation/x$$
+y = $$/imu_data/orientation/y$$
+z = $$/imu_data/orientation/z$$
+
+return quaternionToYaw(x, y, z, w);</equation>
+  </snippet>
+ </customMathEquations>
+ <snippets>
+  <snippet name="1st_derivative">
+   <global>var prevX = 0
+var prevY = 0</global>
+   <equation>dx = time - prevX
+dy = value - prevY
+prevX = time
+prevY = value
+
+return dy/dx</equation>
+  </snippet>
+  <snippet name="1st_order_lowpass">
+   <global>var prevY = 0
+var alpha = 0.1</global>
+   <equation>prevY = alpha * value + (1.-alpha) * prevY
+
+return prevY</equation>
+  </snippet>
+  <snippet name="sum_A_B">
+   <global></global>
+   <equation>return $$PLOT_A$$ + $$PLOT_B$$</equation>
+  </snippet>
+  <snippet name="yaw_from_quaternion">
+   <global>// source: https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
+
+function quaternionToYaw(x, y, z, w)
+{
+  // yaw (z-axis rotation)
+  t1 = 2.0 * (w * z + x * y);
+  t2 = 1.0 - 2.0 * (y * y + z * z);
+  yaw = Math.atan2(t1, t2);
+
+  return yaw
+}</global>
+   <equation>return quaternionToYaw(x, y, z, w);</equation>
+  </snippet>
+ </snippets>
+</root>
+


### PR DESCRIPTION
This pr add option to be able to remove prefix from bag and streaming topics. This is mostly useful for reused of layout when data are recorded with different namespace (/robot1,/robot2) ; but also to reduce topic length when compare different run of same algo (/algo -> /algo1 vs /run1/algo).
I am not totally sure that's the best way to do it (add prefix to layout when loaded should cover most of the usage of this patch).
The user can provide a list of prefix with ';' separator that are removed before adding the prefix name.

If you see interest on this PR, I can rebase it on the parsers branch.