### PR TITLE
Set buttonBackground icon in .ui file

### DIFF
--- a/plotjuggler_app/plot_docker_toolbar.cpp
+++ b/plotjuggler_app/plot_docker_toolbar.cpp
@@ -24,7 +24,6 @@ DockToolbar::DockToolbar(ads::CDockWidget* parent)
   ui->buttonSplitVertical->setVisible(false);
   ui->buttonBackground->setVisible(false);
 
-  ui->buttonBackground->setIcon( LoadSvg("://resources/svg/color_background.svg") );
 
   setMouseTracking(true);
   ui->widgetButtons->setMouseTracking(true);

--- a/plotjuggler_app/plot_docker_toolbar.ui
+++ b/plotjuggler_app/plot_docker_toolbar.ui
@@ -130,6 +130,10 @@
         <property name="text">
          <string/>
         </property>
+        <property name="icon">
+         <iconset>
+         <normaloff>:/resources/svg/color_background.svg</normaloff>:/resources/svg/color_background.svg</iconset>
+        </property>
         <property name="checkable">
          <bool>false</bool>
         </property>


### PR DESCRIPTION
Set the icon for buttonBackground in the plot_docker_toolbar.ui file for consistency with the other buttons
-remove line setting the icon manually in the .cpp file for same reason

This gives a more representative view in Qt Designer:
![image](https://user-images.githubusercontent.com/2954254/179422694-f6850d61-f22f-4a61-a0fa-df8688dda15a.png)

