### PR TITLE
Statistics dialog improvements and bug fixes

### DIFF
--- a/plotjuggler_app/plot_docker.cpp
+++ b/plotjuggler_app/plot_docker.cpp
@@ -306,6 +306,7 @@ DockWidget::DockWidget(PlotDataMapRef& datamap, QWidget* parent)
 
   connect(_plot_widget, &PlotWidget::splitVertical, this, &DockWidget::splitVertical);
 
+  connect(_toolbar, &DockToolbar::titleChanged,_plot_widget,[=](QString title){_plot_widget->setStatisticsTitle(title);});
 
   auto FullscreenAction = [=]() {
     PlotDocker* parent_docker = static_cast<PlotDocker*>(dockManager());

--- a/plotjuggler_app/plot_docker_toolbar.cpp
+++ b/plotjuggler_app/plot_docker_toolbar.cpp
@@ -103,6 +103,7 @@ bool DockToolbar::eventFilter(QObject* object, QEvent* event)
     if (ok)
     {
       ui->label->setText(newName);
+      emit titleChanged(newName);
     }
     return true;
   }

--- a/plotjuggler_app/plot_docker_toolbar.h
+++ b/plotjuggler_app/plot_docker_toolbar.h
@@ -78,6 +78,7 @@ private:
 
 signals:
   void backgroundColorRequest(QString name);
+  void titleChanged(QString title);
 private slots:
   void on_buttonBackground_clicked();
 };

--- a/plotjuggler_app/plotwidget.cpp
+++ b/plotjuggler_app/plotwidget.cpp
@@ -951,6 +951,7 @@ void PlotWidget::setZoomRectangle(QRectF rect, bool emit_signal)
       emit rectChanged(this, rect);
     }
   }
+  updateStatistics();
 }
 
 void PlotWidget::reloadPlotData()
@@ -1121,11 +1122,18 @@ void PlotWidget::updateCurves(bool reset_older_data)
   }
   updateMaximumZoomArea();
 
-  if(_statistics_dialog)
-  {
-    auto rect = canvasBoundingRect();
-    _statistics_dialog->update( {rect.left(), rect.right()} );
-  }
+  updateStatistics(true);
+}
+
+void PlotWidget::updateStatistics(bool forceUpdate){
+    if(_statistics_dialog)
+    {
+      if(_statistics_dialog->calcVisibleRange() || forceUpdate){
+        auto rect = canvasBoundingRect();
+        _statistics_dialog->update( {rect.left(), rect.right()} );
+      }
+    }
+
 }
 
 void PlotWidget::on_changeCurveColor(const QString& curve_name, QColor new_color)
@@ -1250,7 +1258,7 @@ void PlotWidget::onShowDataStatistics()
   connect(this, &PlotWidget::rectChanged, _statistics_dialog,
           [=](PlotWidget*, QRectF rect)
           {
-            _statistics_dialog->update( {rect.left(), rect.right()} );
+              _statistics_dialog->update( {rect.left(), rect.right()} );
           });
 
   connect(_statistics_dialog, &QDialog::rejected,
@@ -1283,11 +1291,7 @@ void PlotWidget::zoomOut(bool emit_signal)
   setZoomRectangle(maxZoomRect(), emit_signal);
   replot();
 
-  if(_statistics_dialog)
-  {
-    auto rect = canvasBoundingRect();
-    _statistics_dialog->update( {rect.left(), rect.right()} );
-  }
+  updateStatistics();
 }
 
 void PlotWidget::on_zoomOutHorizontal_triggered(bool emit_signal)

--- a/plotjuggler_app/plotwidget.cpp
+++ b/plotjuggler_app/plotwidget.cpp
@@ -1218,11 +1218,22 @@ void PlotWidget::onBackgroundColorRequest(QString name)
   }
 }
 
+void PlotWidget::setStatisticsTitle(QString title){
+    _statistics_window_title = title;
+
+    if(_statistics_dialog)
+    {
+      _statistics_dialog->setTitle(_statistics_window_title);
+    }
+}
+
 void PlotWidget::onShowDataStatistics()
 {
   if (!_statistics_dialog) {
     _statistics_dialog = new StatisticsDialog(this);
   }
+
+  setStatisticsTitle(_statistics_window_title);
 
   auto rect = canvasBoundingRect();
   _statistics_dialog->update( {rect.left(), rect.right()} );

--- a/plotjuggler_app/plotwidget.cpp
+++ b/plotjuggler_app/plotwidget.cpp
@@ -1282,6 +1282,12 @@ void PlotWidget::zoomOut(bool emit_signal)
   updateMaximumZoomArea();
   setZoomRectangle(maxZoomRect(), emit_signal);
   replot();
+
+  if(_statistics_dialog)
+  {
+    auto rect = canvasBoundingRect();
+    _statistics_dialog->update( {rect.left(), rect.right()} );
+  }
 }
 
 void PlotWidget::on_zoomOutHorizontal_triggered(bool emit_signal)

