### PR TITLE
compile: add cmake to brew install

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -75,7 +75,7 @@ cp -v install/bin/* AppDir/usr/bin
 
 On Mac, the dependencies can be installed using [brew](https://brew.sh/) with the following command:
 
-    brew install qt@5 protobuf mosquitto zeromq zstd
+    brew install cmake qt@5 protobuf mosquitto zeromq zstd
 
 Clone the repository into **~/plotjuggler_ws**:
 


### PR DESCRIPTION
Hey,

I've noticed that on the fresh OS install the cmake is also missing.
This pr fixes it.