### PR TITLE
Timestampfield

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,7 @@ add_subdirectory( plotjuggler_plugins/DataStreamSample )
 add_subdirectory( plotjuggler_plugins/DataStreamWebsocket )
 add_subdirectory( plotjuggler_plugins/DataStreamUDP )
 add_subdirectory( plotjuggler_plugins/DataStreamMQTT )
-#add_subdirectory( plotjuggler_plugins/DataStreamZMQ )
+add_subdirectory( plotjuggler_plugins/DataStreamZMQ )
 
 add_subdirectory( plotjuggler_plugins/StatePublisherCSV )
 add_subdirectory( plotjuggler_plugins/VideoViewer )

--- a/plotjuggler_app/nlohmann_parsers.cpp
+++ b/plotjuggler_app/nlohmann_parsers.cpp
@@ -6,10 +6,14 @@ bool NlohmannParser::parseMessageImpl(double& timestamp)
 {
   if (_use_message_stamp)
   {
-    auto ts = _json.find("timestamp");
+    auto ts = _json.find(_stamp_fieldname);
     if (ts != _json.end() && ts.value().is_number())
-    {
+    { 
       timestamp = ts.value().get<double>();
+    }
+    else
+    {
+      _use_message_stamp = false;
     }
   }
 

--- a/plotjuggler_app/nlohmann_parsers.h
+++ b/plotjuggler_app/nlohmann_parsers.h
@@ -3,7 +3,6 @@
 
 #include "nlohmann/json.hpp"
 #include "PlotJuggler/messageparser_base.h"
-#include <QCheckBox>
 #include <QDebug>
 
 using namespace PJ;
@@ -76,17 +75,16 @@ public:
 class QCheckBoxClose : public QGroupBox
 {
 public:
-  QCheckBox *checkbox;
   QLineEdit *lineedit;
   QGroupBox *groupbox;
   QCheckBoxClose(QString text) : QGroupBox(text)
   {
+      QGroupBox::setCheckable(true);
+      QGroupBox::setChecked(false);
       lineedit = new QLineEdit(this);
-      checkbox  = new QCheckBox(text, this);
       QVBoxLayout *vbox = new QVBoxLayout;
-      vbox->addWidget(checkbox);
+      vbox->addSpacing(20);
       vbox->addWidget(lineedit);
-      vbox->addStretch(1);
       QGroupBox::setLayout(vbox);
   }
   ~QCheckBoxClose() override
@@ -94,12 +92,6 @@ public:
     qDebug() << "Destroying QCheckBoxClose";
   }
 
-  void setVisible(bool on) override
-  {
-    QGroupBox::setVisible(on);
-    lineedit->setVisible(on);
-    checkbox->setVisible(on);
-  }
 };
 
 class NlohmannParserCreator : public MessageParserCreator
@@ -127,7 +119,7 @@ public:
                                   PlotDataMapRef& data) override
   {
     return std::make_shared<JSON_Parser>(topic_name, data,
-                                         _checkbox_use_timestamp->checkbox->isChecked(), _checkbox_use_timestamp->lineedit->text().toStdString());
+                                         _checkbox_use_timestamp->isChecked(), _checkbox_use_timestamp->lineedit->text().toStdString());
   }
   const char* name() const override
   {
@@ -142,7 +134,7 @@ public:
                                   PlotDataMapRef& data) override
   {
     return std::make_shared<CBOR_Parser>(topic_name, data,
-                                         _checkbox_use_timestamp->checkbox->isChecked(), _checkbox_use_timestamp->lineedit->text().toStdString());
+                                         _checkbox_use_timestamp->isChecked(), _checkbox_use_timestamp->lineedit->text().toStdString());
   }
   const char* name() const override
   {
@@ -157,7 +149,7 @@ public:
                                   PlotDataMapRef& data) override
   {
     return std::make_shared<BSON_Parser>(topic_name, data,
-                                         _checkbox_use_timestamp->checkbox->isChecked(), _checkbox_use_timestamp->lineedit->text().toStdString());
+                                         _checkbox_use_timestamp->isChecked(), _checkbox_use_timestamp->lineedit->text().toStdString());
   }
   const char* name() const override
   {
@@ -172,7 +164,7 @@ public:
                                   PlotDataMapRef& data) override
   {
     return std::make_shared<MessagePack_Parser>(topic_name, data,
-                                                _checkbox_use_timestamp->checkbox->isChecked(), _checkbox_use_timestamp->lineedit->text().toStdString());
+                                                _checkbox_use_timestamp->isChecked(), _checkbox_use_timestamp->lineedit->text().toStdString());
   }
   const char* name() const override
   {

--- a/plotjuggler_plugins/DataStreamZMQ/CMakeLists.txt
+++ b/plotjuggler_plugins/DataStreamZMQ/CMakeLists.txt
@@ -17,7 +17,6 @@ if(ZeroMQ_FOUND)
         ${Qt5Widgets_LIBRARIES}
         plotjuggler_base
         ${ZeroMQ_LIBRARY}
-        ${ZeroMQ_STATIC_LIBRARY}
         )
 
     install(TARGETS DataStreamZMQ DESTINATION ${PJ_PLUGIN_INSTALL_DIRECTORY}  )


### PR DESCRIPTION
I modified the checkbox in streaming plugins to use timestamp field, so that it can use a different field. This is useful to me and I only tested with UDP and ZeroMQ. Using a field with bogus data as timestamp can cause buggy behavior, but that's probably some core function I'm not sure I have the ability to fix.

![PlotJuggler](https://user-images.githubusercontent.com/21337322/152860863-a765a024-d4f1-41b3-b444-dd529000078a.PNG)
