### PR TITLE
Fix/snap rosbag

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -17,6 +17,9 @@ jobs:
       snap-file: ${{ steps.build-snap.outputs.snap }}
     steps:
     - uses: actions/checkout@v2
+      with:
+        # full history for latest tag name
+        fetch-depth: 0
     - uses: snapcore/action-build@v1
       id: build-snap
 

--- a/snap/gui/PlotJuggler-ros2.desktop
+++ b/snap/gui/PlotJuggler-ros2.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=PlotJuggler-ROS2
+Exec=plotjuggler.plotjuggler-ros2
+Icon=${SNAP}/meta/gui/plotjuggler.svg
+Comment=Visualize timeseries like a pro
+Terminal=false
+Categories=Development;
+Name[en_US]=PlotJuggler-ROS2

--- a/snap/gui/PlotJuggler-ros2.desktop
+++ b/snap/gui/PlotJuggler-ros2.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Type=Application
-Name=PlotJuggler-ROS2
-Exec=plotjuggler.plotjuggler-ros2
-Icon=${SNAP}/meta/gui/plotjuggler.svg
-Comment=Visualize timeseries like a pro
-Terminal=false
-Categories=Development;
-Name[en_US]=PlotJuggler-ROS2

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+
+ROS_PLUGIN_VERSION="$(snapctl get ros-plugin-version)"
+case "$ROS_PLUGIN_VERSION" in
+    1) ;;
+    2) ;;
+    *)
+        echo "'$ROS_PLUGIN_VERSION' is not a supported ros-plugin-version. Setting 1 by default" >&2
+	snapctl set ros-plugin-version=1
+        ;;
+esac
+

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+# Set default ros-plugin-version to ROS
+snapctl set ros-plugin-version=1
+

--- a/snap/local/launcher-plotjuggler
+++ b/snap/local/launcher-plotjuggler
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+ROS_PLUGIN_VERSION="$(snapctl get ros-plugin-version)"
+
+if [ "$ROS_PLUGIN_VERSION" == "1" ]; then
+    echo "Running plotjuggler with ROS plugin"
+    exec launcher-plotjuggler-ros $@
+elif [ "$ROS_PLUGIN_VERSION" == "2" ]; then
+    echo "Running plotjuggler with ROS 2 plugin"
+    exec launcher-plotjuggler-ros2 $@
+else
+    echo "ros-plugin-version is $ROS_PLUGIN_VERSION which is not valid. Must be \"1\" or \"2\""
+    echo "Run: snap set plotjuggler ros-plugin-version=\"1\""
+fi
+

--- a/snap/local/launcher-plotjuggler-ros
+++ b/snap/local/launcher-plotjuggler-ros
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+export LD_LIBRARY_PATH=$SNAP/opt/ros/noetic/lib:$SNAP/usr/local/lib:$LD_LIBRARY_PATH
+# Paths to ROS plugins
+export PLUGIN_FOLDERS=$SNAP/opt/ros/noetic/lib/plotjuggler_ros/
+# Set ROS home to a writable path for logging
+export ROS_HOME=${SNAP_USER_DATA}/.ros
+# rospack plugins looks for plugin xml export file on ROS_PACKAGE_PATH
+export ROS_PACKAGE_PATH=${SNAP}/opt/ros/noetic/share
+# pluginlib relies on catkin_find to search for plugin libs.
+# The later search on CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${SNAP}/opt/ros/noetic
+export ROSCONSOLE_CONFIG_FILE=${SNAP_USER_DATA}/rosconsole.config
+
+${SNAP}/usr/local/bin/plotjuggler --plugin_folders $PLUGIN_FOLDERS $@
+

