### PR TITLE
Template parameter named ItemType collides with enum called ItemType

### DIFF
--- a/src/curvelist_view.h
+++ b/src/curvelist_view.h
@@ -18,11 +18,11 @@
 
 class CurveListPanel;
 
-template <typename ItemType>
-class SortedTableItem : public ItemType
+template <typename Item>
+class SortedTableItem : public Item
 {
 public:
-  SortedTableItem(const QString& name) : ItemType(name), str(name.toStdString())
+  SortedTableItem(const QString& name) : Item(name), str(name.toStdString())
   {
   }
 


### PR DESCRIPTION
MSVC fails to compile `SortedTableItem<QTreeWidgetItem>`.

If we use that definition, the class QTreeWidgetItem becomes a baseclass of SortedTableItem. That also inherits an enum called "ItemType" (which is the same as the template name). MSVC stumbles and spits out compilation errors :facepalm: . A simple solution is to rename the template parameter :facepalm: :facepalm: 