### PR TITLE
Enable use on Windows for 3.0.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,7 @@ if(EXISTS "${PROJECT_SOURCE_DIR}/3rdparty/paho.mqtt.c/CMakeLists.txt")
     add_subdirectory( plugins/DataStreamMQTT )
 endif()
 
-if(EXISTS "${PROJECT_SOURCE_DIR}/3rdparty/liblsl/CMakeLists.txt")
+if(EXISTS "${PROJECT_SOURCE_DIR}/3rdparty/liblsl/CMakeLists.txt" AND NOT WIN32)
     SET(LSL_ENABLE_TESTING FALSE CACHE BOOL "Build tests and run" FORCE)
     SET(LSL_ENABLE_CPACK FALSE CACHE BOOL "Enable CPack" FORCE)
     SET(LSL_BUILD_STATIC TRUE CACHE BOOL "Build static library" FORCE)

--- a/src/plotwidget.cpp
+++ b/src/plotwidget.cpp
@@ -150,7 +150,11 @@ PlotWidget::PlotWidget(PlotDataMapRef& datamap, QWidget* parent)
   this->sizePolicy().setHorizontalPolicy(QSizePolicy::Expanding);
   this->sizePolicy().setVerticalPolicy(QSizePolicy::Expanding);
 
+#ifdef Q_OS_WIN
+  auto canvas = new QwtPlotCanvas();
+#else
   auto canvas = new QwtPlotOpenGLCanvas();
+#endif
 
   canvas->setFrameStyle(QFrame::NoFrame);
 


### PR DESCRIPTION
This PR has been created for visibility with regards to #368 and may be merged if desired, or inspected by others curious about running 3.0.x on windows.

As mentioned there, this does not include LSL plugin support, but it does enable the windows build to run under basic functionality. I have not tested UDP streaming or plugins outside DataLoaders (csv and a plugin for a custom format). However, based on the testing I did perform, I did not notice any issues.

For building, I mirrored the environment described in #315.