### PR TITLE
Add CSV table preview and CSV highlighting

### DIFF
--- a/3rdparty/QCodeEditor/CMakeLists.txt
+++ b/3rdparty/QCodeEditor/CMakeLists.txt
@@ -28,6 +28,7 @@ set(INCLUDE_FILES
     include/internal/QHighlightBlockRule.hpp
     include/internal/QCodeEditor.hpp
     include/internal/QCXXHighlighter.hpp
+    include/internal/QCSVHighlighter.hpp
     include/internal/QLineNumberArea.hpp
     include/internal/QStyleSyntaxHighlighter.hpp
     include/internal/QSyntaxStyle.hpp
@@ -47,6 +48,7 @@ set(SOURCE_FILES
     src/internal/QCodeEditor.cpp
     src/internal/QLineNumberArea.cpp
     src/internal/QCXXHighlighter.cpp
+    src/internal/QCSVHighlighter.cpp
     src/internal/QSyntaxStyle.cpp
     src/internal/QStyleSyntaxHighlighter.cpp
     src/internal/QGLSLCompleter.cpp

--- a/3rdparty/QCodeEditor/include/QCSVHighlighter
+++ b/3rdparty/QCodeEditor/include/QCSVHighlighter
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <internal/QCSVHighlighter.hpp>

--- a/3rdparty/QCodeEditor/include/internal/QCSVHighlighter.hpp
+++ b/3rdparty/QCodeEditor/include/internal/QCSVHighlighter.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+// QCodeEditor
+#include <QStyleSyntaxHighlighter> // Required for inheritance
+#include <QHighlightRule>
+#include <QHighlightBlockRule>
+
+// Qt
+#include <QRegularExpression>
+#include <QVector>
+#include <QMap>
+#include <QChar>
+
+class QSyntaxStyle;
+
+/**
+ * @brief Class, that describes C++ code
+ * highlighter.
+ */
+class QCSVHighlighter : public QStyleSyntaxHighlighter
+{
+    Q_OBJECT
+public:
+
+    /**
+     * @brief Constructor.
+     * @param document Pointer to document.
+     */
+    explicit QCSVHighlighter(QTextDocument* document=nullptr);
+
+    QChar delimiter = QChar(',');
+
+protected:
+    void highlightBlock(const QString& text) override;
+
+private:
+    QRegularExpression m_delimiter;
+
+};

--- a/3rdparty/QCodeEditor/src/internal/QCSVHighlighter.cpp
+++ b/3rdparty/QCodeEditor/src/internal/QCSVHighlighter.cpp
@@ -1,0 +1,38 @@
+// QCodeEditor
+#include <QCSVHighlighter>
+#include <QSyntaxStyle>
+#include <QLanguage>
+
+// Qt
+#include <QFile>
+
+
+QCSVHighlighter::QCSVHighlighter(QTextDocument* document) :
+    QStyleSyntaxHighlighter(document),
+    m_delimiter(QRegularExpression(","))
+{
+    Q_INIT_RESOURCE(qcodeeditor_resources);
+
+}
+
+void QCSVHighlighter::highlightBlock(const QString& text)
+{
+    { // Checking for require
+        QRegularExpression m_delimiter;
+        //m_delimiter = QRegularExpression(delimiter);
+        m_delimiter.setPattern(delimiter);
+        auto matchIterator = m_delimiter.globalMatch(text);
+
+        while (matchIterator.hasNext())
+        {
+            auto match = matchIterator.next();
+
+            setFormat(
+                match.capturedStart(),
+                match.capturedLength(),
+                syntaxStyle()->getFormat("VisualWhitespace")
+            );
+
+        }
+    }
+}

--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
@@ -10,6 +10,9 @@
 #include <QPushButton>
 #include "QSyntaxStyle"
 
+
+#include <QStandardItemModel>
+
 const int TIME_INDEX_NOT_DEFINED = -2;
 const int TIME_INDEX_GENERATED = -1;
 
@@ -132,6 +135,14 @@ void DataLoadCSV::parseHeader(QFile& file, std::vector<std::string>& column_name
 {
   file.open(QFile::ReadOnly);
 
+  QStandardItemModel *model = new QStandardItemModel;
+  _ui->tableView->setModel(model);
+  model->clear();
+
+
+  _csvHighlighter.delimiter = _delimiter;
+  _ui->rawText->setHighlighter(&_csvHighlighter);
+
   column_names.clear();
   _ui->listWidgetSeries->clear();
 
@@ -222,10 +233,16 @@ void DataLoadCSV::parseHeader(QFile& file, std::vector<std::string>& column_name
     }
   }
 
+  int x = 0;
   for (const auto& name : column_names)
   {
     _ui->listWidgetSeries->addItem(QString::fromStdString(name));
+
+    QStandardItem *item = new QStandardItem(QString::fromStdString(name));
+    model->setItem(0, x, item);
+    x +=1;
   }
+
 
   int linecount = 1;
   while (!inA.atEnd())
@@ -234,6 +251,15 @@ void DataLoadCSV::parseHeader(QFile& file, std::vector<std::string>& column_name
     if (linecount++ < 100)
     {
       preview_lines += line + "\n";
+
+      // parse the read line into separate pieces(tokens) with "," as the delimiter
+      QStringList lineToken = line.split(_delimiter);
+      // load parsed data to model accordingly
+      for (int j = 0; j < lineToken.size(); j++) {
+          QString value = lineToken.at(j);
+          QStandardItem *item = new QStandardItem(value);
+          model->setItem(linecount-1, j, item);
+      }
     }
     else
     {

--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.h
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.h
@@ -4,6 +4,7 @@
 #include <QtPlugin>
 #include "PlotJuggler/dataloader_base.h"
 #include "ui_dataload_csv.h"
+#include "QCSVHighlighter"
 
 using namespace PJ;
 
@@ -43,6 +44,8 @@ private:
   std::string _default_time_axis;
 
   QChar _delimiter;
+
+  QCSVHighlighter _csvHighlighter;
 
   QDialog* _dialog;
   Ui::DialogCSV* _ui;

--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.ui
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.ui
@@ -176,6 +176,16 @@
           </attribute>
           <layout class="QVBoxLayout" name="verticalLayout_9">
            <item>
+            <widget class="QCheckBox" name="checkBoxSyntaxHilighting">
+             <property name="toolTip">
+              <string>Enable syntax highlighting for csv preview. May be slow for large files with many fields</string>
+             </property>
+             <property name="text">
+              <string>Enable Syntax Highlighting</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QCodeEditor" name="rawText">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -198,6 +208,19 @@
            <string>Table View</string>
           </attribute>
           <layout class="QVBoxLayout" name="verticalLayout_7">
+           <item>
+            <widget class="QCheckBox" name="checkBoxTableView">
+             <property name="toolTip">
+              <string>Enable the table view. May be slow for files with many fields</string>
+             </property>
+             <property name="layoutDirection">
+              <enum>Qt::LeftToRight</enum>
+             </property>
+             <property name="text">
+              <string>Enable Table View</string>
+             </property>
+            </widget>
+           </item>
            <item>
             <widget class="QTableView" name="tableView">
              <property name="sizePolicy">

--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.ui
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.ui
@@ -166,13 +166,68 @@
         </widget>
        </item>
        <item>
-        <widget class="QCodeEditor" name="rawText">
-         <property name="lineWrapMode">
-          <enum>QTextEdit::NoWrap</enum>
+        <widget class="QTabWidget" name="tabWidget">
+         <property name="currentIndex">
+          <number>0</number>
          </property>
-         <property name="readOnly">
-          <bool>true</bool>
-         </property>
+         <widget class="QWidget" name="tab_3">
+          <attribute name="title">
+           <string>Raw Text</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="verticalLayout_9">
+           <item>
+            <widget class="QCodeEditor" name="rawText">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>1</horstretch>
+               <verstretch>1</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="lineWrapMode">
+              <enum>QTextEdit::NoWrap</enum>
+             </property>
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="tab_4">
+          <attribute name="title">
+           <string>Table View</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="verticalLayout_7">
+           <item>
+            <widget class="QTableView" name="tableView">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>1</horstretch>
+               <verstretch>1</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="layoutDirection">
+              <enum>Qt::LeftToRight</enum>
+             </property>
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="showDropIndicator" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="dragDropOverwriteMode">
+              <bool>false</bool>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+             <attribute name="verticalHeaderStretchLastSection">
+              <bool>true</bool>
+             </attribute>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
**CSV Table Preview**
-CSV data loader updated with new table view widget for file preview
-Table view updates when user changes delimiter
-Tab widget added to the CSV data loader to switch between raw text view and table view

https://user-images.githubusercontent.com/2954254/177014679-7dbf53e0-b374-4d22-adb5-0862a1d23c37.mp4

![image](https://user-images.githubusercontent.com/2954254/177014691-d783de24-7ca9-4477-ba97-768c042ba51d.png)


**CSV Highlighting**
-Add QCSVHighlighter to apply syntax highlighting to the selected delimiter in the csv raw text preview
-Highlighting updates when user changes delimiter

![image](https://user-images.githubusercontent.com/2954254/177014721-5bd1d036-c4f6-4d2d-8731-eeca02f03010.png)


