### PR TITLE
Add options for enabling/disabling autozoom in preferences

### DIFF
--- a/plotjuggler_app/plotwidget.h
+++ b/plotjuggler_app/plotwidget.h
@@ -48,7 +48,7 @@ public:
 
   QDomElement xmlSaveState(QDomDocument& doc) const;
 
-  bool xmlLoadState(QDomElement& element);
+  bool xmlLoadState(QDomElement& element, bool autozoom = true);
 
   Range getVisualizationRangeY(Range range_X) const override;
 

--- a/plotjuggler_app/plotwidget_transforms.cpp
+++ b/plotjuggler_app/plotwidget_transforms.cpp
@@ -243,10 +243,16 @@ void DialogTransformEditor::on_pushButtonSave_clicked()
 {
   on_lineEditAlias_editingFinished();
 
+  QSettings settings;
+  bool autozoom_filter_applied = settings.value("Preferences::autozoom_filter_applied",true).toBool();
   QDomDocument doc;
   auto elem = _plotwidget->xmlSaveState(doc);
-  _plotwidget_origin->xmlLoadState(elem);
-  _plotwidget_origin->zoomOut(false);
+  _plotwidget_origin->xmlLoadState(elem,autozoom_filter_applied);
+
+  if(autozoom_filter_applied)
+  {
+    _plotwidget_origin->zoomOut(false);
+  }
 
   this->accept();
 }

--- a/plotjuggler_app/preferences_dialog.cpp
+++ b/plotjuggler_app/preferences_dialog.cpp
@@ -43,6 +43,15 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
   bool use_opengl = settings.value("Preferences::use_opengl", true).toBool();
   ui->checkBoxOpenGL->setChecked(use_opengl);
 
+  bool autozoom_visibility = settings.value("Preferences::autozoom_visibility",true).toBool();
+  ui->checkBoxAutoZoomVisibility->setChecked(autozoom_visibility);
+
+  bool autozoom_curve_added = settings.value("Preferences::autozoom_curve_added",true).toBool();
+  ui->checkBoxAutoZoomAdded->setChecked(autozoom_curve_added);
+
+  bool autozoom_filter_applied = settings.value("Preferences::autozoom_filter_applied",true).toBool();
+  ui->checkBoxAutoZoomFilter->setChecked(autozoom_filter_applied);
+
   //---------------
   auto custom_plugin_folders =
       settings.value("Preferences::plugin_folders", true).toStringList();
@@ -82,6 +91,9 @@ void PreferencesDialog::on_buttonBox_accepted()
                     ui->radioLocalColorIndex->isChecked());
   settings.setValue("Preferences::use_separator", ui->checkBoxSeparator->isChecked());
   settings.setValue("Preferences::use_opengl", ui->checkBoxOpenGL->isChecked());
+  settings.setValue("Preferences::autozoom_visibility", ui->checkBoxAutoZoomVisibility->isChecked());
+  settings.setValue("Preferences::autozoom_curve_added", ui->checkBoxAutoZoomAdded->isChecked());
+  settings.setValue("Preferences::autozoom_filter_applied", ui->checkBoxAutoZoomFilter->isChecked());
 
   QStringList plugin_folders;
   for (int row = 0; row < ui->listWidgetCustom->count(); row++)

--- a/plotjuggler_app/preferences_dialog.ui
+++ b/plotjuggler_app/preferences_dialog.ui
@@ -26,7 +26,7 @@
       <enum>Qt::NoFocus</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -251,6 +251,90 @@
           </widget>
          </item>
         </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="behaviorTab">
+      <attribute name="title">
+       <string>Behavior</string>
+      </attribute>
+      <layout class="QFormLayout" name="formLayout_2">
+       <item row="1" column="1">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="1">
+        <widget class="QGroupBox" name="groupBoxAutoZoom">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>40</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Autozoom</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <layout class="QFormLayout" name="formLayout_4">
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="checkBoxAutoZoomVisibility">
+            <property name="text">
+             <string>Curve visibility toggled</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="checkBoxAutoZoomFilter">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>Filters applied to curves</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelAutoZoom">
+            <property name="text">
+             <string>Reset plot zoom after:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="checkBoxAutoZoomAdded">
+            <property name="text">
+             <string>Curve added to plot</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/plotjuggler_app/resources/stylesheet_dark.qss
+++ b/plotjuggler_app/resources/stylesheet_dark.qss
@@ -469,6 +469,16 @@ QCheckBox::indicator:checked:pressed {
 
 /* QGroupBox -------------------------------------------------------------- */
 
+QGroupBox{
+    margin-top:10px;
+}
+
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding-bottom: 10px;
+}
+
 QGroupBox::indicator {
     margin-left: 4px;
     width: 16px;

--- a/plotjuggler_app/resources/stylesheet_light.qss
+++ b/plotjuggler_app/resources/stylesheet_light.qss
@@ -469,6 +469,16 @@ QCheckBox::indicator:checked:pressed {
 
 /* QGroupBox -------------------------------------------------------------- */
 
+QGroupBox{
+    margin-top:10px;
+}
+
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding-bottom: 10px;
+}
+
 QGroupBox::indicator {
     margin-left: 4px;
     width: 16px;

--- a/plotjuggler_base/src/plotwidget_base.cpp
+++ b/plotjuggler_base/src/plotwidget_base.cpp
@@ -594,7 +594,13 @@ bool PlotWidgetBase::eventFilter(QObject* obj, QEvent* event)
               {
                 it.curve->setVisible(!it.curve->isVisible());
                 //_tracker->redraw();
-                resetZoom();
+
+                QSettings settings;
+                bool autozoom_visibility = settings.value("Preferences::autozoom_visibility",true).toBool();
+                if(autozoom_visibility)
+                {
+                    resetZoom();
+                }
                 replot();
                 return true;
               }


### PR DESCRIPTION
New tab added to preferences for configuring autozoom settings:
![image](https://user-images.githubusercontent.com/2954254/180853236-84180875-293c-43c6-8e35-963dcca66069.png)

Defaults are enabled which preserve the original PlotJuggler behavior

Addresses https://github.com/facontidavide/PlotJuggler/issues/654