### PR TITLE
[bugfix] conversion typo?

### DIFF
--- a/plotjuggler_plugins/ParserROS/rosx_introspection/include/rosx_introspection/details/conversion_impl.hpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/include/rosx_introspection/details/conversion_impl.hpp
@@ -302,7 +302,7 @@ inline void convert_impl( const SRC& from, DST& target )
     //std::cout << "floating_to_signed_conversion" << std::endl;
 
     checkLowerLimitFloat<SRC,DST>(from);
-    checkLowerLimitFloat<SRC,DST>(from);
+    checkUpperLimitFloat<SRC,DST>(from);
 
     if( from != static_cast<SRC>(static_cast<DST>( from)))
         throw RangeException("Floating point truncated");


### PR DESCRIPTION
Fixing what I assume is a typo in the code that I noticed while looking at other things. I didn't see `checkUpperLimitFloat` used anywhere else so I assume it was meant to be here.