### PR TITLE
pal_statistics fixes

### DIFF
--- a/plugins/ROS/ros1_parsers/pal_statistics_msg.h
+++ b/plugins/ROS/ros1_parsers/pal_statistics_msg.h
@@ -139,7 +139,7 @@ public:
       const auto& name = names[index];
       if (index >= values.size())
       {
-        values.emplace_back(&getSeries(_plot_data, _topic_name + "/" + name));
+        values.emplace_back(&getSeries(_plot_data, _base_name + "/" + name));
       }
       values[index]->pushBack({ timestamp, pal_msg.values[index] });
     }

--- a/plugins/ROS/ros1_parsers/pal_statistics_msg.h
+++ b/plugins/ROS/ros1_parsers/pal_statistics_msg.h
@@ -66,8 +66,18 @@ struct Serializer<::PalStatisticsValues_>
 }  // namespace ros
 
 //-----------------------------------------------------
+// key is topic name + names version
+static std::unordered_map<std::string, std::vector<std::string>> _stored_pal_statistics_names;
 
-static std::unordered_map<uint32_t, std::vector<std::string>> _stored_pal_statistics_names;
+std::string get_statistics_base_name(const std::string &topic_name)
+{
+  return topic_name.substr(0, topic_name.rfind('/'));
+}
+
+std::string get_stored_statistics_id(const std::string &base_name, int names_version)
+{
+  return base_name + std::to_string(names_version);
+}
 
 class PalStatisticsNamesParser : public MessageParserBase
 {
@@ -82,7 +92,10 @@ public:
     PalStatisticsNames_ pal_names;
     ros::serialization::IStream is(const_cast<uint8_t*>(msg.data()), msg.size());
     ros::serialization::deserialize(is, pal_names);
-    _stored_pal_statistics_names.insert({ pal_names.names_version, std::move(pal_names.names) });
+    const std::string names_id = get_stored_statistics_id(get_statistics_base_name(_topic_name),
+                                                          pal_names.names_version);
+    _stored_pal_statistics_names.insert({names_id,
+                                         std::move(pal_names.names) });
     return true;
   }
 };
@@ -92,7 +105,7 @@ class PalStatisticsValuesParser : public MessageParserBase
 {
 public:
   PalStatisticsValuesParser(const std::string& topic_name, PlotDataMapRef& plot_data)
-    : MessageParserBase(topic_name, plot_data)
+    : MessageParserBase(topic_name, plot_data), _base_name(get_statistics_base_name(topic_name))
   {
   }
 
@@ -107,7 +120,9 @@ public:
     double header_stamp = pal_msg.header.stamp.toSec();
     timestamp = (_use_header_stamp && header_stamp > 0) ? header_stamp : timestamp;
 
-    auto names_it = _stored_pal_statistics_names.find(pal_msg.names_version);
+    const std::string names_id = get_stored_statistics_id(get_statistics_base_name(_topic_name),
+                                                          pal_msg.names_version);
+    auto names_it = _stored_pal_statistics_names.find(names_id);
     if (names_it == _stored_pal_statistics_names.end())
     {
       return false;  // missing vocabulary
@@ -132,6 +147,7 @@ public:
   }
 
 private:
+  std::string _base_name;
   std::unordered_map<uint32_t, std::vector<PlotData*>> _data;
 };
 


### PR DESCRIPTION
- Allow display of multiple pal_statistics_msg topics with same version
- Remove "values/" from pal_statistics variable names

The second change is cosmetic, but saves some screen space which is always nice.