### PR TITLE
[WIP] Merge data instead of replacing it

### DIFF
--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -1150,15 +1150,16 @@ void MainWindow::importPlotDataMap(PlotDataMapRef& new_data, bool remove_old)
     AddToDeleteList( _mapped_plot_data.numeric, new_data.numeric );
     AddToDeleteList( _mapped_plot_data.strings, new_data.strings );
 
-    if (!old_plots_to_delete.empty())
+    if (!_mapped_plot_data.numeric.empty() || !_mapped_plot_data.strings.empty()|| !_mapped_plot_data.user_defined.empty())
     {
       QMessageBox::StandardButton reply;
       reply = QMessageBox::question(this, tr("Warning"), tr("Do you want to remove the previously loaded data?\n"),
                                     QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
-      if (reply == QMessageBox::Yes)
+      if (!old_plots_to_delete.empty() && reply == QMessageBox::Yes)
       {
         onDeleteMultipleCurves(old_plots_to_delete);
       }
+      remove_old = (reply == QMessageBox::Yes);
     }
   }
 

--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -1152,14 +1152,17 @@ void MainWindow::importPlotDataMap(PlotDataMapRef& new_data, bool remove_old)
 
     if (!_mapped_plot_data.numeric.empty() || !_mapped_plot_data.strings.empty()|| !_mapped_plot_data.user_defined.empty())
     {
-      QMessageBox::StandardButton reply;
-      reply = QMessageBox::question(this, tr("Warning"), tr("Do you want to remove the previously loaded data?\n"),
-                                    QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
-      if (!old_plots_to_delete.empty() && reply == QMessageBox::Yes)
+      QMessageBox message_box(QMessageBox::Warning, tr("Warning"), tr("Do you want to remove the previously loaded data?\n"));
+      message_box.addButton("Yes",                    QMessageBox::YesRole);   // Remove old data
+      message_box.addButton("No (remove duplicates)", QMessageBox::NoRole);    // Keep old data except duplicates
+      message_box.addButton("No (merge duplicates)",  QMessageBox::ApplyRole); // Keep old data and merge duplicates
+      int reply_int = message_box.exec();
+
+      if (!old_plots_to_delete.empty() && reply_int == 0) // Remove duplicate data
       {
         onDeleteMultipleCurves(old_plots_to_delete);
       }
-      remove_old = (reply == QMessageBox::Yes);
+      remove_old = (reply_int != 2); // Set remove_old to false when the data should be merged.
     }
   }
 

--- a/plotjuggler_app/utils.cpp
+++ b/plotjuggler_app/utils.cpp
@@ -75,10 +75,7 @@ MoveDataRet MoveData(PlotDataMapRef &source,
         ret.data_pushed = true;
       }
 
-      for (size_t i = 0; i < source_plot.size(); i++)
-      {
-        destination_plot.pushBack( source_plot.at(i) );
-      }
+      destination_plot.pushBack(source_plot.begin(), source_plot.end());
 
       double max_range_x = source_plot.maximumRangeX();
       destination_plot.setMaximumRangeX(max_range_x);

--- a/plotjuggler_base/include/PlotJuggler/plotdatabase.h
+++ b/plotjuggler_base/include/PlotJuggler/plotdatabase.h
@@ -270,6 +270,12 @@ public:
         return std::nullopt;
     }
 
+    virtual void pushBack(Iterator start, Iterator end) {
+        for(auto p = start; p != end; ++p) {
+            pushBack(*p);
+        }
+    }
+
     virtual void pushBack(const Point &p)
     {
         auto temp = p;

--- a/plotjuggler_base/include/PlotJuggler/stringseries.h
+++ b/plotjuggler_base/include/PlotJuggler/stringseries.h
@@ -29,6 +29,10 @@ public:
         TimeseriesBase<StringRef>::clear();
     }
 
+    void pushBack(typename std::deque<Point>::iterator start, typename std::deque<Point>::iterator end) override {
+        TimeseriesBase<StringRef>::pushBack(start, end);
+    }
+
     void pushBack(const Point &p)  override
     {
         auto temp = p;

--- a/plotjuggler_base/include/PlotJuggler/timeseries.h
+++ b/plotjuggler_base/include/PlotJuggler/timeseries.h
@@ -46,6 +46,14 @@ public:
       return ( index < 0 ) ? std::nullopt : std::optional( _points[index].y );
     }
 
+    void pushBack(typename std::deque<Point>::iterator start, typename std::deque<Point>::iterator end) override {
+        for(auto it = start; it != end; ++it) {
+            auto temp = *it;
+            PlotDataBase<double, Value>::pushBack(std::move(temp));
+        }
+        std::sort(_points.begin(), _points.end(), [](auto& p1, auto& p2){return p1.x < p2.x;});
+    }
+
     void pushBack(const Point &p) override
     {
         auto temp = p;


### PR DESCRIPTION
This changes the way new data is added. New data with an already known name is merged with the old data (if the user wants to keep it).

This enables multiple bags recorded over the same timespan to be replayed (as "plotjuggler::rosbag1::consecutive_messages" can be merged).

It also enables to load simultaneously data recorded over a different timespan.

Relates to PlotJuggler/plotjuggler-ros-plugins#27