### PR TITLE
Add tooltips to CSV publisher buttons

### DIFF
--- a/plotjuggler_plugins/StatePublisherCSV/publisher_csv_dialog.ui
+++ b/plotjuggler_plugins/StatePublisherCSV/publisher_csv_dialog.ui
@@ -35,7 +35,7 @@ p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Use the vertical time tracker to select a time range.&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Within this timerange you can either compute the statistics (min, max, average values) or export all the data points in a CSV file&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Within this time range you can either compute the statistics (min, max, average values) or export all the data points in a CSV file&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>
@@ -80,6 +80,9 @@ p, li { white-space: pre-wrap; }
          <width>24</width>
          <height>24</height>
         </size>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set start of time range to current time tracker position&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
         <string>+</string>
@@ -132,6 +135,9 @@ p, li { white-space: pre-wrap; }
          <width>24</width>
          <height>24</height>
         </size>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set end of time range to current time tracker position&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
         <string>+</string>


### PR DESCRIPTION
-Add tooltips to the buttons that set the start/end time based on vertical time tracker position
-add missing space in text ("timerange" to "time range")

![image](https://user-images.githubusercontent.com/2954254/178120800-2729f79c-95e8-4940-a0f8-a7001d8f9a91.png)
(added space to "timerange" not shown in image above)