### PR TITLE
Add CSV loader date-time format help dialog

### DIFF
--- a/plotjuggler_plugins/DataLoadCSV/CMakeLists.txt
+++ b/plotjuggler_plugins/DataLoadCSV/CMakeLists.txt
@@ -4,10 +4,14 @@ include_directories(  ../ )
 add_definitions(${QT_DEFINITIONS})
 add_definitions(-DQT_PLUGIN)
 
-QT5_WRAP_UI ( UI_SRC  dataload_csv.ui  )
+QT5_WRAP_UI ( UI_SRC
+    dataload_csv.ui
+    datetimehelp.ui
+    )
 
 SET( SRC
     dataload_csv.cpp
+    datetimehelp.cpp
     )
 
 add_library(DataLoadCSV SHARED ${SRC} ${UI_SRC}  )

--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
@@ -9,6 +9,7 @@
 #include <QInputDialog>
 #include <QPushButton>
 #include "QSyntaxStyle"
+#include "datetimehelp.h"
 
 
 #include <QStandardItemModel>
@@ -97,6 +98,9 @@ DataLoadCSV::DataLoadCSV()
   _ui = new Ui::DialogCSV();
   _ui->setupUi(_dialog);
 
+  _dateTime_dialog = new DateTimeHelp(_dialog);
+
+
   _ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
 
   connect(_ui->radioButtonSelect, &QRadioButton::toggled, this, [this](bool checked) {
@@ -117,6 +121,9 @@ DataLoadCSV::DataLoadCSV()
   connect(_ui->checkBoxDateFormat, &QCheckBox::toggled, this,
           [this](bool checked) { _ui->lineEditDateFormat->setEnabled(checked); });
 
+  connect(_ui->dateTimeHelpButton,&QPushButton::clicked, this, [this](){
+        _dateTime_dialog->show();
+  });
   _ui->rawText->setHighlighter(&_csvHighlighter);
 
   QSizePolicy sp_retain = _ui->tableView->sizePolicy();
@@ -134,6 +141,7 @@ DataLoadCSV::~DataLoadCSV()
 {
   delete _ui;
   delete _dialog;
+  delete _dateTime_dialog;
 }
 
 const std::vector<const char*>& DataLoadCSV::compatibleFileExtensions() const

--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.h
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.h
@@ -9,6 +9,8 @@
 
 using namespace PJ;
 
+class DateTimeHelp;
+
 class DataLoadCSV : public DataLoader
 {
   Q_OBJECT
@@ -52,8 +54,10 @@ private:
 
   QDialog* _dialog;
   Ui::DialogCSV* _ui;
+  DateTimeHelp *_dateTime_dialog;
 
   QStandardItemModel *_model;
 
   bool multiple_columns_warning_ = true;
+
 };

--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.ui
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.ui
@@ -142,14 +142,34 @@
         </layout>
        </item>
        <item>
-        <widget class="QLabel" name="label_4">
-         <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Visit &lt;a href=&quot;https://doc.qt.io/qt-5/qtime.html#toString&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;this link&lt;/span&gt;&lt;/a&gt; to learn more about the Date-Time format.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="openExternalLinks">
-          <bool>true</bool>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QPushButton" name="dateTimeHelpButton">
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Date Format Help</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="Line" name="line_2">

--- a/plotjuggler_plugins/DataLoadCSV/datetimehelp.cpp
+++ b/plotjuggler_plugins/DataLoadCSV/datetimehelp.cpp
@@ -1,0 +1,64 @@
+#include "datetimehelp.h"
+#include "ui_datetimehelp.h"
+
+#include <QScrollBar>
+
+//Source: https://stackoverflow.com/a/42458736
+void verticalResizeTableViewToContents(QTableView *tableView)
+{
+    int count=tableView->verticalHeader()->count();
+    int scrollBarHeight = 0;
+    if(tableView->horizontalScrollBar()->isVisible())
+    {
+        scrollBarHeight=tableView->horizontalScrollBar()->height();
+    }
+    int horizontalHeaderHeight=tableView->horizontalHeader()->height();
+    int rowTotalHeight=0;
+    for (int i = 0; i < count; ++i) {
+        // 2018-03 edit: only account for row if it is visible
+        if (!tableView->verticalHeader()->isSectionHidden(i)) {
+            rowTotalHeight+=tableView->verticalHeader()->sectionSize(i);
+        }
+    }
+    tableView->setMinimumHeight(horizontalHeaderHeight+rowTotalHeight+scrollBarHeight);
+}
+
+DateTimeHelp::DateTimeHelp(QDialog *parent) :
+    QDialog(parent), ui(new Ui::DateTimeHelp), _parent(parent)
+{
+    ui->setupUi(this);
+
+    verticalResizeTableViewToContents(ui->dateFormatTable);
+    verticalResizeTableViewToContents(ui->timeFormatTable);
+
+    refreshExample();
+
+    connect(ui->exampleDateTimeDateTimeEdit,&QDateTimeEdit::dateTimeChanged,this, [this](){
+        refreshExample();
+    });
+
+    connect(ui->exampleFormatStringLineEdit,&QLineEdit::textChanged,this, [this](){
+        refreshExample();
+    });
+
+    connect(_parent,&QDialog::finished,this,[this](){
+        if(ui->autoCloseCheckBox->isChecked())
+        {
+            accept();
+        }
+
+    });
+
+}
+
+DateTimeHelp::~DateTimeHelp()
+{
+    delete ui;
+}
+
+void DateTimeHelp::refreshExample()
+{
+    auto dateTime = ui->exampleDateTimeDateTimeEdit->dateTime();
+    auto formatString = ui->exampleFormatStringLineEdit->text();
+    ui->resultLineEdit->setText(dateTime.toString(formatString));
+}

--- a/plotjuggler_plugins/DataLoadCSV/datetimehelp.h
+++ b/plotjuggler_plugins/DataLoadCSV/datetimehelp.h
@@ -1,0 +1,26 @@
+#ifndef DATETIMEHELP_H
+#define DATETIMEHELP_H
+
+#include <QDialog>
+
+namespace Ui {
+class DateTimeHelp;
+}
+
+class DateTimeHelp : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit DateTimeHelp(QDialog *parent = nullptr);
+    ~DateTimeHelp();
+
+    void refreshExample();
+
+private:
+    Ui::DateTimeHelp *ui;
+
+    QDialog* _parent;
+};
+
+#endif // DATETIMEHELP_H

--- a/plotjuggler_plugins/DataLoadCSV/datetimehelp.ui
+++ b/plotjuggler_plugins/DataLoadCSV/datetimehelp.ui
@@ -1,0 +1,599 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DateTimeHelp</class>
+ <widget class="QDialog" name="DateTimeHelp">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>984</width>
+    <height>652</height>
+   </rect>
+  </property>
+  <property name="acceptDrops">
+   <bool>false</bool>
+  </property>
+  <property name="windowTitle">
+   <string>Date-Time Format</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="font">
+        <font>
+         <family>Ubuntu</family>
+         <pointsize>10</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="title">
+        <string>Date-Time Example</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <item>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="exampleDateTimeLabel">
+            <property name="text">
+             <string>Example Date-Time (Format: M/d/yyyy h:mm:ss.zzz AP):</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDateTimeEdit" name="exampleDateTimeDateTimeEdit">
+            <property name="displayFormat">
+             <string>M/d/yyyy h:mm:ss.zzz AP</string>
+            </property>
+            <property name="calendarPopup">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="exampleFormatStringLabel">
+            <property name="text">
+             <string>Example Format String</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="exampleFormatStringLineEdit">
+            <property name="text">
+             <string>d-MM-yyyy h:mm:ss</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="resultLabel">
+            <property name="text">
+             <string>Result</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="resultLineEdit">
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QScrollArea" name="scrollArea">
+       <property name="verticalScrollBarPolicy">
+        <enum>Qt::ScrollBarAsNeeded</enum>
+       </property>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAsNeeded</enum>
+       </property>
+       <property name="sizeAdjustPolicy">
+        <enum>QAbstractScrollArea::AdjustToContents</enum>
+       </property>
+       <property name="widgetResizable">
+        <bool>true</bool>
+       </property>
+       <widget class="QWidget" name="scrollAreaWidgetContents">
+        <property name="geometry">
+         <rect>
+          <x>0</x>
+          <y>0</y>
+          <width>937</width>
+          <height>1084</height>
+         </rect>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_7">
+           <item>
+            <widget class="QGroupBox" name="groupBox_2">
+             <property name="font">
+              <font>
+               <family>Ubuntu</family>
+               <pointsize>10</pointsize>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="title">
+              <string/>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_6">
+              <item>
+               <widget class="QLabel" name="label_5">
+                <property name="text">
+                 <string>All other input characters will be treated as text. Any non-empty sequence of characters enclosed in single quotes will also be treated (stripped of the quotes) as text and not be interpreted as expressions.</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_5">
+                <item>
+                 <widget class="QLabel" name="label_4">
+                  <property name="text">
+                   <string>Date Format</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QTableWidget" name="dateFormatTable">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                    <horstretch>1</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="verticalScrollBarPolicy">
+                   <enum>Qt::ScrollBarAlwaysOff</enum>
+                  </property>
+                  <property name="sizeAdjustPolicy">
+                   <enum>QAbstractScrollArea::AdjustToContents</enum>
+                  </property>
+                  <property name="editTriggers">
+                   <set>QAbstractItemView::NoEditTriggers</set>
+                  </property>
+                  <property name="showDropIndicator" stdset="0">
+                   <bool>false</bool>
+                  </property>
+                  <property name="alternatingRowColors">
+                   <bool>true</bool>
+                  </property>
+                  <attribute name="horizontalHeaderStretchLastSection">
+                   <bool>true</bool>
+                  </attribute>
+                  <attribute name="verticalHeaderVisible">
+                   <bool>false</bool>
+                  </attribute>
+                  <row>
+                   <property name="text">
+                    <string>row1</string>
+                   </property>
+                  </row>
+                  <row>
+                   <property name="text">
+                    <string>row2</string>
+                   </property>
+                  </row>
+                  <row>
+                   <property name="text">
+                    <string>row3</string>
+                   </property>
+                  </row>
+                  <row>
+                   <property name="text">
+                    <string>row4</string>
+                   </property>
+                  </row>
+                  <row>
+                   <property name="text">
+                    <string>row5</string>
+                   </property>
+                  </row>
+                  <row>
+                   <property name="text">
+                    <string>row6</string>
+                   </property>
+                  </row>
+                  <row>
+                   <property name="text">
+                    <string>row7</string>
+                   </property>
+                  </row>
+                  <row>
+                   <property name="text">
+                    <string>row8</string>
+                   </property>
+                  </row>
+                  <row>
+                   <property name="text">
+                    <string>row9</string>
+                   </property>
+                  </row>
+                  <row>
+                   <property name="text">
+                    <string>row10</string>
+                   </property>
+                  </row>
+                  <column>
+                   <property name="text">
+                    <string>Expression</string>
+                   </property>
+                  </column>
+                  <column>
+                   <property name="text">
+                    <string>Output</string>
+                   </property>
+                  </column>
+                  <item row="0" column="0">
+                   <property name="text">
+                    <string>d</string>
+                   </property>
+                  </item>
+                  <item row="0" column="1">
+                   <property name="text">
+                    <string>The day as a number without a leading zero (1 to 31)</string>
+                   </property>
+                  </item>
+                  <item row="1" column="0">
+                   <property name="text">
+                    <string>dd</string>
+                   </property>
+                  </item>
+                  <item row="1" column="1">
+                   <property name="text">
+                    <string>The day as a number with a leading zero (01 to 31)</string>
+                   </property>
+                  </item>
+                  <item row="2" column="0">
+                   <property name="text">
+                    <string>ddd</string>
+                   </property>
+                  </item>
+                  <item row="2" column="1">
+                   <property name="text">
+                    <string>The abbreviated localized day name (e.g. 'Mon' to 'Sun')</string>
+                   </property>
+                  </item>
+                  <item row="3" column="0">
+                   <property name="text">
+                    <string>dddd</string>
+                   </property>
+                  </item>
+                  <item row="3" column="1">
+                   <property name="text">
+                    <string>The long localized day name (e.g. 'Monday' to 'Sunday').</string>
+                   </property>
+                  </item>
+                  <item row="4" column="0">
+                   <property name="text">
+                    <string>M</string>
+                   </property>
+                  </item>
+                  <item row="4" column="1">
+                   <property name="text">
+                    <string>The month as a number without a leading zero (1 to 12)</string>
+                   </property>
+                  </item>
+                  <item row="5" column="0">
+                   <property name="text">
+                    <string>MM</string>
+                   </property>
+                  </item>
+                  <item row="5" column="1">
+                   <property name="text">
+                    <string>The month as a number with a leading zero (01 to 12)</string>
+                   </property>
+                  </item>
+                  <item row="6" column="0">
+                   <property name="text">
+                    <string>MMM</string>
+                   </property>
+                  </item>
+                  <item row="6" column="1">
+                   <property name="text">
+                    <string>The abbreviated localized month name (e.g. 'Jan' to 'Dec')</string>
+                   </property>
+                  </item>
+                  <item row="7" column="0">
+                   <property name="text">
+                    <string>MMMM</string>
+                   </property>
+                  </item>
+                  <item row="7" column="1">
+                   <property name="text">
+                    <string>The long localized month name (e.g. 'January' to 'December')</string>
+                   </property>
+                  </item>
+                  <item row="8" column="0">
+                   <property name="text">
+                    <string>yy</string>
+                   </property>
+                  </item>
+                  <item row="8" column="1">
+                   <property name="text">
+                    <string>The year as a two digit number (00 to 99)</string>
+                   </property>
+                  </item>
+                  <item row="9" column="0">
+                   <property name="text">
+                    <string>yyyy</string>
+                   </property>
+                  </item>
+                  <item row="9" column="1">
+                   <property name="text">
+                    <string>The year as a four digit number, possibly plus a leading minus sign for negative years.</string>
+                   </property>
+                  </item>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_3">
+                <property name="text">
+                 <string>Time Format</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QTableWidget" name="timeFormatTable">
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="verticalScrollBarPolicy">
+                 <enum>Qt::ScrollBarAlwaysOff</enum>
+                </property>
+                <property name="horizontalScrollBarPolicy">
+                 <enum>Qt::ScrollBarAsNeeded</enum>
+                </property>
+                <property name="sizeAdjustPolicy">
+                 <enum>QAbstractScrollArea::AdjustToContents</enum>
+                </property>
+                <property name="editTriggers">
+                 <set>QAbstractItemView::NoEditTriggers</set>
+                </property>
+                <property name="alternatingRowColors">
+                 <bool>true</bool>
+                </property>
+                <attribute name="horizontalHeaderStretchLastSection">
+                 <bool>true</bool>
+                </attribute>
+                <attribute name="verticalHeaderVisible">
+                 <bool>false</bool>
+                </attribute>
+                <row>
+                 <property name="text">
+                  <string>row1</string>
+                 </property>
+                </row>
+                <row>
+                 <property name="text">
+                  <string>row2</string>
+                 </property>
+                </row>
+                <row>
+                 <property name="text">
+                  <string>row3</string>
+                 </property>
+                </row>
+                <row>
+                 <property name="text">
+                  <string>row4</string>
+                 </property>
+                </row>
+                <row>
+                 <property name="text">
+                  <string>row5</string>
+                 </property>
+                </row>
+                <row>
+                 <property name="text">
+                  <string>row6</string>
+                 </property>
+                </row>
+                <row>
+                 <property name="text">
+                  <string>row7</string>
+                 </property>
+                </row>
+                <row>
+                 <property name="text">
+                  <string>row8</string>
+                 </property>
+                </row>
+                <row>
+                 <property name="text">
+                  <string>row9</string>
+                 </property>
+                </row>
+                <row>
+                 <property name="text">
+                  <string>row10</string>
+                 </property>
+                </row>
+                <row>
+                 <property name="text">
+                  <string>row11</string>
+                 </property>
+                </row>
+                <row>
+                 <property name="text">
+                  <string>row12</string>
+                 </property>
+                </row>
+                <column>
+                 <property name="text">
+                  <string>Expression</string>
+                 </property>
+                </column>
+                <column>
+                 <property name="text">
+                  <string>Output</string>
+                 </property>
+                </column>
+                <item row="0" column="0">
+                 <property name="text">
+                  <string>h</string>
+                 </property>
+                </item>
+                <item row="0" column="1">
+                 <property name="text">
+                  <string>The hour without a leading zero (0 to 23 or 1 to 12 if AM/PM display)</string>
+                 </property>
+                </item>
+                <item row="1" column="0">
+                 <property name="text">
+                  <string>hh</string>
+                 </property>
+                </item>
+                <item row="1" column="1">
+                 <property name="text">
+                  <string>The hour with a leading zero (00 to 23 or 01 to 12 if AM/PM display)</string>
+                 </property>
+                </item>
+                <item row="2" column="0">
+                 <property name="text">
+                  <string>H</string>
+                 </property>
+                </item>
+                <item row="2" column="1">
+                 <property name="text">
+                  <string>The hour without a leading zero (0 to 23, even with AM/PM display)</string>
+                 </property>
+                </item>
+                <item row="3" column="0">
+                 <property name="text">
+                  <string>HH</string>
+                 </property>
+                </item>
+                <item row="3" column="1">
+                 <property name="text">
+                  <string>The hour with a leading zero (00 to 23, even with AM/PM display)</string>
+                 </property>
+                </item>
+                <item row="4" column="0">
+                 <property name="text">
+                  <string>m</string>
+                 </property>
+                </item>
+                <item row="4" column="1">
+                 <property name="text">
+                  <string>The minute without a leading zero (0 to 59)</string>
+                 </property>
+                </item>
+                <item row="5" column="0">
+                 <property name="text">
+                  <string>mm</string>
+                 </property>
+                </item>
+                <item row="5" column="1">
+                 <property name="text">
+                  <string>The minute with a leading zero (00 to 59)</string>
+                 </property>
+                </item>
+                <item row="6" column="0">
+                 <property name="text">
+                  <string>s</string>
+                 </property>
+                </item>
+                <item row="6" column="1">
+                 <property name="text">
+                  <string>The whole second, without any leading zero (0 to 59)</string>
+                 </property>
+                </item>
+                <item row="7" column="0">
+                 <property name="text">
+                  <string>ss</string>
+                 </property>
+                </item>
+                <item row="7" column="1">
+                 <property name="text">
+                  <string>The whole second, with a leading zero where applicable (00 to 59)</string>
+                 </property>
+                </item>
+                <item row="8" column="0">
+                 <property name="text">
+                  <string>z</string>
+                 </property>
+                </item>
+                <item row="8" column="1">
+                 <property name="text">
+                  <string>The fractional part of the second, to go after a decimal point, without trailing zeroes (0 to 999). Thus &quot;s.z&quot; reports the seconds to full available (millisecond) precision without trailing zeroes.</string>
+                 </property>
+                </item>
+                <item row="9" column="0">
+                 <property name="text">
+                  <string>zzz</string>
+                 </property>
+                </item>
+                <item row="9" column="1">
+                 <property name="text">
+                  <string>The fractional part of the second, to millisecond precision, including trailing zeroes where applicable (000 to 999).</string>
+                 </property>
+                </item>
+                <item row="10" column="0">
+                 <property name="text">
+                  <string>AP or A</string>
+                 </property>
+                </item>
+                <item row="10" column="1">
+                 <property name="text">
+                  <string>Interpret as an AM/PM time. A/AP will match an upper-case version of either QLocale::amText() or QLocale::pmText().</string>
+                 </property>
+                </item>
+                <item row="11" column="0">
+                 <property name="text">
+                  <string>ap or a</string>
+                 </property>
+                </item>
+                <item row="11" column="1">
+                 <property name="text">
+                  <string>Interpret as an am/pm time. a/ap will match a lower-case version of either QLocale::amText() or QLocale::pmText().</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="autoCloseCheckBox">
+       <property name="text">
+        <string>Close window automatically</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Added a new dialog window to the CSV loader to help with the date time format strings.

![image](https://user-images.githubusercontent.com/2954254/185810075-6ee28075-f68d-475f-881c-ddb80ca3bb19.png)

**Features:**
-Date time format string preview: displays the result from a given format string for a user-specified date time
-Checkbox at the bottom to allow the help dialog to stay open when opening multiple csv files

The dialog can be opened by clicking on the new "Date Format Help" button that replaces the old message with hyperlink to the Qt documentation

