### PR TITLE
Add precision to CSV export to handle geocoordinates

### DIFF
--- a/plotjuggler_plugins/StatePublisherCSV/publisher_csv.cpp
+++ b/plotjuggler_plugins/StatePublisherCSV/publisher_csv.cpp
@@ -345,7 +345,7 @@ QString StatePublisherCSV::generateRangeCSV(double time_start, double time_end)
     {
       if (!std::isnan(row_values[i]))
       {
-        row_str += QString::number(row_values[i], 'f');
+        row_str += QString::number(row_values[i], 'f', 9);
         // value used, move to the nex index
         indices[i]++;
       }


### PR DESCRIPTION
With geographic coordinates, the precision is critical to get centimeter accuracy.

On the following image in QGis, le red dots have a precision of 6 and the blue ones have a precision of 9 digits.
For reference, the red rectangle has a width of 2 m.
![image](https://user-images.githubusercontent.com/8845664/192714024-531b03aa-e7e9-471f-aeda-14736c354e57.png)

According to [this answer](https://gis.stackexchange.com/questions/8650/measuring-accuracy-of-latitude-and-longitude/8674#8674), 8 digits should be enough already but I have used 9 as a multiple of 3. But I can change it if you wish.