### PR TITLE
build fixes to work on ROS2 eloquent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if( CATKIN_DEVEL_PREFIX OR catkin_FOUND OR CATKIN_BUILD_BINARY_PACKAGE)
 
 elseif( DEFINED ENV{AMENT_PREFIX_PATH})
     set(COMPILING_WITH_AMENT 1)
-
+    
     message(STATUS "---------------------------------------------------------------------")
     message(STATUS "PlotJuggler is being built using AMENT. ROS2 plugins will be compiled")
     message(STATUS "---------------------------------------------------------------------")
@@ -146,6 +146,7 @@ if(COMPILING_WITH_CATKIN)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_BIN_DESTINATION})
 
 elseif(COMPILING_WITH_AMENT)
+    find_package(ament_cmake REQUIRED)
 
 else()
     set(CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})

--- a/package.xml
+++ b/package.xml
@@ -47,6 +47,6 @@
 
     <!-- The export tag contains other, unspecified, tags -->
     <export>
-        <!-- build_type condition="$ROS_VERSION == 2">ament_cmake</build_type -->
+        <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
     </export>
 </package>

--- a/plugins/ROS/CMakeLists.txt
+++ b/plugins/ROS/CMakeLists.txt
@@ -91,6 +91,7 @@ elseif(COMPILING_WITH_AMENT)
     find_package(Boost REQUIRED)
     find_package(plotjuggler_msgs REQUIRED)
     find_package(tf2_msgs REQUIRED)
+    find_package(tf2_ros REQUIRED)
 
     include_directories(
         ./ ../ ../
@@ -103,7 +104,7 @@ elseif(COMPILING_WITH_AMENT)
         ros2_introspection/src/stringtree.cpp
         ros2_parsers/ros2_parser.cpp )
 
-    set(AMENT_DEPENDECIES
+    set(AMENT_DEPENDENCIES
         rclcpp
         rosbag2
         rcpputils
@@ -114,6 +115,7 @@ elseif(COMPILING_WITH_AMENT)
         nav_msgs
         plotjuggler_msgs
         tf2_msgs
+        tf2_ros
         )
 
     add_library( commonROS STATIC ${COMMON_SRC} ${COMMON_UI_SRC})
@@ -124,26 +126,26 @@ elseif(COMPILING_WITH_AMENT)
         ${Qt5Xml_LIBRARIES}
         fastcdr
         fmt::fmt-header-only )
-    ament_target_dependencies( commonROS ${AMENT_DEPENDECIES})
+    ament_target_dependencies( commonROS ${AMENT_DEPENDENCIES})
 
     #############
     add_library( DataLoadROS2 SHARED
         DataLoadROS2/dataload_ros2.cpp
         ${PLUGIN_BASE_DIR}/dataloader_base.h )
     target_link_libraries( DataLoadROS2 commonROS)
-    ament_target_dependencies( DataLoadROS2 ${AMENT_DEPENDECIES})
+    ament_target_dependencies( DataLoadROS2 ${AMENT_DEPENDENCIES})
     #############
     add_library( DataStreamROS2 SHARED
         DataStreamROS2/datastream_ros2.cpp
         ${PLUGIN_BASE_DIR}/datastreamer_base.h )
     target_link_libraries( DataStreamROS2  commonROS)
-    ament_target_dependencies( DataStreamROS2 ${AMENT_DEPENDECIES})
+    ament_target_dependencies( DataStreamROS2 ${AMENT_DEPENDENCIES})
     #############
     add_library( TopicPublisherROS2 SHARED
         TopicPublisherROS2/publisher_ros2.cpp
         ${PLUGIN_BASE_DIR}/statepublisher_base.h)
     target_link_libraries( TopicPublisherROS2 commonROS)
-    ament_target_dependencies( TopicPublisherROS2 ${AMENT_DEPENDECIES})
+    ament_target_dependencies( TopicPublisherROS2 ${AMENT_DEPENDENCIES})
 endif()
 
 #######################################################################


### PR DESCRIPTION
Resolves #304 / #306 , allows PlotJuggler to be built from source and run on ROS2 eloquent.