### PR TITLE
Fix another sprintf buffer size warning

### DIFF
--- a/plugins/DataLoadULog/ulog_parser.cpp
+++ b/plugins/DataLoadULog/ulog_parser.cpp
@@ -780,7 +780,7 @@ ULogParser::Timeseries ULogParser::createTimeseries(const ULogParser::Format* fo
         std::string array_suffix = "";
         if (field.array_size > 1)
         {
-          char buff[10];
+          char buff[16];
           sprintf(buff, ".%02d", i);
           array_suffix = buff;
         }


### PR DESCRIPTION
Silences:

```
Warnings   << plotjuggler:make /home/administrator/ortools_ws/logs/plotjuggler/build.make.000.log
/home/administrator/ortools_ws/src/PlotJuggler/plugins/DataLoadULog/ulog_parser.cpp: In lambda function:
/home/administrator/ortools_ws/src/PlotJuggler/plugins/DataLoadULog/ulog_parser.cpp:784:27: warning: ‘%02d’ directive writing between 2 and 10 bytes into a region of size 9  -Wformat-overflow=]
  784 |           sprintf(buff, ".%02d", i);
      |                           ^~~~
/home/administrator/ortools_ws/src/PlotJuggler/plugins/DataLoadULog/ulog_parser.cpp:784:25: note: directive argument in the range [0, 2147483647]
  784 |           sprintf(buff, ".%02d", i);
      |                         ^~~~~~~
In file included from /usr/include/stdio.h:867,
                 from /usr/include/c++/9/cstdio:42,
                 from /usr/include/c++/9/ext/string_conversions.h:43,
                 from /usr/include/c++/9/bits/basic_string.h:6493,
                 from /usr/include/c++/9/string:55,
                 from /usr/include/c++/9/bits/locale_classes.h:40,
                 from /usr/include/c++/9/bits/ios_base.h:41,
                 from /usr/include/c++/9/ios:42,
                 from /usr/include/c++/9/ostream:38,
                 from /usr/include/c++/9/iostream:39,
                 from /home/administrator/ortools_ws/src/PlotJuggler/plugins/DataLoadULog/ulog_parser.h:3,
                 from /home/administrator/ortools_ws/src/PlotJuggler/plugins/DataLoadULog/ulog_parser.cpp:1:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:36:34: note: ‘__builtin___sprintf_chk’ output between 4 and 12 bytes into a destination of size 10
   36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   37 |       __bos (__s), __fmt, __va_arg_pack ());
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```