### PR TITLE
Modify install command to make it easier to install PlotJuggler

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If you want a simple example to learn how to write your own plugins, have a look
 
 Install the debian packages using: 
 
-     sudo apt install ros-<distro>-plotjuggler-ros
+     sudo apt install ros-$ROS_DISTRO-plotjuggler-ros
 
 ## How to build
 


### PR DESCRIPTION
To make it easy for everybody to just copy the command and install the PlotJuggler, ROS has the version name, kinetic, melodic ... etc., in its environmental variable $ROS_DISTRO. Also, the name is self-explanatory for someone new to ROS who needs to substitute with the required ROS distribution name. This modification will at least try to make it easier for somebody who already has the right environment to install PlotJuggler.