--- a/plotjuggler_app/plotwidget.h
+++ b/plotjuggler_app/plotwidget.h
@@ -81,6 +81,8 @@ public:
 
   void setStatisticsTitle(QString title);
 
+  void updateStatistics(bool forceUpdate = false);
+
 protected:
   PlotDataMapRef& _mapped_data;
 

--- a/plotjuggler_app/plotwidget.h
+++ b/plotjuggler_app/plotwidget.h
@@ -79,6 +79,8 @@ public:
 
   bool isZoomLinkEnabled() const;
 
+  void setStatisticsTitle(QString title);
+
 protected:
   PlotDataMapRef& _mapped_data;
 
@@ -179,6 +181,8 @@ private:
 
   CurveTracker* _tracker;
   QwtPlotGrid* _grid;
+
+  QString _statistics_window_title = "";
 
   std::unique_ptr<BackgroundColorItem> _background_item;
 

--- a/plotjuggler_app/resources/stylesheet_dark.qss
+++ b/plotjuggler_app/resources/stylesheet_dark.qss
@@ -652,6 +652,29 @@ QHeaderView::section {
     border: 1px solid #6c6c6c;
 }
 
+QHeaderView::text{
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
+QHeaderView::up-arrow { 
+    subcontrol-position: center right;
+    image: url(":/style_${theme}/arrow_up.png");
+    height: 12px;
+    width: 12px;
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
+QHeaderView::down-arrow { 
+    subcontrol-position: center right;
+    image: url(":/style_${theme}/arrow_down.png");
+    height: 12px;
+    width: 12px;
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
 QTreeView:branch {
     background-color: transparent;
 }

--- a/plotjuggler_app/resources/stylesheet_light.qss
+++ b/plotjuggler_app/resources/stylesheet_light.qss
@@ -652,6 +652,29 @@ QHeaderView::section {
     border: 1px solid #6c6c6c;
 }
 
+QHeaderView::text{
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
+QHeaderView::up-arrow { 
+    subcontrol-position: center right;
+    image: url(":/style_${theme}/arrow_up.png");
+    height: 12px;
+    width: 12px;
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
+QHeaderView::down-arrow { 
+    subcontrol-position: center right;
+    image: url(":/style_${theme}/arrow_down.png");
+    height: 12px;
+    width: 12px;
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
 QTreeView:branch {
     background-color: transparent;
 }

--- a/plotjuggler_app/statistics_dialog.cpp
+++ b/plotjuggler_app/statistics_dialog.cpp
@@ -16,7 +16,7 @@ StatisticsDialog::StatisticsDialog(PlotWidget *parent) :
 {
   ui->setupUi(this);
 
-  setWindowTitle(QString("Statistics: %1").arg(_parent->windowTitle()));
+  setWindowTitle(QString("Statistics | %1").arg(_parent->windowTitle()));
   setWindowFlag(Qt::Tool);
 
   ui->tableWidget->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
@@ -91,6 +91,13 @@ void StatisticsDialog::update(PJ::Range range)
     }
     row++;
   }
+}
+
+void StatisticsDialog::setTitle(QString title){
+    if(title == "..."){
+        title = "";
+    }
+    setWindowTitle(QString("Statistics | %1").arg(title));
 }
 
 void StatisticsDialog::closeEvent(QCloseEvent *event)

--- a/plotjuggler_app/statistics_dialog.cpp
+++ b/plotjuggler_app/statistics_dialog.cpp
@@ -17,7 +17,7 @@ StatisticsDialog::StatisticsDialog(PlotWidget *parent) :
   ui->setupUi(this);
 
   setWindowTitle(QString("Statistics: %1").arg(_parent->windowTitle()));
-  setWindowFlag(Qt::WindowStaysOnTopHint);
+  setWindowFlag(Qt::Tool);
 
   ui->tableWidget->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
 }

--- a/plotjuggler_app/statistics_dialog.cpp
+++ b/plotjuggler_app/statistics_dialog.cpp
@@ -33,6 +33,10 @@ StatisticsDialog::~StatisticsDialog()
   delete ui;
 }
 
+bool StatisticsDialog::calcVisibleRange(){
+    return (ui->rangeComboBox->currentIndex() == 0);
+}
+
 void StatisticsDialog::update(PJ::Range range)
 {
   std::map<QString, Statistics> statistics;
@@ -47,7 +51,7 @@ void StatisticsDialog::update(PJ::Range range)
     for( size_t i=0; i<ts->size(); i++)
     {
       const auto p = ts->sample(i);
-      if(ui->rangeComboBox->currentIndex() == 0){
+      if(calcVisibleRange()){
         if( p.x() <  range.min )
         {
           continue;

--- a/plotjuggler_app/statistics_dialog.cpp
+++ b/plotjuggler_app/statistics_dialog.cpp
@@ -20,6 +20,12 @@ StatisticsDialog::StatisticsDialog(PlotWidget *parent) :
   setWindowFlag(Qt::Tool);
 
   ui->tableWidget->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+
+  connect(ui->rangeComboBox,qOverload<int>(&QComboBox::currentIndexChanged),this,[this](){
+                            auto rect = _parent->canvasBoundingRect();
+                            update({rect.left(), rect.right()});
+                            });
+
 }
 
 StatisticsDialog::~StatisticsDialog()
@@ -41,13 +47,15 @@ void StatisticsDialog::update(PJ::Range range)
     for( size_t i=0; i<ts->size(); i++)
     {
       const auto p = ts->sample(i);
-      if( p.x() <  range.min )
-      {
-        continue;
-      }
-      if( p.x() >  range.max )
-      {
-        break;
+      if(ui->rangeComboBox->currentIndex() == 0){
+        if( p.x() <  range.min )
+        {
+          continue;
+        }
+        if( p.x() >  range.max )
+        {
+          break;
+        }
       }
       stat.count++;
       if( first )

--- a/plotjuggler_app/statistics_dialog.h
+++ b/plotjuggler_app/statistics_dialog.h
@@ -36,6 +36,8 @@ public:
 
   void closeEvent(QCloseEvent *event);
 
+  void setTitle(QString title);
+
 private:
   Ui::statistics_dialog *ui;
 

--- a/plotjuggler_app/statistics_dialog.h
+++ b/plotjuggler_app/statistics_dialog.h
@@ -38,6 +38,8 @@ public:
 
   void setTitle(QString title);
 
+  bool calcVisibleRange();
+
 private:
   Ui::statistics_dialog *ui;
 

--- a/plotjuggler_app/statistics_dialog.ui
+++ b/plotjuggler_app/statistics_dialog.ui
@@ -19,6 +19,9 @@
      <property name="selectionMode">
       <enum>QAbstractItemView::NoSelection</enum>
      </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
      <attribute name="verticalHeaderVisible">
       <bool>false</bool>
      </attribute>

--- a/plotjuggler_app/statistics_dialog.ui
+++ b/plotjuggler_app/statistics_dialog.ui
@@ -20,7 +20,7 @@
       <enum>QAbstractItemView::NoSelection</enum>
      </property>
      <property name="sortingEnabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <attribute name="verticalHeaderVisible">
       <bool>false</bool>

--- a/plotjuggler_app/statistics_dialog.ui
+++ b/plotjuggler_app/statistics_dialog.ui
@@ -53,14 +53,69 @@
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="font">
+        <font>
+         <family>Segoe UI</family>
+         <pointsize>9</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>Calculate statistics from: </string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="rangeComboBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>125</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Segoe UI</family>
+         <pointsize>9</pointsize>
+        </font>
+       </property>
+       <item>
+        <property name="text">
+         <string>Visible Range</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Full Range</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="font">
+        <font>
+         <family>Segoe UI</family>
+         <pointsize>9</pointsize>
+        </font>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Close</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Changes and bug fixes to the statistics dialog window

Improvements:
- Statistics can now be calculated from the visible range or by the full data range (previously only visible range)
![image](https://user-images.githubusercontent.com/2954254/180676582-1be21e5b-3ddb-4262-8ca0-d1a3aa1b8bab.png)

- Statistics window title now includes the title from the plot
- Made the dialog window stay on top of the PlotJuggler window but not on top of other programs. The statistics dialogs will minimize/restore with the main PJ window. Previously the statistics dialog windows would stay on top of all windows

- ~~Made the table sortable by column (click on the header item to sort by that column)~~  (**Edit:** disabled this as there are bugs. earlier commit kept as it set the styling for the arrows)


Bug fixes:
- Fix bug where statistics would only get updated for the plot with the mouse over it when zooming while plot zooms were linked
- Fix bug where the statistics weren't updated when the zoom reset button was pressed
- Fix bug where series weren't removed from the statistics dialog right away after a curve was removed from the plot