### PR TITLE
Add required Qt5::Network for DataStreamUDP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,8 @@ find_package(Qt5 REQUIRED COMPONENTS
     Xml
     Svg
     OpenGL
-    WebSockets)
+    WebSockets
+    Network)
 
 set( QT_LINK_LIBRARIES
     Qt5::Core

--- a/plugins/DataStreamUDP/CMakeLists.txt
+++ b/plugins/DataStreamUDP/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(DataStreamUDP SHARED ${SRC} ${UI_SRC}  )
 
 target_link_libraries(DataStreamUDP
     ${Qt5Widgets_LIBRARIES}
+    Qt5::Network
     plotjuggler_plugin_base
     )
 


### PR DESCRIPTION
Otherwise build fails for me on OSX with linking errors.