### PR TITLE
Fix typo in "load transformations" prompt

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1899,7 +1899,7 @@ bool MainWindow::loadLayoutFromFile(QString filename)
     {
       QMessageBox msgBox(this);
       msgBox.setWindowTitle("Overwrite custom transforms?");
-      msgBox.setText("Your layour file contains a set of custom transforms different from "
+      msgBox.setText("Your layout file contains a set of custom transforms different from "
                      "the last one you used.\nWant to load these transformations?");
       msgBox.addButton(QMessageBox::No);
       msgBox.addButton(QMessageBox::Yes);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1900,7 +1900,7 @@ bool MainWindow::loadLayoutFromFile(QString filename)
       QMessageBox msgBox(this);
       msgBox.setWindowTitle("Overwrite custom transforms?");
       msgBox.setText("Your layour file contains a set of custom transforms different from "
-                     "the last one you used.\nant to load these transformations?");
+                     "the last one you used.\nWant to load these transformations?");
       msgBox.addButton(QMessageBox::No);
       msgBox.addButton(QMessageBox::Yes);
       msgBox.setDefaultButton(QMessageBox::Yes);


### PR DESCRIPTION
Fairly straight forward. There's two typos in the prompt for loading transformations :)

![image](https://user-images.githubusercontent.com/3762382/111762646-85277580-88a1-11eb-82e2-fc5139625a46.png)