--- a/snap/local/launcher-plotjuggler-ros2
+++ b/snap/local/launcher-plotjuggler-ros2
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export LD_LIBRARY_PATH=$SNAP/opt/ros/foxy/lib:$SNAP/opt/ros/snap/lib:$SNAP/opt/ros/foxy/lib/x86_64-linux-gnu:$SNAP/opt/ros/foxy/opt/yaml_cpp_vendor/lib:$SNAP/usr/local/lib:$LD_LIBRARY_PATH
+# Paths to ROS 2 plugins
+export PLUGIN_FOLDERS=$SNAP/opt/ros/snap/lib/plotjuggler_ros
+export AMENT_PREFIX_PATH=$SNAP/opt/ros/foxy
+# Disable FastDDS shared-memory
+export FASTRTPS_DEFAULT_PROFILES_FILE=${SNAP}/usr/share/fastdds_no_shared_memory.xml
+
+${SNAP}/usr/local/bin/plotjuggler --plugin_folders $PLUGIN_FOLDERS $@
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,22 +53,11 @@ apps:
     extensions: [kde-neon]
 
 parts:
-  # we need to build zmq so we have the ZeroMQConfig.cmake
-  zmq:
-    plugin: cmake
-    source: https://github.com/zeromq/libzmq.git
-    source-tag: v4.3.4
-    cmake-parameters:
-      - -DCMAKE_BUILD_TYPE=Release
-
   plotjuggler:
-    after: [zmq]
     plugin: cmake
     source: .
     cmake-parameters:
       - -DCMAKE_BUILD_TYPE=Release
-      # point to previous zmq part
-      - -DZeroMQ_DIR:PATH=$SNAPCRAFT_STAGE/usr/local/lib/cmake/ZeroMQ
     build-packages:
       - distro-info-data
       - libpulse0
@@ -78,10 +67,12 @@ parts:
       - libprotoc-dev
       - libgl-dev
       - libmosquitto-dev
+      - libzmq3-dev
     stage-packages:
       - libdw1
       - libmosquitto1
       - libprotobuf17
+      - libzmq5
     override-pull: |
         snapcraftctl pull
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,6 +5,22 @@ description: |
   QT5 based application to display time series in plots,
   using an intuitive "drag and drop" interface.
 
+  The snap comes with ROS and ROS 2 plugins.
+  You can launch them respectively with
+
+    $ plotjuggler.ros
+    $ plotjuggler.ros2
+
+  For convenience a third command is provided,
+
+    $ plotjuggler
+
+  launching PlotJuggler with ROS plugins by default.
+
+  You can change to ROS 2 plugin with
+
+    $ sudo snap set plotjuggler ros-plugin-version=2
+
 issues: https://github.com/facontidavide/plotjuggler/issues
 source-code: https://github.com/facontidavide/plotjuggler
 license: MPL-2.0
@@ -33,31 +49,17 @@ package-repositories:
 
 apps:
   plotjuggler:
-    command: usr/local/bin/plotjuggler --plugin_folders $PLUGIN_FOLDERS
-    environment:
-      LD_LIBRARY_PATH: $SNAP/opt/ros/noetic/lib:$SNAP/usr/local/lib
-      # Paths to ROS plugins
-      PLUGIN_FOLDERS: $SNAP/opt/ros/noetic/lib/plotjuggler_ros/
-      # Set ROS home to a writable path for logging
-      ROS_HOME: ${SNAP_USER_DATA}/.ros
-      # rospack plugins looks for plugin xml export file on ROS_PACKAGE_PATH
-      ROS_PACKAGE_PATH: ${SNAP}/opt/ros/noetic/share
-      # pluginlib relies on catkin_find to search for plugin libs.
-      # The later search on CMAKE_PREFIX_PATH
-      CMAKE_PREFIX_PATH: ${SNAP}/opt/ros/noetic
-      ROSCONSOLE_CONFIG_FILE: ${SNAP_USER_DATA}/rosconsole.config
-    plugs: [network, network-bind, home]
+    command: usr/bin/launcher-plotjuggler
+    plugs: [network, network-bind, home, removable-media]
     extensions: [kde-neon]
 
