### PR TITLE
Do not throw exception when trying to convert NAN

### DIFF
--- a/plugins/ROS/ros1_introspection/include/ros_type_introspection/details/conversion_impl.hpp
+++ b/plugins/ROS/ros1_introspection/include/ros_type_introspection/details/conversion_impl.hpp
@@ -196,8 +196,9 @@ inline void checkLowerLimit(const From& from)
 template <typename From, typename To>
 inline void checkTruncation(const From& from)
 {
-  if( from != static_cast<From>(static_cast<To>( from))){
-    throw RangeException("Floating point truncated");
+  if (!std::isnan(from) && from != static_cast<From>(static_cast<To>(from)))
+  {
+    throw RangeException("Floating point truncated 1");
   }
 }
 


### PR DESCRIPTION
Correct exception error when I want to import a rosbag containing float32=NAN (see issue #335). 
It also helps when live streaming ROS topics with same float32=NAN value.