### PR TITLE
New widget for Lua script editing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ qt5_wrap_cpp(PLOTJUGGLER_BASE_MOCS
   plotjuggler_base/include/PlotJuggler/transform_function.h
   plotjuggler_base/include/PlotJuggler/plotwidget_base.h
   plotjuggler_base/include/PlotJuggler/lua_highlighter.h
+  plotjuggler_base/include/PlotJuggler/script_editor.h
 )
 
 add_library( plotjuggler_base
@@ -170,6 +171,7 @@ add_library( plotjuggler_base
      plotjuggler_base/src/timeseries_qwt.cpp
      plotjuggler_base/src/reactive_function.cpp
      plotjuggler_base/src/lua_highlighter.cpp
+     plotjuggler_base/src/script_editor.cpp
      )
 # target_link_libraries(plotjuggler_base plotjuggler_qwt)
 

--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -2713,6 +2713,42 @@ void MainWindow::on_actionShare_the_love_triggered()
                                  "tweet?hashtags=PlotJuggler"));
 }
 
+void MainWindow::on_actionQt_License_Info_triggered(){
+    QMessageBox msgBox;
+    msgBox.setText(R"PREFIX(Copyright (C) 2016 The Qt Company Ltd.
+Contact: https://www.qt.io/licensing/
+
+BSD License Usage
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+  * Neither the name of The Qt Company Ltd nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.")PREFIX");
+    msgBox.exec();
+
+}
+
 void MainWindow::on_actionAbout_triggered()
 {
   QDialog* dialog = new QDialog(this);

--- a/plotjuggler_app/mainwindow.h
+++ b/plotjuggler_app/mainwindow.h
@@ -238,6 +238,7 @@ public slots:
   // TODO ?  void on_actionSaveAllPlotTabs_triggered();
 
   void on_actionAbout_triggered();
+  void on_actionQt_License_Info_triggered();
   void on_actionExit_triggered();
 
   void on_pushButtonActivateGrid_toggled(bool checked);

--- a/plotjuggler_app/mainwindow.ui
+++ b/plotjuggler_app/mainwindow.ui
@@ -1367,7 +1367,7 @@
                      <string>tt</string>
                     </property>
                     <property name="icon">
-                     <iconset>
+                     <iconset resource="resource.qrc">
                       <normaloff>:/style_light/line_tracker_1.png</normaloff>:/style_light/line_tracker_1.png</iconset>
                     </property>
                     <property name="iconSize">
@@ -1838,6 +1838,7 @@
     <addaction name="actionShare_the_love"/>
     <addaction name="actionReportBug"/>
     <addaction name="separator"/>
+    <addaction name="actionQt_License_Info"/>
     <addaction name="actionAbout"/>
    </widget>
    <widget class="QMenu" name="menuTools">
@@ -1866,7 +1867,7 @@
   </action>
   <action name="actionReportBug">
    <property name="icon">
-    <iconset>
+    <iconset resource="resource.qrc">
      <normaloff>:/resources/github.png</normaloff>:/resources/github.png</iconset>
    </property>
    <property name="text">
@@ -1927,7 +1928,7 @@
   </action>
   <action name="actionShare_the_love">
    <property name="icon">
-    <iconset>
+    <iconset resource="resource.qrc">
      <normaloff>:/resources/twitter.png</normaloff>:/resources/twitter.png</iconset>
    </property>
    <property name="text">
@@ -1937,6 +1938,11 @@
   <action name="actionLoadStyleSheet">
    <property name="text">
     <string>Load StyleSheet</string>
+   </property>
+  </action>
+  <action name="actionQt_License_Info">
+   <property name="text">
+    <string>Qt License Info</string>
    </property>
   </action>
  </widget>
@@ -1953,6 +1959,8 @@
    <header location="global">menubar.h</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="resource.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/plotjuggler_app/transforms/function_editor.ui
+++ b/plotjuggler_app/transforms/function_editor.ui
@@ -555,7 +555,7 @@
                 <number>0</number>
                </property>
                <item>
-                <widget class="QPlainTextEdit" name="globalVarsText">
+                <widget class="ScriptEditor" name="globalVarsText">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                    <horstretch>0</horstretch>
@@ -584,7 +584,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QPlainTextEdit" name="functionText">
+                <widget class="ScriptEditor" name="functionText">
                  <property name="minimumSize">
                   <size>
                    <width>0</width>
@@ -622,7 +622,7 @@
          <property name="childrenCollapsible">
           <bool>false</bool>
          </property>
-         <widget class="QWidget" name="">
+         <widget class="QWidget" name="layoutWidget">
           <layout class="QVBoxLayout" name="verticalLayout_6">
            <property name="rightMargin">
             <number>10</number>
@@ -871,7 +871,7 @@
                <number>0</number>
               </property>
               <item>
-               <widget class="QPlainTextEdit" name="globalVarsTextBatch">
+               <widget class="ScriptEditor" name="globalVarsTextBatch">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                   <horstretch>0</horstretch>
@@ -900,7 +900,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QPlainTextEdit" name="functionTextBatch">
+               <widget class="ScriptEditor" name="functionTextBatch">
                 <property name="minimumSize">
                  <size>
                   <width>0</width>
@@ -974,6 +974,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScriptEditor</class>
+   <extends>QPlainTextEdit</extends>
+   <header>PlotJuggler/script_editor.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/plotjuggler_base/include/PlotJuggler/script_editor.h
+++ b/plotjuggler_base/include/PlotJuggler/script_editor.h
@@ -1,0 +1,116 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the examples of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:BSD$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** BSD License Usage
+** Alternatively, you may use this file under the terms of the BSD license
+** as follows:
+**
+** "Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are
+** met:
+**   * Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**   * Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in
+**     the documentation and/or other materials provided with the
+**     distribution.
+**   * Neither the name of The Qt Company Ltd nor the names of its
+**     contributors may be used to endorse or promote products derived
+**     from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+** "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+** LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+** A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+** OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef CODEEDITOR_H
+#define CODEEDITOR_H
+
+#include <QPlainTextEdit>
+
+QT_BEGIN_NAMESPACE
+class QPaintEvent;
+class QResizeEvent;
+class QSize;
+class QWidget;
+QT_END_NAMESPACE
+
+class LineNumberArea;
+
+//![codeeditordefinition]
+
+class ScriptEditor : public QPlainTextEdit
+{
+    Q_OBJECT
+
+public:
+    ScriptEditor(QWidget *parent = nullptr);
+
+    void lineNumberAreaPaintEvent(QPaintEvent *event);
+    int lineNumberAreaWidth();
+    void setTheme(QString theme);
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+
+private slots:
+    void updateLineNumberAreaWidth(int newBlockCount);
+    void highlightCurrentLine();
+    void updateLineNumberArea(const QRect &rect, int dy);
+
+private:
+    QWidget *lineNumberArea;
+};
+
+//![codeeditordefinition]
+//![extraarea]
+
+class LineNumberArea : public QWidget
+{
+public:
+    LineNumberArea(ScriptEditor *editor) : QWidget(editor), scriptEditor(editor)
+    {}
+
+    QSize sizeHint() const override
+    {
+        return QSize(scriptEditor->lineNumberAreaWidth(), 0);
+    }
+
+protected:
+    void paintEvent(QPaintEvent *event) override
+    {
+        scriptEditor->lineNumberAreaPaintEvent(event);
+    }
+
+private:
+    ScriptEditor *scriptEditor;
+};
+
+//![extraarea]
+
+#endif

--- a/plotjuggler_base/src/script_editor.cpp
+++ b/plotjuggler_base/src/script_editor.cpp
@@ -1,0 +1,185 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the examples of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:BSD$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** BSD License Usage
+** Alternatively, you may use this file under the terms of the BSD license
+** as follows:
+**
+** "Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are
+** met:
+**   * Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**   * Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in
+**     the documentation and/or other materials provided with the
+**     distribution.
+**   * Neither the name of The Qt Company Ltd nor the names of its
+**     contributors may be used to endorse or promote products derived
+**     from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+** "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+** LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+** A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+** OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "PlotJuggler/script_editor.h"
+
+#include <QPainter>
+#include <QTextBlock>
+#include <QtGlobal>
+
+//![constructor]
+
+ScriptEditor::ScriptEditor(QWidget *parent) : QPlainTextEdit(parent)
+{
+    lineNumberArea = new LineNumberArea(this);
+
+    connect(this, &ScriptEditor::blockCountChanged, this, &ScriptEditor::updateLineNumberAreaWidth);
+    connect(this, &ScriptEditor::updateRequest, this, &ScriptEditor::updateLineNumberArea);
+    connect(this, &ScriptEditor::cursorPositionChanged, this, &ScriptEditor::highlightCurrentLine);
+
+    updateLineNumberAreaWidth(0);
+    highlightCurrentLine();
+}
+
+//![constructor]
+
+//![extraAreaWidth]
+
+int ScriptEditor::lineNumberAreaWidth()
+{
+    int digits = 1;
+    int max = qMax(1, blockCount());
+    while (max >= 10) {
+        max /= 10;
+        ++digits;
+    }
+
+    #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+    int space = 3 + fontMetrics().width(QLatin1Char('9')) * digits;
+    #else
+    int space = 3 + fontMetrics().horizontalAdvance(QLatin1Char('9')) * digits;
+    #endif
+
+    return space;
+}
+
+//![extraAreaWidth]
+
+//![slotUpdateExtraAreaWidth]
+
+void ScriptEditor::updateLineNumberAreaWidth(int /* newBlockCount */)
+{
+    setViewportMargins(lineNumberAreaWidth(), 0, 0, 0);
+}
+
+//![slotUpdateExtraAreaWidth]
+
+//![slotUpdateRequest]
+
+void ScriptEditor::updateLineNumberArea(const QRect &rect, int dy)
+{
+    if (dy)
+        lineNumberArea->scroll(0, dy);
+    else
+        lineNumberArea->update(0, rect.y(), lineNumberArea->width(), rect.height());
+
+    if (rect.contains(viewport()->rect()))
+        updateLineNumberAreaWidth(0);
+}
+
+//![slotUpdateRequest]
+
+//![resizeEvent]
+
+void ScriptEditor::resizeEvent(QResizeEvent *e)
+{
+    QPlainTextEdit::resizeEvent(e);
+
+    QRect cr = contentsRect();
+    lineNumberArea->setGeometry(QRect(cr.left(), cr.top(), lineNumberAreaWidth(), cr.height()));
+}
+
+//![resizeEvent]
+
+//![cursorPositionChanged]
+
+void ScriptEditor::highlightCurrentLine()
+{
+    QList<QTextEdit::ExtraSelection> extraSelections;
+
+    if (!isReadOnly()) {
+        QTextEdit::ExtraSelection selection;
+
+        QColor lineColor = QColor(119,119,119,64);
+
+        selection.format.setBackground(lineColor);
+        selection.format.setProperty(QTextFormat::FullWidthSelection, true);
+        selection.cursor = textCursor();
+        selection.cursor.clearSelection();
+        extraSelections.append(selection);
+    }
+
+    setExtraSelections(extraSelections);
+}
+
+//![cursorPositionChanged]
+
+//![extraAreaPaintEvent_0]
+
+void ScriptEditor::lineNumberAreaPaintEvent(QPaintEvent *event)
+{
+    QPainter painter(lineNumberArea);
+    painter.fillRect(event->rect(), QColor(102,102,102,64));
+
+//![extraAreaPaintEvent_0]
+
+//![extraAreaPaintEvent_1]
+    QTextBlock block = firstVisibleBlock();
+    int blockNumber = block.blockNumber();
+    int top = qRound(blockBoundingGeometry(block).translated(contentOffset()).top());
+    int bottom = top + qRound(blockBoundingRect(block).height());
+//![extraAreaPaintEvent_1]
+
+//![extraAreaPaintEvent_2]
+    while (block.isValid() && top <= event->rect().bottom()) {
+        if (block.isVisible() && bottom >= event->rect().top()) {
+            QString number = QString::number(blockNumber + 1);
+            painter.setPen(Qt::black);
+            painter.drawText(0, top, lineNumberArea->width(), fontMetrics().height(),
+                             Qt::AlignRight, number);
+        }
+
+        block = block.next();
+        top = bottom;
+        bottom = top + qRound(blockBoundingRect(block).height());
+        ++blockNumber;
+    }
+}
+//![extraAreaPaintEvent_2]

--- a/plotjuggler_plugins/ToolboxLuaEditor/lua_editor.ui
+++ b/plotjuggler_plugins/ToolboxLuaEditor/lua_editor.ui
@@ -22,7 +22,7 @@
       </font>
      </property>
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The &lt;span style=&quot; font-weight:600;&quot;&gt;Script Editor &lt;/span&gt;is an advanced Lua editor that allows the user to create new series (ScatteXY or Timeseries) which are updated when the timetracker slider is moved or new data is received. &lt;a href=&quot;https://slides.com/davidefaconti/plotjuggler-reactive-scripts/fullscreen&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Tutorial link&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The &lt;span style=&quot; font-weight:600;&quot;&gt;Script Editor &lt;/span&gt;is an advanced Lua editor that allows the user to create new series (ScatterXY or Timeseries) which are updated when the timetracker slider is moved or new data is received. &lt;a href=&quot;https://slides.com/davidefaconti/plotjuggler-reactive-scripts/fullscreen&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Tutorial link&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -45,7 +45,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -64,7 +64,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QPlainTextEdit" name="textGlobal">
+            <widget class="ScriptEditor" name="textGlobal">
              <property name="font">
               <font>
                <pointsize>12</pointsize>
@@ -99,7 +99,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QPlainTextEdit" name="textFunction">
+            <widget class="ScriptEditor" name="textFunction">
              <property name="font">
               <font>
                <pointsize>12</pointsize>
@@ -296,7 +296,7 @@
         </layout>
        </item>
        <item>
-        <widget class="QPlainTextEdit" name="textLibrary">
+        <widget class="ScriptEditor" name="textLibrary">
          <property name="font">
           <font>
            <pointsize>12</pointsize>
@@ -397,6 +397,13 @@ end
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScriptEditor</class>
+   <extends>QPlainTextEdit</extends>
+   <header>PlotJuggler/script_editor.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Replace simple QPlainTextEdit in Lua script editors with widget from [Qt Code Editor example](https://doc.qt.io/qt-6/qtwidgets-widgets-codeeditor-example.html) to add line numbering and highlighting. The new widget inherits from QPlainTextEdit and original functionality is untouched.

Places updated with new widget:

- Custom Lua script editor (single and batch)
- Reactive Script Editor

Demo video below:

https://user-images.githubusercontent.com/2954254/173200613-2bff3d7b-1410-4b9d-bb2f-c05e53bc3273.mp4


A Qt license info dialog was also added per the Qt BSD license for the widget:

https://user-images.githubusercontent.com/2954254/173200725-36a67107-9b7b-40f3-b09a-d8efa9d92766.mp4



