### PR TITLE
[bugfix] Allow for NaN floating point numbers

### DIFF
--- a/plotjuggler_plugins/ParserROS/rosx_introspection/include/rosx_introspection/details/conversion_impl.hpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/include/rosx_introspection/details/conversion_impl.hpp
@@ -38,6 +38,7 @@
 #include <type_traits>
 #include <limits>
 #include <iostream>
+#include <cmath>
 #include "rosx_introspection/builtin_types.hpp"
 #include "rosx_introspection/details/exceptions.hpp"
 
@@ -225,6 +226,10 @@ template<typename SRC,typename DST,
 inline void convert_impl( const SRC& from, DST& target )
 {
     //std::cout << "float_conversion" << std::endl;
+    if (std::isnan(from)){
+        target = NAN;
+        return;
+    }
     checkTruncation<SRC,DST>(from);
     target = static_cast<DST>( from );
 }


### PR DESCRIPTION
I have been playing around with the mcap data storage type and noticed that messages with NaN entries throw a truncation error in the latest PlotJuggler release.

Here we first check for NaN before doing the truncation check.

Please let me know if there are unit tests I can add/update. Thanks.