### PR TITLE
Add option to build plotjuggler_base as shared library

### DIFF
--- a/3rdparty/lua-5.4.3/CMakeLists.txt
+++ b/3rdparty/lua-5.4.3/CMakeLists.txt
@@ -31,13 +31,18 @@ set(LUA_LIB_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/lutf8lib.c 
     ${CMAKE_CURRENT_SOURCE_DIR}/src/loadlib.c 
     ${CMAKE_CURRENT_SOURCE_DIR}/src/linit.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/lua.c)
+    )
 set(LUA_LIB_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 add_compile_options(-fPIC)
 
-add_library(lua_static STATIC ${LUA_LIB_SRCS})
+add_library(lua_static STATIC
+    ${LUA_LIB_SRCS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/lua.c
+)
 target_include_directories(lua_static PUBLIC ${LUA_LIB_INCLUDE})
+
+add_library(lua_objects OBJECT ${LUA_LIB_SRCS})
 
 if ( NOT WIN32 )
     set(LUA_DEFINITIONS LUA_USE_POSIX)

--- a/3rdparty/qwt/src/CMakeLists.txt
+++ b/3rdparty/qwt/src/CMakeLists.txt
@@ -193,7 +193,6 @@ set( QWT_SRC
 
 add_library(plotjuggler_qwt STATIC ${QWT_SRC})
 
-
 target_link_libraries(plotjuggler_qwt
     ${Qt5Widgets_LIBRARIES}
     ${Qt5Concurrent_LIBRARIES}
@@ -201,6 +200,9 @@ target_link_libraries(plotjuggler_qwt
     )
 target_compile_definitions(plotjuggler_qwt PUBLIC QWT_MOC_INCLUDE)
 #target_compile_definitions(plotjuggler_qwt PUBLIC QWT_DLL QWT_MAKEDLL )
+
+add_library(plotjuggler_qwt_objects OBJECT ${QWT_SRC})
+target_compile_definitions(plotjuggler_qwt_objects PUBLIC QWT_MOC_INCLUDE)
 
 #install(
 #    TARGETS plotjuggler_qwt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ add_definitions(
 #add_definitions( -DPJ_DEFAULT_ARGS="${PJ_DEFAULT_ARGS}")
 
 option(ENABLE_ASAN "Enable Address Sanitizer" OFF)
+option(BASE_AS_SHARED "Build the base library as a shared libary" OFF)
 
 IF (NOT WIN32 AND ENABLE_ASAN)
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
@@ -161,6 +162,21 @@ include_directories(
 )
 
 #########################  BASE library  ####################################
+
+set(PLOTJUGGLER_BASE_SRC
+    plotjuggler_base/src/plotdata.cpp
+    plotjuggler_base/src/datastreamer_base.cpp
+    plotjuggler_base/src/transform_function.cpp
+    plotjuggler_base/src/plotwidget_base.cpp
+    plotjuggler_base/src/plotzoomer.cpp
+    plotjuggler_base/src/plotmagnifier.cpp
+    plotjuggler_base/src/plotlegend.cpp
+    plotjuggler_base/src/plotpanner.cpp
+    plotjuggler_base/src/timeseries_qwt.cpp
+    plotjuggler_base/src/reactive_function.cpp
+    plotjuggler_base/src/special_messages.cpp
+)
+
 qt5_wrap_cpp(PLOTJUGGLER_BASE_MOCS
   plotjuggler_base/include/PlotJuggler/dataloader_base.h
   plotjuggler_base/include/PlotJuggler/statepublisher_base.h
@@ -170,22 +186,21 @@ qt5_wrap_cpp(PLOTJUGGLER_BASE_MOCS
   plotjuggler_base/include/PlotJuggler/plotwidget_base.h
 )
 
-add_library( plotjuggler_base
-    ${PLOTJUGGLER_BASE_MOCS}
-     plotjuggler_base/src/plotdata.cpp
-     plotjuggler_base/src/datastreamer_base.cpp
-     plotjuggler_base/src/transform_function.cpp
-     plotjuggler_base/src/plotwidget_base.cpp
-     plotjuggler_base/src/plotzoomer.cpp
-     plotjuggler_base/src/plotmagnifier.cpp
-     plotjuggler_base/src/plotlegend.cpp
-     plotjuggler_base/src/plotpanner.cpp
-     plotjuggler_base/src/timeseries_qwt.cpp
-     plotjuggler_base/src/reactive_function.cpp
-     plotjuggler_base/src/special_messages.cpp
-     )
+if (BASE_AS_SHARED)
+    add_library(plotjuggler_base SHARED
+        ${PLOTJUGGLER_BASE_SRC}
+        ${PLOTJUGGLER_BASE_MOCS}
+        )
+    target_link_libraries(plotjuggler_base PRIVATE lua_objects plotjuggler_qwt_objects)
+else()
+    add_library(plotjuggler_base STATIC
+        ${PLOTJUGGLER_BASE_SRC}
+        ${PLOTJUGGLER_BASE_MOCS}
+        )
+endif()
 
 # target_link_libraries(plotjuggler_base plotjuggler_qwt)
+
 target_include_directories(plotjuggler_base INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include>
@@ -229,7 +244,7 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/PlotJuggler.desktop
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/plotjuggler.svg
         DESTINATION ${DESKTOP_ICON_DIR}  )
 
-######################## Main App, Libraries amd Plugins ###################################
+######################## Main App, Libraries and Plugins ###################################
 
 add_subdirectory( 3rdparty/qwt/src )
 add_subdirectory( 3rdparty/lz4 )


### PR DESCRIPTION
Whilst the MPL2.0 allows for static linking to `plotjuggler`, doing so still makes legal teams in industry nervous. This change adds an option to build the `plotjuggler_base` library as a shared library to the CMakeLists file. The base library can then be dynamically linked to from proprietary PlotJuggler plugin implementations.  

The default build will still build the library as a static library, like usual, so there will be no impact to existing projects.