### PR TITLE
Use ordered map, appendData needs to insert data in order

### DIFF
--- a/plugins/ROS/RosMsgParsers/pal_statistics_msg.h
+++ b/plugins/ROS/RosMsgParsers/pal_statistics_msg.h
@@ -65,7 +65,7 @@ template<> struct Serializer< ::PalStatisticsValues_ >
 
 //-----------------------------------------------------
 
-static std::unordered_map<uint32_t, std::vector<std::string> > _stored_pal_statistics_names;
+static std::map<uint32_t, std::vector<std::string> > _stored_pal_statistics_names;
 
 class PalStatisticsNamesParser: public RosParserBase
 {
@@ -157,7 +157,7 @@ public:
     }
 
 private:
-    std::unordered_map<uint32_t, std::vector< PlotData > > _data;
+    std::map<uint32_t, std::vector< PlotData > > _data;
 
 };
 


### PR DESCRIPTION
Otherwise the time order may not be respected and the data is loaded
incorrectly

Load the following bag and check the foo, bar and bar1 variables.

Using the ordered map is only valid as long as the `names_version` field is always incremental (which it is) but I guess we should order by data timestamp to be 100% correct.

[demo.tar.gz](https://github.com/facontidavide/PlotJuggler/files/4122716/demo.tar.gz)
