### PR TITLE
Fix/add other dds vendors

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -287,6 +287,8 @@ parts:
       - ros-foxy-vrxperience-msgs
       - ros-foxy-webots-ros2-msgs
       - ros-foxy-wiimote-msgs
+      # Cyclonedds
+      - ros-foxy-rmw-cyclonedds-cpp
     override-pull: |
       if [ ! -d plotjuggler-ros-plugins ]; then
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -287,8 +287,10 @@ parts:
       - ros-foxy-vrxperience-msgs
       - ros-foxy-webots-ros2-msgs
       - ros-foxy-wiimote-msgs
-      # Cyclonedds
+      # Additional DDS vendors
       - ros-foxy-rmw-cyclonedds-cpp
+      - ros-foxy-rmw-connext-cpp
+      - ros-foxy-rmw-gurumdds-cpp
     override-pull: |
       if [ ! -d plotjuggler-ros-plugins ]; then
 


### PR DESCRIPTION
Add additional DDS vendors to the snap.

This will fix https://github.com/facontidavide/PlotJuggler/issues/752

Since the snap is isolated, additional DDS vendors must be added to the snap itself.