### PR TITLE
fix Cancel button in CSV loader

### DIFF
--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
@@ -7,6 +7,7 @@
 #include <QProgressDialog>
 #include <QDateTime>
 #include <QInputDialog>
+#include <QPushButton>
 
 const int TIME_INDEX_NOT_DEFINED = -2;
 const int TIME_INDEX_GENERATED = -1;
@@ -91,16 +92,18 @@ DataLoadCSV::DataLoadCSV()
   _ui = new Ui::DialogCSV();
   _ui->setupUi(_dialog);
 
+  _ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+
   connect(_ui->radioButtonSelect, &QRadioButton::toggled, this, [this](bool checked) {
     _ui->listWidgetSeries->setEnabled(checked);
     auto selected = _ui->listWidgetSeries->selectionModel()->selectedIndexes();
     bool box_enabled = !checked || selected.size() == 1;
-    _ui->buttonBox->setEnabled(box_enabled);
+    _ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(box_enabled);
   });
   connect(_ui->listWidgetSeries, &QListWidget::itemSelectionChanged, this, [this]() {
     auto selected = _ui->listWidgetSeries->selectionModel()->selectedIndexes();
     bool box_enabled = _ui->radioButtonIndex->isChecked() || selected.size() == 1;
-    _ui->buttonBox->setEnabled(box_enabled);
+    _ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(box_enabled);
   });
 
   connect(_ui->listWidgetSeries, &QListWidget::itemDoubleClicked, this,

--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.ui
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.ui
@@ -182,7 +182,7 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
minor change to CSV loader to allow the cancel button to always be enabled. Previously the cancel button was enabled/disabled with the Ok button