### PR TITLE
Fix MutableTimeseries shadowed by MutableScatterXY

### DIFF
--- a/plotjuggler_base/include/PlotJuggler/reactive_function.h
+++ b/plotjuggler_base/include/PlotJuggler/reactive_function.h
@@ -5,7 +5,9 @@
 #include <sol/sol.hpp>
 
 class TimeseriesRef;
-class CreatedSeries;
+class CreatedSeriesBase;
+class CreatedSeriesTime;
+class CreatedSeriesXY;
 
 namespace PJ {
 
@@ -24,9 +26,9 @@ struct TimeseriesRef
 
 //-----------------------
 
-struct CreatedSeries
+struct CreatedSeriesBase
 {
-  CreatedSeries(PlotDataMapRef* data_map, const std::string& name, bool timeseries);
+  CreatedSeriesBase(PlotDataMapRef* data_map, const std::string& name, bool timeseries);
 
   std::pair<double, double> at(unsigned i) const;
 
@@ -37,6 +39,16 @@ struct CreatedSeries
   unsigned size() const;
 
   PJ::PlotDataXY* _plot_data = nullptr;
+};
+
+struct CreatedSeriesTime : public CreatedSeriesBase
+{
+  CreatedSeriesTime(PlotDataMapRef* data_map, const std::string& name);
+};
+
+struct CreatedSeriesXY : public CreatedSeriesBase
+{
+  CreatedSeriesXY(PlotDataMapRef* data_map, const std::string& name);
 };
 
 //-----------------------
@@ -104,7 +116,8 @@ protected:
   sol::protected_function _lua_function;
 
   sol::usertype<TimeseriesRef> _timeseries_ref;
-  sol::usertype<CreatedSeries> _created_timeseries;
+  sol::usertype<CreatedSeriesTime> _created_timeseries;
+  sol::usertype<CreatedSeriesXY> _created_scatter;
 private:
   void init();
 };

--- a/plotjuggler_base/src/reactive_function.cpp
+++ b/plotjuggler_base/src/reactive_function.cpp
@@ -12,6 +12,7 @@ void ReactiveLuaFunction::init()
 
   _lua_engine.open_libraries(sol::lib::base);
   _lua_engine.open_libraries(sol::lib::string);
+  _lua_engine.open_libraries(sol::lib::math);
 
   _lua_engine.script(_library_code);
 

--- a/plotjuggler_base/src/reactive_function.cpp
+++ b/plotjuggler_base/src/reactive_function.cpp
@@ -100,7 +100,7 @@ void ReactiveLuaFunction::prepareLua()
   _timeseries_ref["atTime"] = &TimeseriesRef::atTime;
 
   //---------------------------------------
-  _created_timeseries = _lua_engine.new_usertype<CreatedSeries>("MutableTimeseries");
+  _created_timeseries = _lua_engine.new_usertype<CreatedSeriesTime>("MutableTimeseries");
 
   _created_timeseries["new"] = [&](sol::object name)
   {
@@ -109,38 +109,39 @@ void ReactiveLuaFunction::prepareLua()
       return sol::make_object(_lua_engine, sol::lua_nil);
     }
     auto str_name = name.as<std::string>();
-    auto series = CreatedSeries(plotData(), str_name, true);
+    auto series = CreatedSeriesTime(plotData(), str_name);
     series.clear();
     _created_curves.push_back( str_name );
     return sol::object(_lua_engine, sol::in_place, series);
   };
 
-  _created_timeseries["at"] = &CreatedSeries::at;
-  _created_timeseries["size"] = &CreatedSeries::size;
-  _created_timeseries["clear"] = &CreatedSeries::clear;
-  _created_timeseries["push_back"] = &CreatedSeries::push_back;
+  _created_timeseries["at"] = &CreatedSeriesTime::at;
+  _created_timeseries["size"] = &CreatedSeriesTime::size;
+  _created_timeseries["clear"] = &CreatedSeriesTime::clear;
+  _created_timeseries["push_back"] = &CreatedSeriesTime::push_back;
 
   //---------------------------------------
