### PR TITLE
Fix start/end time bug in CSV Exporter

### DIFF
--- a/plotjuggler_plugins/StatePublisherCSV/publisher_csv.cpp
+++ b/plotjuggler_plugins/StatePublisherCSV/publisher_csv.cpp
@@ -49,12 +49,16 @@ void StatePublisherCSV::setEnabled(bool enabled)
     //--------------------
     connect(_ui->buttonGetStart, &QPushButton::clicked, this, [this]() {
       _start_time = _previous_time;
+      _ui->checkBoxFirst->setChecked(false);
+      _ui->lineEditStart->setEnabled(true);
       _ui->lineEditStart->setText(QString::number(_previous_time, 'f', 3));
       updateButtonsState();
     });
     //--------------------
     connect(_ui->buttonGetEnd, &QPushButton::clicked, this, [this]() {
       _end_time = _previous_time;
+      _ui->checkBoxLast->setChecked(false);
+      _ui->lineEditEnd->setEnabled(true);
       _ui->lineEditEnd->setText(QString::number(_previous_time, 'f', 3));
       updateButtonsState();
     });


### PR DESCRIPTION
Fix bug with the csv publisher where clicking buttonGetStart or buttonGetEnd buttons would override the checkBoxFirst/checkBoxLast selections

![image](https://user-images.githubusercontent.com/2954254/178119689-dbcf863a-4e9d-4bec-8012-b3c6e7c3376e.png)


~~Fixed by enabling/disabling the buttons when the checkboxes are toggled~~
**Edit:** fixed by unchecking the first/last checkboxes when the button is pressed. This seems less of an annoyance where a user may move the cursor and want to set the time and not notice that the first/last checkbox is checked

