### PR TITLE
Fix typo in toolbox Lua

### DIFF
--- a/plotjuggler_plugins/ToolboxLuaEditor/lua_editor.ui
+++ b/plotjuggler_plugins/ToolboxLuaEditor/lua_editor.ui
@@ -313,8 +313,8 @@
  
  Assuming we have multiple series in the form:
  
-   /trajectory/node.{X}/position/x
-   /trajectory/node.{X}/position/y
+   /trajectory/node.{N}/position/x
+   /trajectory/node.{N}/position/y
    
  where {N} is the index of the array (integer). We can create a reactive series from the array with:
  


### PR DESCRIPTION
While trying to use the new ReactiveLuaFunction, I came across of what I think is a typo. I will try to propose more examples for custom functions.