### PR TITLE
add qt5 deps to vcpkg for easier windows building

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,6 +5,9 @@
     "protobuf",
     "mosquitto",
     "zeromq",
+    "qt5-base",
+    "qt5-svg",
+    "qt5-websockets",
     {
       "name": "arrow",
       "features": [ "parquet" ]


### PR DESCRIPTION
I wasn't able to build in windows with vcpkg using the default vcpkg manifest. This seemed to work for me using the following steps:
(in repo folder)
mkdir build
cd build
cmake -G "Visual Studio 16 2019" .. -DCMAKE_TOOLCHAIN_FILE=\path\to\scripts\buildsystems\vcpkg.cmake
cmake --build .

Might be able to simplify the windows github actions as well using this method? (seems to depend on qt5 already being installed)

Cheers,
Nate