-  plotjuggler-ros2:
-    command: usr/local/bin/plotjuggler --plugin_folders $PLUGIN_FOLDERS
-    environment:
-      LD_LIBRARY_PATH: $SNAP/opt/ros/foxy/lib:$SNAP/opt/ros/snap/lib:$SNAP/opt/ros/foxy/lib/x86_64-linux-gnu:$SNAP/opt/ros/foxy/opt/yaml_cpp_vendor/lib:$SNAP/usr/local/lib
-      # Paths to ROS 2 plugins
-      PLUGIN_FOLDERS: $SNAP/opt/ros/snap/lib/plotjuggler_ros
-      AMENT_PREFIX_PATH: $SNAP/opt/ros/foxy
-      # Disable FastDDS shared-memory
-      FASTRTPS_DEFAULT_PROFILES_FILE: ${SNAP}/usr/share/fastdds_no_shared_memory.xml
+  ros:
+    command: usr/bin/launcher-plotjuggler-ros
+    plugs: [network, network-bind, home, removable-media]
+    extensions: [kde-neon]
+
+  ros2:
+    command: usr/bin/launcher-plotjuggler-ros2
     plugs: [network, network-bind, home, removable-media]
     extensions: [kde-neon]
 
@@ -90,6 +92,7 @@ parts:
         snapcraftctl set-version "$version"
         snapcraftctl set-grade "$grade"
 
+        # Necessary to bypass XDG desktop portals because ROS 2 bags metadata.yaml are refering db3 files relatively
         sed -i '/QApplication app(new_argc, new_argv.data());/a QCoreApplication::setAttribute(Qt::AA_DontUseNativeDialogs);' plotjuggler_app/main.cpp
 
   plotjuggler-ros:
@@ -305,4 +308,5 @@ parts:
     source: snap/local/
     organize:
       'fastdds_no_shared_memory.xml': usr/share/
+      'launcher-plotjuggler*': usr/bin/
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,6 +41,14 @@ apps:
       AMENT_PREFIX_PATH: $SNAP/opt/ros/foxy
       # Disable FastDDS shared-memory
       FASTRTPS_DEFAULT_PROFILES_FILE: ${SNAP}/usr/share/fastdds_no_shared_memory.xml
+      # Set ROS home to a writable path for logging
+      ROS_HOME: ${SNAP_USER_DATA}/.ros
+      # rospack plugins looks for plugin xml export file on ROS_PACKAGE_PATH
+      ROS_PACKAGE_PATH: ${SNAP}/opt/ros/noetic/share
+      # pluginlib relies on catkin_find to search for plugin libs.
+      # The later search on CMAKE_PREFIX_PATH
+      CMAKE_PREFIX_PATH: ${SNAP}/opt/ros/noetic
+      ROSCONSOLE_CONFIG_FILE: ${SNAP_USER_DATA}/rosconsole.config
     plugs: [network, network-bind, home]
     extensions: [kde-neon]
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,12 +35,9 @@ apps:
   plotjuggler:
     command: usr/local/bin/plotjuggler --plugin_folders $PLUGIN_FOLDERS
     environment:
-      LD_LIBRARY_PATH: $SNAP/opt/ros/noetic/lib:$SNAP/opt/ros/foxy/lib:$SNAP/opt/ros/snap/lib:$SNAP/opt/ros/foxy/lib/x86_64-linux-gnu:$SNAP/opt/ros/foxy/opt/yaml_cpp_vendor/lib:$SNAP/usr/local/lib
-      # Paths to ROS (2) plugins
-      PLUGIN_FOLDERS: $SNAP/opt/ros/noetic/lib/plotjuggler_ros/;$SNAP/opt/ros/snap/lib/plotjuggler_ros
-      AMENT_PREFIX_PATH: $SNAP/opt/ros/foxy
-      # Disable FastDDS shared-memory
-      FASTRTPS_DEFAULT_PROFILES_FILE: ${SNAP}/usr/share/fastdds_no_shared_memory.xml
+      LD_LIBRARY_PATH: $SNAP/opt/ros/noetic/lib:$SNAP/usr/local/lib
+      # Paths to ROS plugins
+      PLUGIN_FOLDERS: $SNAP/opt/ros/noetic/lib/plotjuggler_ros/
       # Set ROS home to a writable path for logging
       ROS_HOME: ${SNAP_USER_DATA}/.ros
       # rospack plugins looks for plugin xml export file on ROS_PACKAGE_PATH
