### PR TITLE
[bugfix] fix parsing of custom types added multiple times in messages

### DIFF
--- a/plotjuggler_plugins/ParserROS/rosx_introspection/src/ros_message.cpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/src/ros_message.cpp
@@ -112,25 +112,29 @@ std::vector<ROSMessage::Ptr> ParseMessageDefinitions(
       }
     }
 
-    // adjust types with undefined package type
-    for (ROSField& field: msg->fields())
+    // add to vector
+    parsed_msgs.push_back( msg );
+    known_type.push_back( msg->type() );
+  }
+
+  // adjust types with undefined package type
+  for (auto& msg: parsed_msgs)
+  {
+    for (ROSField& field : msg->fields())
     {
       // if package name is missing, try to find msgName in the list of known_type
-      if( field.type().pkgName().empty() )
+      if (field.type().pkgName().empty())
       {
-        for (const ROSType& known_type: known_type)
+        for (const ROSType& known_type : known_type)
         {
-          if( field.type().msgName() == known_type.msgName()  )
+          if (field.type().msgName() == known_type.msgName())
           {
-            field.changeType( known_type );
+            field.changeType(known_type);
             break;
           }
         }
       }
     }
-    // add to vector
-    parsed_msgs.push_back( msg );
-    known_type.push_back( msg->type() );
   }
 
   std::reverse(parsed_msgs.begin(), parsed_msgs.end());


### PR DESCRIPTION
In the latest PlotJuggler I'm failing to decode some messages with the following error: `throw std::runtime_error("Missing ROSType in library");`

A common thread for the messages throwing this error is that they all contain the same custom types in multiple sub-entries. The result is that the reverse parsing of messages is not sufficient to capture all dependencies. 

This PR suggests creating all the known types the first time through the messages and then filling in the packages only after. It is slightly less efficient, but correctly captures dependencies (as far as I can tell).