### PR TITLE
Passing CI on ROS2 Rolling

### DIFF
--- a/.github/workflows/ros2.yaml
+++ b/.github/workflows/ros2.yaml
@@ -9,6 +9,7 @@ jobs:
         env:
           - {ROS_DISTRO: foxy, ROS_REPO: main}
           - {ROS_DISTRO: galactic, ROS_REPO: main}
+          - {ROS_DISTRO: rolling, ROS_REPO: main}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,8 @@ message(${catkin_INCLUDE_DIRS})
 elseif( DEFINED ENV{AMENT_PREFIX_PATH})
     set(COMPILING_WITH_AMENT 1)
 
+    find_package(ament_cmake REQUIRED)
     find_package(ament_index_cpp REQUIRED)
-    include_directories(${ament_index_cpp_INCLUDE_DIRS})
 
     message(STATUS "--------------------------------------------------")
     message(STATUS "PlotJuggler is being built using AMENT.")
@@ -182,7 +182,6 @@ if(COMPILING_WITH_CATKIN)
 
 elseif(COMPILING_WITH_AMENT)
 
-    find_package(ament_cmake REQUIRED)
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
     set(PJ_PLUGIN_INSTALL_DIRECTORY lib/${PROJECT_NAME} )

--- a/plotjuggler_app/CMakeLists.txt
+++ b/plotjuggler_app/CMakeLists.txt
@@ -118,7 +118,7 @@ if(COMPILING_WITH_CATKIN)
 
 elseif(COMPILING_WITH_AMENT)
 
-    target_link_libraries(plotjuggler ${ament_index_cpp_LIBRARIES} )
+    ament_target_dependencies(plotjuggler ament_index_cpp)
 
     install(TARGETS plotjuggler
         DESTINATION lib/${PROJECT_NAME} )


### PR DESCRIPTION
These changes should resolve the rolling build on Ubuntu Jammy https://build.ros2.org/view/Rbin_uJ64/job/Rbin_uJ64__plotjuggler__ubuntu_jammy_amd64__binary/

Also adds a Rolling CI.