### PR TITLE
Fix F10 is ambiguous

### DIFF
--- a/plotter_gui/mainwindow.ui
+++ b/plotter_gui/mainwindow.ui
@@ -984,7 +984,7 @@
     <string>Ctrl+Shift+C</string>
    </property>
   </action>
-  <action name="actionFullscreen">
+  <!--action name="actionFullscreen">
    <property name="text">
     <string>Fullscreen mode</string>
    </property>
@@ -994,7 +994,7 @@
    <property name="shortcut">
     <string>F10</string>
    </property>
-  </action>
+  </action-->
   <action name="actionSaveAllPlotTabs">
    <property name="text">
     <string>Save all plot tabs as images</string>


### PR DESCRIPTION
The shortcut F10 to toggle fullscreen is not working anymore.
An action is defined in the main_window.ui file and a qt shortcut is defined in the main_window.cpp:
https://github.com/facontidavide/PlotJuggler/blob/ac8460c78f6379ad6b51c84226000789bb160ad0/plotter_gui/mainwindow.cpp#L52
At the moment using the action is not working (could not leave fullscreen mode with the action : is it a focus problem ?). So, the simple fix is to keep hard-coded shortcut in cpp....
