### PR TITLE
Update Reactive Scripts on playback loop

### DIFF
--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -2725,6 +2725,7 @@ void MainWindow::onPlaybackLoop()
   //////////////////
   updatedDisplayTime();
   onUpdateLeftTableValues();
+  updateReactivePlots();
 
   for (auto& it : _state_publisher)
   {


### PR DESCRIPTION
update the reactive scripts on playback loop. previously on moving manually the timeslider updated them.

PS: thanks for this amazing tool, I use it everyday!