### PR TITLE
Add line numbers to csv loader

### DIFF
--- a/plotjuggler_plugins/DataLoadCSV/CMakeLists.txt
+++ b/plotjuggler_plugins/DataLoadCSV/CMakeLists.txt
@@ -14,7 +14,8 @@ add_library(DataLoadCSV SHARED ${SRC} ${UI_SRC}  )
 target_link_libraries(DataLoadCSV
     ${Qt5Widgets_LIBRARIES}
     ${Qt5Xml_LIBRARIES}
-    plotjuggler_base)
+    plotjuggler_base
+    QCodeEditor)
 
 
 install(TARGETS DataLoadCSV DESTINATION ${PJ_PLUGIN_INSTALL_DIRECTORY}  )

--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
@@ -8,6 +8,7 @@
 #include <QDateTime>
 #include <QInputDialog>
 #include <QPushButton>
+#include "QSyntaxStyle"
 
 const int TIME_INDEX_NOT_DEFINED = -2;
 const int TIME_INDEX_GENERATED = -1;
@@ -284,6 +285,21 @@ int DataLoadCSV::launchDialog(QFile& file, std::vector<std::string>* column_name
       _delimiter = ' ';
     }
     file.close();
+  }
+
+
+  QString theme = settings.value("StyleSheet::theme", "light").toString();
+  auto style_path = (theme == "light" ) ? ":/resources/lua_style_light.xml" :
+                                          ":/resources/lua_style_dark.xml";
+
+  QFile fl(style_path);
+  if (fl.open(QIODevice::ReadOnly))
+  {
+    auto style = new QSyntaxStyle(this);
+    if (style->load(fl.readAll()))
+    {
+      _ui->rawText->setSyntaxStyle( style );
+    }
   }
 
   // temporary connection

--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.ui
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.ui
@@ -166,9 +166,9 @@
         </widget>
        </item>
        <item>
-        <widget class="QPlainTextEdit" name="rawText">
+        <widget class="QCodeEditor" name="rawText">
          <property name="lineWrapMode">
-          <enum>QPlainTextEdit::NoWrap</enum>
+          <enum>QTextEdit::NoWrap</enum>
          </property>
          <property name="readOnly">
           <bool>true</bool>
@@ -194,6 +194,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QCodeEditor</class>
+   <extends>QTextEdit</extends>
+   <header location="global">QCodeEditor</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Promote the rawText widget in csv loader to QCodeEditor for line number display and set the widget theme to be consistent with the Lua script editor (no syntax highlighting)

![image](https://user-images.githubusercontent.com/2954254/176927443-9f6d0017-f28b-40b1-b06d-244f8cede767.png)
