### PR TITLE
installing plotjuggler bin in /usr/bin to make it globally accesible

### DIFF
--- a/plotter_gui/CMakeLists.txt
+++ b/plotter_gui/CMakeLists.txt
@@ -88,7 +88,7 @@ if(COMPILING_WITH_CATKIN)
      )
     install(
         PROGRAMS scripts/plotjuggler
-        DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+        DESTINATION /usr/bin
     )
 else()
     install(TARGETS PlotJuggler DESTINATION bin  )


### PR DESCRIPTION
I forgot to push the commit that puts the binary in /usr/bin...