### PR TITLE
fix(snap): remove yaml grade

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,6 @@ issues: https://github.com/facontidavide/plotjuggler/issues
 source-code: https://github.com/facontidavide/plotjuggler
 license: MPL-2.0
 
-grade: devel
 confinement: strict
 base: core20
 


### PR DESCRIPTION
From this comment: https://github.com/facontidavide/PlotJuggler/pull/714#issuecomment-1206335503
We realized that releasing the snap to a stable branch wasn't working.

The `grade` was programmatically set during the pull of the PlotJuggler part. But the YAML was also setting the `grade`.
And the YAML file has the priority: https://github.com/facontidavide/PlotJuggler/runs/7689122227?check_suite_focus=true#step:3:14109

Removing the `grade` from the YAML solves the problem.
Sorry for the inconvenience.