### PR TITLE
Added support for converted int types

### DIFF
--- a/plotjuggler_plugins/DataLoadParquet/dataload_parquet.cpp
+++ b/plotjuggler_plugins/DataLoadParquet/dataload_parquet.cpp
@@ -68,6 +68,7 @@ void DataLoadParquet::setupDialog(QDialog* dialog)
 bool DataLoadParquet::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_data)
 {
   using parquet::Type;
+  using parquet::ConvertedType;
 
   parquet_reader_ = parquet::ParquetFileReader::OpenFile(info->filename.toStdString());
 
@@ -84,13 +85,17 @@ bool DataLoadParquet::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_
   setupDialog(dialog);
 
   std::vector<parquet::Type::type> column_type;
+  std::vector<parquet::ConvertedType::type> converted_column_type;
   std::vector<bool> valid_column( num_columns, true );
 
   for( size_t col=0; col<num_columns; col++ )
   {
     auto column =  schema->Column(col);
     auto type = column->physical_type();
+    auto converted_type = column->converted_type();
+
     column_type.push_back( type );
+    converted_column_type.push_back( converted_type );
 
     valid_column[col] = (type == Type::BOOLEAN ||
                          type == Type::INT32 ||
@@ -178,6 +183,7 @@ bool DataLoadParquet::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_
         continue;
       }
       auto type = column_type[col];
+      auto converted_type = converted_column_type[col];
 
       switch(type)
       {
@@ -187,16 +193,67 @@ bool DataLoadParquet::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_
           row_values[col] = static_cast<double>(tmp);
           break;
         }
-        case Type::INT32: {
-          int32_t tmp;
-          os >> tmp;
-          row_values[col] = static_cast<double>(tmp);
-          break;
-        }
+        case Type::INT32: 
         case Type::INT64: {
-          int64_t tmp;
-          os >> tmp;
-          row_values[col] = static_cast<double>(tmp);
+          switch(converted_type)
+          {
+            case ConvertedType::INT_8:
+            {
+              int8_t tmp;
+              os >> tmp;
+              row_values[col] = static_cast<double>(tmp);
+              break;
+            }
+            case ConvertedType::INT_16:
+            {
+              int16_t tmp;
+              os >> tmp;
+              row_values[col] = static_cast<double>(tmp);
+              break;
+            }
+            case ConvertedType::INT_32:
+            {
+              int32_t tmp;
+              os >> tmp;
+              row_values[col] = static_cast<double>(tmp);
+              break;
+            }
+            case ConvertedType::INT_64:
+            {
+              int64_t tmp;
+              os >> tmp;
+              row_values[col] = static_cast<double>(tmp);
+              break;
+            }
+            case ConvertedType::UINT_8:
+            {
+              uint8_t tmp;
+              os >> tmp;
+              row_values[col] = static_cast<double>(tmp);
+              break;
+            }
+            case ConvertedType::UINT_16:
+            {
+              uint16_t tmp;
+              os >> tmp;
+              row_values[col] = static_cast<double>(tmp);
+              break;
+            }
+            case ConvertedType::UINT_32:
+            {
+              uint32_t tmp;
+              os >> tmp;
+              row_values[col] = static_cast<double>(tmp);
+              break;
+            }
+            case ConvertedType::UINT_64:
+            {
+              uint64_t tmp;
+              os >> tmp;
+              row_values[col] = static_cast<double>(tmp);
+              break;
+            }
+          }
           break;
         }
         case Type::FLOAT: {


### PR DESCRIPTION
Currently the parquet loader plugin only supports INT32 and INT64 parquet types. This commit adds supports for the following extra data types by using the ConvertedType from each column:

UINT8
UINT16
UINT32
UINT64
INT8
INT16