### PR TITLE
add include array header file to fix MAC OS X build error

### DIFF
--- a/plotter_gui/curvelist_panel.h
+++ b/plotter_gui/curvelist_panel.h
@@ -12,7 +12,7 @@
 #include "transforms/custom_function.h"
 #include "tree_completer.h"
 #include "curvetree_view.h"
-
+#include <array>
 
 namespace Ui {
 class CurveListPanel;


### PR DESCRIPTION
Using Mac OS X to compile on the current main branch will output the following error
```
[  1%] Built target fmt
[  2%] Automatic MOC and UIC for target colorwidgets
[  2%] Built target colorwidgets_autogen
[  6%] Built target colorwidgets
[  7%] Automatic MOC and UIC for target marl
[  7%] Built target marl_autogen
[ 16%] Built target marl
[ 17%] Automatic MOC and UIC for target qwt_static
[ 17%] Built target qwt_static_autogen
[ 65%] Built target qwt_static
[ 66%] Automatic MOC and UIC for target PlotJuggler
[ 66%] Built target PlotJuggler_autogen
Scanning dependencies of target PlotJuggler
[ 67%] Building CXX object plotter_gui/CMakeFiles/PlotJuggler.dir/PlotJuggler_autogen/mocs_compilation.cpp.o
In file included from /Users/xiaowei/src/PlotJuggler/build/plotter_gui/PlotJuggler_autogen/mocs_compilation.cpp:7:
In file included from /Users/xiaowei/src/PlotJuggler/build/plotter_gui/PlotJuggler_autogen/EWIEGA46WW/moc_curvelist_panel.cpp:10:
In file included from /Users/xiaowei/src/PlotJuggler/build/plotter_gui/PlotJuggler_autogen/EWIEGA46WW/../../../../plotter_gui/curvelist_panel.h:14:
In file included from /Users/xiaowei/src/PlotJuggler/plotter_gui/curvetree_view.h:4:
/Users/xiaowei/src/PlotJuggler/plotter_gui/curvelist_view.h:94:10: warning: 'addItem' overrides a member function but is not marked
      'override' [-Winconsistent-missing-override]
    void addItem(const QString& item_name);
         ^
/Users/xiaowei/src/PlotJuggler/plotter_gui/curvelist_view.h:47:18: note: overridden virtual function is here
    virtual void addItem(const QString& item_name) = 0;
                 ^
/Users/xiaowei/src/PlotJuggler/plotter_gui/curvelist_view.h:120:32: warning: 'hiddenItemsCount' overrides a member function but is not
      marked 'override' [-Winconsistent-missing-override]
    virtual std::pair<int,int> hiddenItemsCount()
                               ^
/Users/xiaowei/src/PlotJuggler/plotter_gui/curvelist_view.h:65:32: note: overridden virtual function is here
    virtual std::pair<int,int> hiddenItemsCount() = 0;
                               ^
In file included from /Users/xiaowei/src/PlotJuggler/build/plotter_gui/PlotJuggler_autogen/mocs_compilation.cpp:7:
In file included from /Users/xiaowei/src/PlotJuggler/build/plotter_gui/PlotJuggler_autogen/EWIEGA46WW/moc_curvelist_panel.cpp:10:
In file included from /Users/xiaowei/src/PlotJuggler/build/plotter_gui/PlotJuggler_autogen/EWIEGA46WW/../../../../plotter_gui/curvelist_panel.h:14:
/Users/xiaowei/src/PlotJuggler/plotter_gui/curvetree_view.h:44:10: warning: 'addItem' overrides a member function but is not marked
      'override' [-Winconsistent-missing-override]
    void addItem(const QString& item_name);
         ^
/Users/xiaowei/src/PlotJuggler/plotter_gui/curvelist_view.h:47:18: note: overridden virtual function is here
    virtual void addItem(const QString& item_name) = 0;
                 ^
3 warnings generated.
[ 68%] Building CXX object plotter_gui/CMakeFiles/PlotJuggler.dir/curvelist_panel.cpp.o
In file included from /Users/xiaowei/src/PlotJuggler/plotter_gui/curvelist_panel.cpp:1:
In file included from /Users/xiaowei/src/PlotJuggler/plotter_gui/curvelist_panel.h:14:
In file included from /Users/xiaowei/src/PlotJuggler/plotter_gui/curvetree_view.h:4:
/Users/xiaowei/src/PlotJuggler/plotter_gui/curvelist_view.h:94:10: warning: 'addItem' overrides a member function but is not marked
      'override' [-Winconsistent-missing-override]
    void addItem(const QString& item_name);
         ^
/Users/xiaowei/src/PlotJuggler/plotter_gui/curvelist_view.h:47:18: note: overridden virtual function is here
    virtual void addItem(const QString& item_name) = 0;
                 ^
/Users/xiaowei/src/PlotJuggler/plotter_gui/curvelist_view.h:120:32: warning: 'hiddenItemsCount' overrides a member function but is not
      marked 'override' [-Winconsistent-missing-override]
    virtual std::pair<int,int> hiddenItemsCount()
                               ^
/Users/xiaowei/src/PlotJuggler/plotter_gui/curvelist_view.h:65:32: note: overridden virtual function is here
    virtual std::pair<int,int> hiddenItemsCount() = 0;
                               ^
In file included from /Users/xiaowei/src/PlotJuggler/plotter_gui/curvelist_panel.cpp:1:
In file included from /Users/xiaowei/src/PlotJuggler/plotter_gui/curvelist_panel.h:14:
/Users/xiaowei/src/PlotJuggler/plotter_gui/curvetree_view.h:44:10: warning: 'addItem' overrides a member function but is not marked
      'override' [-Winconsistent-missing-override]
    void addItem(const QString& item_name);
         ^
/Users/xiaowei/src/PlotJuggler/plotter_gui/curvelist_view.h:47:18: note: overridden virtual function is here
    virtual void addItem(const QString& item_name) = 0;
                 ^
/Users/xiaowei/src/PlotJuggler/plotter_gui/curvelist_panel.cpp:352:31: error: implicit instantiation of undefined template
      'std::__1::array<CurvesView *, 3>'
    std::array<CurvesView*,3> views = { _table_view, _tree_view, _custom_view };
                              ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__tuple:223:64: note:
      template is declared here
template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
                                                               ^
3 warnings and 1 error generated.
make[2]: *** [plotter_gui/CMakeFiles/PlotJuggler.dir/curvelist_panel.cpp.o] Error 1
make[1]: *** [plotter_gui/CMakeFiles/PlotJuggler.dir/all] Error 2
make: *** [all] Error 2
```
This PR is to fix this compilation error. It contains the array header file

