### PR TITLE
Make tutorial link open in browser when clicked

### DIFF
--- a/plotjuggler_plugins/ToolboxLuaEditor/lua_editor.ui
+++ b/plotjuggler_plugins/ToolboxLuaEditor/lua_editor.ui
@@ -27,6 +27,9 @@
      <property name="wordWrap">
       <bool>true</bool>
      </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
Similar to https://github.com/facontidavide/PlotJuggler/pull/658 but applied to the tutorial link in the reactive lua editor