### PR TITLE
Prefix of Logs

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1236,9 +1236,11 @@ bool MainWindow::loadDataFromFiles(QStringList filenames)
   {
     FileLoadInfo info;
     info.filename = filenames[i];
-    if (filenames.size() > 1)
+    if (true)//filenames.size() > 1)
     {
-      info.prefix = prefix_ch;
+      QFileInfo fi;
+      fi = filenames[i];
+      info.prefix = fi.fileName();
     }
 
     if (loadDataFromFile(info))


### PR DESCRIPTION
Prefix of logs are not longer A,B,C,D...
Logs' names are now their prefix.
This way it is easy to follow graps.