### PR TITLE
Add quaternion to Euler conversion snippets

### DIFF
--- a/plotjuggler_app/resources/default.snippets.xml
+++ b/plotjuggler_app/resources/default.snippets.xml
@@ -55,4 +55,51 @@ end
 return value - first_value</function>
     <linkedSource></linkedSource>
   </snippet>
+  
+  <snippet name="quat_to_roll">
+    <global></global>
+    <function>w = value
+x = v1
+y = v2
+z = v3
+
+dcm21 = 2 * (w * x + y * z)
+dcm22 = w*w - x*x - y*y + z*z
+
+roll = math.atan(dcm21, dcm22)
+
+return roll</function>
+    <linkedSource></linkedSource>
+  </snippet>
+
+  <snippet name="quat_to_pitch">
+    <global></global>
+    <function>w = value
+x = v1
+y = v2
+z = v3
+
+dcm20 = 2 * (x * z - w * y)
+
+pitch = math.asin(-dcm20)
+
+return pitch</function>
+    <linkedSource></linkedSource>
+  </snippet>
+
+    <snippet name="quat_to_yaw">
+    <global></global>
+    <function>w = value
+x = v1
+y = v2
+z = v3
+
+dcm10 = 2 * (x * y + w * z)
+dcm00 = w*w + x*x - y*y - z*z
+
+yaw = math.atan(dcm10, dcm00)
+
+return yaw</function>
+    <linkedSource></linkedSource>
+  </snippet>
 </snippets>


### PR DESCRIPTION
@facontidavide This have been really useful to me in the past to inspect PX4 (`.ulg`) logs and will be really useful to other users. Instead of having to share a `.xml` gist to everyone, I'm wondering if you would be OK to add these functions to the default snippet set.

Summary:
Add 3 functions to convert a Hamiltonian attitude quaternion to its Euler (Tait-Bryan 321/yaw-pitch-roll) representation

Result:
![DeepinScreenshot_select-area_20210614172642](https://user-images.githubusercontent.com/14822839/121918296-366d6880-cd36-11eb-9a47-aed332b83821.png)
