### PR TITLE
[bugfix] Allow for very large uint64_t types

### DIFF
--- a/plotjuggler_plugins/ParserROS/rosx_introspection/include/rosx_introspection/variant.hpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/include/rosx_introspection/variant.hpp
@@ -304,27 +304,27 @@ template<typename DST> inline DST Variant::convert() const
 template<> inline double Variant::convert() const
 {
   using namespace RosMsgParser::details;
-  double target = 0;
+  double long target = 0;
   const auto& raw_data = &_storage.raw_data[0];
   //----------
   switch( _type )
   {
   case CHAR:
-  case INT8:   convert_impl<int8_t,  double>(*reinterpret_cast<const int8_t*>( raw_data), target  ); break;
+  case INT8:   convert_impl<int8_t,  double long>(*reinterpret_cast<const int8_t*>( raw_data), target  ); break;
 
-  case INT16:  convert_impl<int16_t, double>(*reinterpret_cast<const int16_t*>( raw_data), target  ); break;
-  case INT32:  convert_impl<int32_t, double>(*reinterpret_cast<const int32_t*>( raw_data), target  ); break;
-  case INT64:  convert_impl<int64_t, double>(*reinterpret_cast<const int64_t*>( raw_data), target  ); break;
+  case INT16:  convert_impl<int16_t, double long>(*reinterpret_cast<const int16_t*>( raw_data), target  ); break;
+  case INT32:  convert_impl<int32_t, double long>(*reinterpret_cast<const int32_t*>( raw_data), target  ); break;
+  case INT64:  convert_impl<int64_t, double long>(*reinterpret_cast<const int64_t*>( raw_data), target  ); break;
 
   case BOOL:
   case BYTE:
-  case UINT8:   convert_impl<uint8_t,  double>(*reinterpret_cast<const uint8_t*>( raw_data), target  ); break;
+  case UINT8:   convert_impl<uint8_t,  double long>(*reinterpret_cast<const uint8_t*>( raw_data), target  ); break;
 
-  case UINT16:  convert_impl<uint16_t, double>(*reinterpret_cast<const uint16_t*>( raw_data), target  ); break;
-  case UINT32:  convert_impl<uint32_t, double>(*reinterpret_cast<const uint32_t*>( raw_data), target  ); break;
-  case UINT64:  convert_impl<uint64_t, double>(*reinterpret_cast<const uint64_t*>( raw_data), target  ); break;
+  case UINT16:  convert_impl<uint16_t, double long>(*reinterpret_cast<const uint16_t*>( raw_data), target  ); break;
+  case UINT32:  convert_impl<uint32_t, double long>(*reinterpret_cast<const uint32_t*>( raw_data), target  ); break;
+  case UINT64:  convert_impl<uint64_t, double long>(*reinterpret_cast<const uint64_t*>( raw_data), target  ); break;
 
-  case FLOAT32:  convert_impl<float, double>(*reinterpret_cast<const float*>( raw_data), target  ); break;
+  case FLOAT32:  convert_impl<float, double long>(*reinterpret_cast<const float*>( raw_data), target  ); break;
   case FLOAT64:  return extract<double>();
 
   case STRING: {
@@ -340,7 +340,7 @@ template<> inline double Variant::convert() const
   default: throw TypeException("Variant::convert -> cannot convert type" + std::to_string(_type));
 
   }
-  return  target;
+  return  static_cast<double>(target);
 }
 
 template<> inline RosMsgParser::Time Variant::convert() const


### PR DESCRIPTION
Again exploring mcap data storage type (not sure if this bug also exists with other types):

Very large uint64_t types fail this check and will not load in the latest PlotJuggler: 
```
if( from != static_cast<SRC>(static_cast<DST>( from)))
        throw RangeException("Floating point truncated");
```

For instance, 
```
    uint64_t val_int = std::numeric_limits<uint64_t>::max() - 1000;
    double val_double = 0;
    val_double = static_cast<double>(val_int);
    uint64_t val_int2 = static_cast<uint64_t>(val_double);

    std::cout.precision(25);
    std::cout << "val_i1: " << val_int << std::endl;
    std::cout << "val_d1: " << val_double << std::endl;
    std::cout << "val_i2: " << val_int2 << std::endl;
```
returns
```
val_i1: 18446744073709550615
val_d1: 18446744073709551616
val_i2: 0
```
presumably because the `double` does not have enough precision to accurately represent the large `uint64_t`.

The proposal here could be a bit of a hack, I'm not sure. However, it solves the problem on my machine and is likely supported on most modern architectures. The idea is that all uint64_t values can be accurately represented by a larger data type so use a `double long` during the conversion/checking process, and then cast back to `double` when you are confident that the data are valid.

Let me know if there is a better fix.