### PR TITLE
RosMsgParsers: add cast to be clang compatible

### DIFF
--- a/plugins/ROS/RosMsgParsers/ros_parser.cpp
+++ b/plugins/ROS/RosMsgParsers/ros_parser.cpp
@@ -120,7 +120,7 @@ void RosMessageParser::pushMessageRef(const std::string &topic_name,
 
     bool max_size_ok = _introspection_parser->deserializeIntoFlatContainer(
                 topic_name,
-                {const_cast<uint8_t*>(msg.data()), msg.size()},
+                {const_cast<uint8_t*>(msg.data()), static_cast<long>(msg.size())},
                 &flat_container,
                 _max_array_size );
 


### PR DESCRIPTION
This closes #207 by adding the requested cast.