### PR TITLE
Always use topic names for creating MQTT parsers

### DIFF
--- a/plotjuggler_plugins/DataStreamMQTT/datastream_mqtt.cpp
+++ b/plotjuggler_plugins/DataStreamMQTT/datastream_mqtt.cpp
@@ -149,7 +149,7 @@ void DataStreamMQTT::onMessageReceived(const mosquitto_message *message)
   if( it == _parsers.end() )
   {
     auto& parser_factory = parserFactories()->at( _protocol );
-    auto parser = parser_factory->createParser({}, {}, {}, dataMap());
+    auto parser = parser_factory->createParser({message->topic}, {}, {}, dataMap());
     it = _parsers.insert( {message->topic, parser} ).first;
   }
   auto& parser = it->second;


### PR DESCRIPTION
The MQTT data streamer in plot juggler currently does not use the MQTT topic name when creating parsers. If/when #745 is merged, this becomes a larger issue as data from multiple different topics becomes merged together. If different MQTT topics contain fields of the same name, then it is next to impossible to differentiate them in PJ. This change allows the topic name to be reflected in the tree view when selecting data and makes the data fields easily distinguishable.