### PR TITLE
Add missed abseil_cpp depend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ if(COMPILING_WITH_CATKIN)
     message(STATUS "---------------------------------------------------------------------")
 
     set(ROS_DEPENDENCIES
+        abseil_cpp
         rosbag
         rosbag_storage
         roscpp

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
 
 <buildtool_depend>catkin</buildtool_depend>
 
+<build_depend>abseil_cpp</build_depend>
 <build_depend>rosbag</build_depend>
 <build_depend>rosbag_storage</build_depend>
 <build_depend>roscpp</build_depend>
@@ -28,6 +29,7 @@
 <build_depend>diagnostic_msgs</build_depend>
 <build_depend>nav_msgs</build_depend>
 
+<run_depend>abseil_cpp</run_depend>
 <run_depend>rosbag</run_depend>
 <run_depend>rosbag_storage</run_depend>
 <run_depend>roscpp</run_depend>

--- a/plugins/ROS/TopicPublisherROS/statepublisher_rostopic.cpp
+++ b/plugins/ROS/TopicPublisherROS/statepublisher_rostopic.cpp
@@ -1,6 +1,7 @@
 #include "statepublisher_rostopic.h"
 #include "PlotJuggler/any.hpp"
 #include "../qnodedialog.h"
+#include <absl/types/span.h>
 #include "ros_type_introspection/ros_introspection.hpp"
 #include <QDialog>
 #include <QFormLayout>


### PR DESCRIPTION
I had a compilation error that turned out to be related with an old version of `abseil_cpp`, but I found out that `PlotJuggler` didn't depend on `abseil_cpp`. This simply adds the missed dependency and also one missed header, although for it compiles find w/o this PR at the end.