### PR TITLE
Added libprotoc-dev to the apt install package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Clone the repository as usual:
 The only binary dependency that you need installed in your system is Qt5. 
 On Ubuntu, the debians can be installed with the the command:
 
-    sudo apt -y install qtbase5-dev libqt5svg5-dev libqt5websockets5-dev libqt5opengl5-dev libqt5x11extras5-dev
+    sudo apt -y install qtbase5-dev libqt5svg5-dev libqt5websockets5-dev libqt5opengl5-dev libqt5x11extras5-dev libprotoc-dev
     
 On Fedora:
 


### PR DESCRIPTION
To compile the Protobuf parser plugin I needed to install  libprotoc-dev on Ubuntu 20.04, so it might be useful to note this in the Readme.md