@@ -50,6 +47,18 @@ apps:
       CMAKE_PREFIX_PATH: ${SNAP}/opt/ros/noetic
       ROSCONSOLE_CONFIG_FILE: ${SNAP_USER_DATA}/rosconsole.config
     plugs: [network, network-bind, home]
+    extensions: [kde-neon]
+
+  plotjuggler-ros2:
+    command: usr/local/bin/plotjuggler --plugin_folders $PLUGIN_FOLDERS
+    environment:
+      LD_LIBRARY_PATH: $SNAP/opt/ros/foxy/lib:$SNAP/opt/ros/snap/lib:$SNAP/opt/ros/foxy/lib/x86_64-linux-gnu:$SNAP/opt/ros/foxy/opt/yaml_cpp_vendor/lib:$SNAP/usr/local/lib
+      # Paths to ROS 2 plugins
+      PLUGIN_FOLDERS: $SNAP/opt/ros/snap/lib/plotjuggler_ros
+      AMENT_PREFIX_PATH: $SNAP/opt/ros/foxy
+      # Disable FastDDS shared-memory
+      FASTRTPS_DEFAULT_PROFILES_FILE: ${SNAP}/usr/share/fastdds_no_shared_memory.xml
+    plugs: [network, network-bind, home, removable-media]
     extensions: [kde-neon]
 
 parts:
@@ -80,6 +89,8 @@ parts:
         [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable
         snapcraftctl set-version "$version"
         snapcraftctl set-grade "$grade"
+
+        sed -i '/QApplication app(new_argc, new_argv.data());/a QCoreApplication::setAttribute(Qt::AA_DontUseNativeDialogs);' plotjuggler_app/main.cpp
 
   plotjuggler-ros:
     after: [plotjuggler]
@@ -142,6 +153,7 @@ parts:
       - git
       - python3-vcstool
       - ros-foxy-ros-core
+      - patchelf
     stage-packages:
       # ROS 2 plugin need to source messages to plot them
       # No custom message is going to be support for now


### PR DESCRIPTION
This PR slightly alters the snap, resulting in the following user experience,
Install the snap,

`sudo snap install plutjuggler`

Launch the snap with ROS support,

`plotjuggler`

This is also achieved hitting the desktop launcher. It is on par with the behaviour of the current ‘stable’ snap. So far, no disruption for users.

The actual change is the introduction of two new commands,

`plotjuggler.ros`
`plotjuggler.ros2`

Which respectively (explicitly) launch PJ with ROS or ROS 2 support.
Finally, users are able to change the behaviour of the ‘plotjuggler’ command as follows,

`sudo snap set plotjuggler ros-plugin-version=2`

So that the command now launches PJ with ROS 2 support instead of ROS.

This change is the result of fixing the issue with loading rosbags.

Being able to load rosbag brought up two main problems:
- Due to libraries that have the same name (`libclass_loader.so`) both ROS/ROS 2 plugins cannot be loaded at the same time
- ROS 2 bag `metadata.yaml` are referring to the `.db3` file relatively. In snaps GUI with Qt, files loaded with `QFileDialog` are fuse-mounted to `/run/user/<uid>/doc/<hash>/` in order to give your snapped application access to it (from the[ xdg-desktop-portals](https://snapcraft.io/docs/xdg-desktop-portals)). The `.db3` file is then searched within `/run/user/<uid>/doc/<hash>/` which only contains the `metadata.yaml`.

This PR also includes:

- GitHub workflow action is now checking out the full history of the repository since we need the latest tag for the snap versioning.
- ZMQ build was removed since now ZMQ can be found from the deb package


This PR does not disrupt any existing install while bringing ROS 2 support along with an explicit command.

Feel free to ask any questions regarding the snap or its usage.

