### PR TITLE
Do not compile FloatingWidgetTitleBar on OSX

### DIFF
--- a/3rdparty/Qt-Advanced-Docking/CMakeLists.txt
+++ b/3rdparty/Qt-Advanced-Docking/CMakeLists.txt
@@ -52,7 +52,7 @@ set(ads_SRCS
     include/Qads/DockComponentsFactory.h
 )
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
     set(ads_SRCS
         src/linux/FloatingWidgetTitleBar.cpp
         ${ads_SRCS}


### PR DESCRIPTION
See https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/blob/master/src/CMakeLists.txt#L52

Fix #353 