### PR TITLE
Fix for segfault in DataLoadCSV destructor

### DIFF
--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
@@ -140,8 +140,8 @@ DataLoadCSV::DataLoadCSV()
 DataLoadCSV::~DataLoadCSV()
 {
   delete _ui;
-  delete _dialog;
   delete _dateTime_dialog;
+  delete _dialog;
 }
 
 const std::vector<const char*>& DataLoadCSV::compatibleFileExtensions() const


### PR DESCRIPTION
- Closes #778
- Change order of deletion for dialogs.
- First delete child dialog `_dateTime_dialog` then parent `_dialog`.

Signed-off-by: Michael Orlov <michael.orlov@apex.ai>