### PR TITLE
Save to rosbag is not working at the moment

### DIFF
--- a/plugins/ROS/DataStreamROS/datastream_ROS.cpp
+++ b/plugins/ROS/DataStreamROS/datastream_ROS.cpp
@@ -310,6 +310,7 @@ void DataStreamROS::saveIntoRosbag()
         QStringList args;
         args << "reindex" << fileName;
         process.start("rosbag" ,args);
+        process.waitForFinished();
     }
 }
 


### PR DESCRIPTION
This is more an issue than a complete PR.
The save to rosbag function is broken at the moment for two reasons:
- the reindex process launch at the end of the function is kill before finish work (when exit function, QProcess is destroyed and send kill to rosbag process): the pr fix this.
- the rosbag save function have only access to the plugin PlotDataMapRef and not the application one. Most of the time the plugin buffer only contain very few messages as buffer is transfer to the application one on update trigger.

From my point of view, there is 3 way to correct this:
1. allow read access of the plugin to the main PlotDataMapRef custom values.
2. don't move custom values from plugin to main application buffer.
3. remove/disable this function for the moment.
I think this is very related to what you are doing around parsers, so this is just for memory. If you have an idea of the best way to do that i can make this pr more complete with your guidance.

ps : again thanks for the great work!