### PR TITLE
Set MQTT topics list to be multi-selectable

### DIFF
--- a/plotjuggler_plugins/DataStreamMQTT/datastream_mqtt.ui
+++ b/plotjuggler_plugins/DataStreamMQTT/datastream_mqtt.ui
@@ -588,6 +588,9 @@
           <property name="editTriggers">
            <set>QAbstractItemView::NoEditTriggers</set>
           </property>
+          <property name="selectionMode">
+           <set>QAbstractItemView::ExtendedSelection</set>
+          </property>
          </widget>
         </item>
        </layout>


### PR DESCRIPTION
PlotJuggler has become an integral part of our workflow for testing our system. Previous version of PJ allowed you to subscribe to multiple MQTT topics, but since the change to the mosquito-based MQTT plugin, this is no longer possible. This change fixes that and allows us to plot data from multiple topics once more.