### PR TITLE
Fix plot widget drag and drop bug (Issue #716)

### DIFF
--- a/plotjuggler_app/plotwidget.cpp
+++ b/plotjuggler_app/plotwidget.cpp
@@ -95,6 +95,7 @@ PlotWidget::PlotWidget(PlotDataMapRef& datamap, QWidget* parent)
   connect(this, &PlotWidgetBase::viewResized, this, &PlotWidget::on_externallyResized);
 
   connect(this, &PlotWidgetBase::dragEnterSignal, this, &PlotWidget::onDragEnterEvent);
+  connect(this, &PlotWidgetBase::dragLeaveSignal, this, &PlotWidget::onDragLeaveEvent);
 
   connect(this, &PlotWidgetBase::dropSignal, this, &PlotWidget::onDropEvent);
 
@@ -520,6 +521,11 @@ void PlotWidget::onDragEnterEvent(QDragEnterEvent* event)
       event->acceptProposedAction();
     }
   }
+}
+
+void PlotWidget::onDragLeaveEvent(QDragLeaveEvent* event){
+    _dragging.mode = DragInfo::NONE;
+    _dragging.curves.clear();
 }
 
 void PlotWidget::onDropEvent(QDropEvent*)
@@ -1587,7 +1593,7 @@ bool PlotWidget::canvasEventFilter(QEvent* event)
     case QEvent::MouseButtonPress: {
       if (_dragging.mode != DragInfo::NONE)
       {
-        return true;  // don't pass to canvas().
+          return true;  // don't pass to canvas().
       }
 
       QMouseEvent* mouse_event = static_cast<QMouseEvent*>(event);

--- a/plotjuggler_app/plotwidget.h
+++ b/plotjuggler_app/plotwidget.h
@@ -87,6 +87,7 @@ protected:
 
   bool eventFilter(QObject* obj, QEvent* event) override;
   void onDragEnterEvent(QDragEnterEvent* event);
+  void onDragLeaveEvent(QDragLeaveEvent* event);
   void onDropEvent(QDropEvent* event);
 
   bool canvasEventFilter(QEvent* event);

--- a/plotjuggler_app/tabbedplotwidget.cpp
+++ b/plotjuggler_app/tabbedplotwidget.cpp
@@ -124,7 +124,7 @@ PlotDocker* TabbedPlotWidget::addTab(QString tab_name)
 {
   static int tab_suffix_count = 1;
 
-  // this must be done before ant PlotDocker is created
+  // this must be done before any PlotDocker is created
   ads::CDockManager::setConfigFlag(ads::CDockManager::DockAreaHasTabsMenuButton, false);
   ads::CDockManager::setConfigFlag(ads::CDockManager::DockAreaHasUndockButton, false);
   ads::CDockManager::setConfigFlag(ads::CDockManager::AlwaysShowTabs, true);

--- a/plotjuggler_base/include/PlotJuggler/plotwidget_base.h
+++ b/plotjuggler_base/include/PlotJuggler/plotwidget_base.h
@@ -110,6 +110,7 @@ signals:
   void viewResized(const QRectF&);
 
   void dragEnterSignal(QDragEnterEvent* event);
+  void dragLeaveSignal(QDragLeaveEvent* event);
 
   void dropSignal(QDropEvent* event);
 

--- a/plotjuggler_base/src/plotwidget_base.cpp
+++ b/plotjuggler_base/src/plotwidget_base.cpp
@@ -156,6 +156,11 @@ public:
     event_callback(event);
   }
 
+  void dragLeaveEvent(QDragLeaveEvent* event) override
+  {
+      event_callback(event);
+  }
+
   void dropEvent(QDropEvent* event) override
   {
     event_callback(event);
@@ -319,6 +324,10 @@ PlotWidgetBase::PlotWidgetBase(QWidget* parent)
     if (auto ev = dynamic_cast<QDragEnterEvent*>(event))
     {
       emit dragEnterSignal(ev);
+    }
+    else if(auto ev = dynamic_cast<QDragLeaveEvent*>(event))
+    {
+        emit dragLeaveSignal(ev);
     }
     else if (auto ev = dynamic_cast<QDropEvent*>(event))
     {


### PR DESCRIPTION
- Plot widgets were not clearing their drag and drop state if a drag event left the widget, causing mouse events to not be handled properly if the drop event happened in another plot widget
- Added event handlers for drag leave event

(This was actually a pain to debug at first because it seemed like it was only impacting the first plot widget that existed, but it was just unfortunate that I was really repeatably dragging across the same widget)