### PR TITLE
Minor fixes

### DIFF
--- a/plotter_gui/mainwindow.cpp
+++ b/plotter_gui/mainwindow.cpp
@@ -866,7 +866,7 @@ void MainWindow::deleteDataMultipleCurves(const std::vector<std::string> &curve_
         auto plot_curve = _mapped_plot_data.numeric.find( curve_name );
         if( plot_curve == _mapped_plot_data.numeric.end())
         {
-            return;
+          continue;
         }
 
         emit requestRemoveCurveByName( curve_name );

--- a/plotter_gui/transforms/function_editor.cpp
+++ b/plotter_gui/transforms/function_editor.cpp
@@ -89,7 +89,14 @@ AddCustomPlotDialog::~AddCustomPlotDialog()
 
 void AddCustomPlotDialog::setLinkedPlotName(const QString &linkedPlotName)
 {
-    ui->combo_linkedChannel->setCurrentText(linkedPlotName);
+    
+    int idx = ui->combo_linkedChannel->findText(linkedPlotName);
+    if (idx == -1)
+    {
+      idx = 0;
+      ui->combo_linkedChannel->insertItem(idx, linkedPlotName);
+    }
+    ui->combo_linkedChannel->setCurrentIndex(idx);
 }
 
 void AddCustomPlotDialog::setEditorMode(EditorMode mode)
@@ -119,7 +126,6 @@ QString AddCustomPlotDialog::getName() const
 {
     return ui->nameLineEdit->text();
 }
-
 
 void AddCustomPlotDialog::editExistingPlot(CustomPlotPtr data)
 {

--- a/plugins/ROS/RosMsgParsers/ros_parser.cpp
+++ b/plugins/ROS/RosMsgParsers/ros_parser.cpp
@@ -96,6 +96,7 @@ bool RosMessageParser::registerSchema(const std::string &topic_name,
     if( !inserted ) {
         _introspection_parser->registerMessageDefinition(topic_name, type, definition);
     }
+    return inserted;
 }
 
 void RosMessageParser::pushMessageRef(const std::string &topic_name,


### PR DESCRIPTION
Three small fix:
1. the ref topic in custom function, could be change by the editor if this topic does not exist/is not loaded yet. The first commit add the ref in the combo box if not present.
2. the deleteDataMultipleCurves make a return if a curve if not found, I thinks it is more a continue here. As every curve should be deleted
3. the RosMessageParser::registerSchema did not return a value. This produce big mess with the optimiser ....

Also just as a side note:
the _builtin_parsers parsers objects are never deleted and I don't think they are automatic object.
https://github.com/facontidavide/PlotJuggler/blob/ace1da563ba09ce2363a08ec4e254a9c644bf498/plugins/ROS/RosMsgParsers/ros_parser.cpp#L19 
https://github.com/facontidavide/PlotJuggler/blob/ace1da563ba09ce2363a08ec4e254a9c644bf498/plugins/ROS/RosMsgParsers/ros_parser.cpp#L76