### PR TITLE
Fix segfault when swap plotwidget on archlinux (qt5.12.3).

### DIFF
--- a/plotter_gui/plotwidget.cpp
+++ b/plotter_gui/plotwidget.cpp
@@ -1788,7 +1788,7 @@ bool PlotWidget::canvasEventFilter(QEvent *event)
         if( _dragging.mode == DragInfo::NONE )
         {
             changeBackgroundColor( Qt::white );
-            QApplication::restoreOverrideCursor();
+
             return false;
         }
     }break;


### PR DESCRIPTION
A fix for a bug on archlinux, a segfault append when I try to swap two plot widgets.
It is not yet visible on ubuntu but it's just a matter of time...

This bug is introduced in: 7959e54 Spurious DragLeave fixed?
And produce a segfault(nullptr) in QCursor::shape() call by
QBasicDrag::updateCursor(Qt::DropAction) [trigger by plotwidget.cpp:1352
drag->exec();].
It seems to me that the change of global application cursor on leave event during drag drop
operation cause the problem [is it the drop widget duty to reset cursor?].

Full stack trace:
"""
Stack trace (most recent call last):
#31   Object "/usr/lib/libQt5Widgets.so.5", at 0x7f8e9a5213c0, in QApplication::notify(QObject*, QEvent*)
#30   Object "/usr/lib/libQt5Widgets.so.5", at 0x7f8e9a519da3, in QApplicationPrivate::notify_helper(QObject*, QEvent*)
#29   Object "/usr/lib/libQt5Widgets.so.5", at 0x7f8e9a578cd6, in QDesktopWidget::qt_metacall(QMetaObject::Call, int, void**)
#28   Object "/usr/lib/libQt5Widgets.so.5", at 0x7f8e9a575c12, in QDesktopWidget::qt_metacall(QMetaObject::Call, int, void**)
#27   Object "/usr/lib/libQt5Widgets.so.5", at 0x7f8e9a520936, in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool)
#26   Object "/usr/lib/libQt5Core.so.5", at 0x7f8e99b43848, in QCoreApplication::notifyInternal2(QObject*, QEvent*)
#25   Object "/usr/lib/libQt5Widgets.so.5", at 0x7f8e9a521608, in QApplication::notify(QObject*, QEvent*)
#24   Object "/usr/lib/libQt5Widgets.so.5", at 0x7f8e9a519d93, in QApplicationPrivate::notify_helper(QObject*, QEvent*)
#23   Object "/usr/lib/libQt5Core.so.5", at 0x7f8e99b4355a, in QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*)
#22   Object "plotjuggler/PlotJuggler", at 0x56353656bace, in PlotWidget::canvasEventFilter(QEvent*)
      Source "PlotJuggler/plotter_gui/plotwidget.cpp", line 1759, in PlotWidget::canvasEventFilter(QEvent*) [0x56353656bace]
       1757:                 mimeData->setData("plot_area", data );
       1758:                 drag->setMimeData(mimeData);
      >1759:                 drag->exec();
       1760: 
       1761:                 return true; // don't pass to canvas().
       1762:             }
#21   Object "/usr/lib/libQt5Gui.so.5", at 0x7f8e99f5c4cc, in QDrag::exec(QFlags<Qt::DropAction>, Qt::DropAction)
#20   Object "/usr/lib/libQt5Gui.so.5", at 0x7f8e99f5c205, in QDragManager::drag(QDrag*)
#19   Object "/usr/lib/libQt5Gui.so.5", at 0x7f8e99f5eae5, in QBasicDrag::drag(QDrag*)
#18   Object "/usr/lib/libQt5Core.so.5", at 0x7f8e99b424db, in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>)
#17   Object "/usr/lib/libQt5Core.so.5", at 0x7f8e99b98968, in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>)
#16   Object "/usr/lib/libglib-2.0.so.0", at 0x7f8e985588ad, in g_main_context_iteration
#15   Object "/usr/lib/libglib-2.0.so.0", at 0x7f8e98558868, in g_main_context_acquire
#14   Object "/usr/lib/libglib-2.0.so.0", at 0x7f8e9855690e, in g_main_context_dispatch
#13   Object "/usr/lib/libQt5XcbQpa.so.5", at 0x7f8e94beeb8b, in QXcbNativeInterface::dumpNativeWindows(unsigned long long) const
#12   Object "/usr/lib/libQt5Gui.so.5", at 0x7f8e99effd9b, in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>)
#11   Object "/usr/lib/libQt5Gui.so.5", at 0x7f8e99f26955, in QGuiApplicationPrivate::processWindowSystemEvent(QWindowSystemInterfacePrivate::WindowSystemEvent*)
#10   Object "/usr/lib/libQt5Gui.so.5", at 0x7f8e99f2552c, in QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*)
#9    Object "/usr/lib/libQt5Core.so.5", at 0x7f8e99b43848, in QCoreApplication::notifyInternal2(QObject*, QEvent*)
#8    Object "/usr/lib/libQt5Widgets.so.5", at 0x7f8e9a5213c0, in QApplication::notify(QObject*, QEvent*)
#7    Object "/usr/lib/libQt5Widgets.so.5", at 0x7f8e9a519de1, in QApplicationPrivate::notify_helper(QObject*, QEvent*)
#7    Object "/usr/lib/libQt5Widgets.so.5", at 0x7f8e9a519de1, in QApplicationPrivate::notify_helper(QObject*, QEvent*)
#6    Object "/usr/lib/libQt5Core.so.5", at 0x7f8e99b4342a, in QCoreApplicationPrivate::sendThroughApplicationEventFilters(QObject*, QEvent*)
#5    Object "/usr/lib/libQt5Gui.so.5", at 0x7f8e99f5efa5, in QBasicDrag::eventFilter(QObject*, QEvent*)
#4    Object "/usr/lib/libQt5XcbQpa.so.5", at 0x7f8e94bf7dcf, in QXcbConnection::initializeScreens()
#3    Object "/usr/lib/libQt5XcbQpa.so.5", at 0x7f8e94bf529f, in QXcbConnection::initializeScreens()
#2    Object "/usr/lib/libQt5XcbQpa.so.5", at 0x7f8e94bf4c42, in QXcbConnection::initializeScreens()
#1    Object "/usr/lib/libQt5Gui.so.5", at 0x7f8e99f60268, in QBasicDrag::updateCursor(Qt::DropAction)
#0    Object "/usr/lib/libQt5Gui.so.5", at 0x7f8e99f336c6, in QCursor::shape() const
Erreur de segmentation (Adresse non associée à un objet [(nil)])
Erreur de segmentation (core dumped)
"""