### PR TITLE
Fix nan check

### DIFF
--- a/plotjuggler_plugins/ParserROS/rosx_introspection/include/rosx_introspection/details/conversion_impl.hpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/include/rosx_introspection/details/conversion_impl.hpp
@@ -224,7 +224,7 @@ template<typename SRC,typename DST,
           typename details::EnableIf< details::float_conversion<SRC, DST>>* = nullptr >
 inline void convert_impl( const SRC& from, DST& target )
 {
-  if(std::isnan(from)){
+  if(!std::isnan(from)) {
     checkTruncation<SRC,DST>(from);
   }
   target = static_cast<DST>( from );


### PR DESCRIPTION
Commit https://github.com/facontidavide/PlotJuggler/commit/b68e353fcf186e3a56e542f3b088cf080395099e added checks that prevented checking for bad conversions when the source value was NaN. Then, for reasons I cannot figure out, all those checks were removed in https://github.com/facontidavide/PlotJuggler/commit/6b29e1ffff96fa74d4e9dfeff72fd4ff99924cff. However, one check was left but seems to be backward now. Now, it only checks for truncation if the source _is_ NaN.

This PR reverses that check. Please let me know if I'm missing something here. Seems to me like the original commit was correct.