### PR TITLE
Fix custom update

### DIFF
--- a/plotter_gui/mainwindow.cpp
+++ b/plotter_gui/mainwindow.cpp
@@ -1904,13 +1904,14 @@ void MainWindow::updateDataAndReplot(bool replot_hidden_tabs)
         {
             _curvelist_widget->refreshColumns();
         }
-
-        for( auto& custom_it: _custom_plots)
-        {
-            auto* dst_plot = &_mapped_plot_data.numeric.at(custom_it.first);
-            custom_it.second->calculate(_mapped_plot_data, dst_plot);
-        }
     }
+
+    for( auto& custom_it: _custom_plots)
+    {
+        auto* dst_plot = &_mapped_plot_data.numeric.at(custom_it.first);
+        custom_it.second->calculate(_mapped_plot_data, dst_plot);
+    }
+    
 
     const bool is_streaming_active = isStreamingActive();
 

--- a/plotter_gui/transforms/custom_function.h
+++ b/plotter_gui/transforms/custom_function.h
@@ -75,7 +75,7 @@ private:
     std::vector<std::string> _used_channels;
 
     std::unique_ptr<QJSEngine> _jsEngine;
-    double _last_updated_timestamp;
+    int _last_updated_idx;
 };
 
 


### PR DESCRIPTION
This PR fix two different problems related to custom function update.

=== When streaming (eda7c54) ===
If custom function is used, when streaming time is reset, the custom function is not updated anymore.
Step by step to make the problem happend :
- start streaming
- add custom function related to topic  and plot it
- start the bag 
- everything is ok
- restart the bag
- buffer is cleared and normal topic are display again but custom topic are not updated.

=== During data loading (e8649d7) ===
If data are loaded after custom function is defined, the custom function is not updated.
Step by Step:
- load layout with custom function define in it (keep placeholder).
- load data from bag.
