### PR TITLE
Add automatic data reload on change

### DIFF
--- a/plotjuggler_app/mainwindow.h
+++ b/plotjuggler_app/mainwindow.h
@@ -117,6 +117,7 @@ private:
   std::map<QString, StatePublisherPtr> _state_publisher;
   std::map<QString, DataStreamerPtr> _data_streamer;
   std::map<QString, ToolboxPluginPtr> _toolboxes;
+  std::map<QString, QDateTime> _log_last_modified;
 
   QString _default_streamer;
 
@@ -146,6 +147,7 @@ private:
   MonitoredValue _time_offset;
 
   QTimer* _replot_timer;
+  QTimer* _log_monitor_timer;
   QTimer* _publish_timer;
   PJ::DelayedCallback _tracker_delay;
 
@@ -211,6 +213,8 @@ private:
   void updateDerivedSeries();
 
   void updateReactivePlots();
+
+  void checkLogs();
 
 signals:
   void dataSourceRemoved(const std::string& name);

--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
@@ -558,6 +558,9 @@ bool DataLoadCSV::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_data
   if (time_index >= 0)
   {
     _default_time_axis = column_names[time_index];
+  } else if (time_index == TIME_INDEX_GENERATED)
+  {
+    _default_time_axis = "__TIME_INDEX_GENERATED__";
   }
 
   // cleanups


### PR DESCRIPTION
This adds a feature which automatically reloads log data based on the last modified date.  This allows new data (e.g. from a simulation run) to be displayed without user intervention simply by overwriting the log file.

NOTE: This feature is currently enabled by default but in the end should probably be enabled via a preference either globally or in the data load dialog.  I'll wait for suggestions on the most suitable location and best way to accomplish this.

Discussion: https://github.com/facontidavide/PlotJuggler/discussions/653