### PR TITLE
add STATUS to CmakeLists.txt message() to avoid 'message called with incorrect number of arguments'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ if( CATKIN_DEVEL_PREFIX OR catkin_FOUND OR CATKIN_BUILD_BINARY_PACKAGE)
         CATKIN_DEPENDS roslib
     )
 
-message(${catkin_INCLUDE_DIRS})
+message(STATUS ${catkin_INCLUDE_DIRS})
 
     include_directories(${catkin_INCLUDE_DIRS})
     add_definitions(-DCOMPILED_WITH_CATKIN)


### PR DESCRIPTION
cmake 3.22.1 errors on this