-  sol::usertype<CreatedSeries> created_scatter =
-      _lua_engine.new_usertype<CreatedSeries>("MutableScatterXY");
+  _created_scatter = _lua_engine.new_usertype<CreatedSeriesXY>("MutableScatterXY");
 
-  created_scatter["new"] = [&](sol::object name)
+  _created_scatter["new"] = [&](sol::object name)
   {
     if (name.is<std::string>() == false)
     {
       return sol::make_object(_lua_engine, sol::lua_nil);
     }
     auto str_name = name.as<std::string>();
-    auto series = CreatedSeries(plotData(), str_name, false);
+    auto series = CreatedSeriesXY(plotData(), str_name);
     series.clear();
     _created_curves.push_back( str_name );
     return sol::object(_lua_engine, sol::in_place, series);
   };
 
-  created_scatter["at"] = &CreatedSeries::at;
-  created_scatter["size"] = &CreatedSeries::size;
-  created_scatter["clear"] = &CreatedSeries::clear;
-  created_scatter["push_back"] = &CreatedSeries::push_back;
+  _created_scatter["at"] = &CreatedSeriesXY::at;
+  _created_scatter["size"] = &CreatedSeriesXY::size;
+  _created_scatter["clear"] = &CreatedSeriesXY::clear;
+  _created_scatter["push_back"] = &CreatedSeriesXY::push_back;
+
+  //---------------------------------------
 }
 
 TimeseriesRef::TimeseriesRef(PlotData *data): _plot_data(data)
@@ -163,37 +164,48 @@ unsigned TimeseriesRef::size() const
   return _plot_data->size();
 }
 
-CreatedSeries::CreatedSeries(PlotDataMapRef *data_map, const std::string &name, bool timeseries)
+CreatedSeriesBase::CreatedSeriesBase(PlotDataMapRef *data_map, const std::string &name, bool timeseries)
 {
   if( timeseries )
   {
+    std::cout << "[DEBUG] Create timeserie, bool timeseries=" << timeseries << "\n";
     _plot_data = &(data_map->getOrCreateNumeric(name));
   }
   else
   {
+    std::cout << "[DEBUG] Create scatterplot, bool timeseries=" << timeseries << "\n";
     _plot_data = &(data_map->getOrCreateScatterXY(name));
   }
 }
 
-std::pair<double, double> CreatedSeries::at(unsigned i) const
+std::pair<double, double> CreatedSeriesBase::at(unsigned i) const
 {
   const auto& p = _plot_data->at(i);
   return {p.x, p.y};
 }
 
-void CreatedSeries::clear()
+void CreatedSeriesBase::clear()
 {
   _plot_data->clear();
 }
 
-void CreatedSeries::push_back(double x, double y)
+void CreatedSeriesBase::push_back(double x, double y)
 {
   _plot_data->pushBack( {x,y} );
 }
 
-unsigned CreatedSeries::size() const
+unsigned CreatedSeriesBase::size() const
 {
   return _plot_data->size();
 }
+
+
+CreatedSeriesTime::CreatedSeriesTime(PlotDataMapRef *data_map, const std::string &name) : 
+  CreatedSeriesBase(data_map, name, true)
+{}
+
+CreatedSeriesXY::CreatedSeriesXY(PlotDataMapRef *data_map, const std::string &name) : 
+  CreatedSeriesBase(data_map, name, false)
+{}
 
 }


### PR DESCRIPTION
I noticed on the last commit of the main branch I weren't able to use MutableTimeseries. It seemed after some investigations it was always overshadowed by MutableScatterXY. 

Way to reproduce the bug : 
1. Use Reactive Function Editor
2. Create a new MutableTimeseries
3. The created timeserie is a scatter plot.

I guessed it was because new_usertype in sol overwrite last type if a previous type with a different name but same base class has already been declared. So I used inheritance to declare two subtypes `CreatedSeriesTime` and `CreatedSeriesXY` deriving from `CreatedSeriesBase`. 

Side note I also added lua math that I think was missing.   