### PR TITLE
Support Protos That Reference Google/Protobuf

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -82,6 +82,7 @@ parts:
       - libdw1
       - libmosquitto1
       - libprotobuf17
+      - libprotobuf-dev
       - libzmq5
     override-pull: |
         snapcraftctl pull


### PR DESCRIPTION
Installed plotjuggler via snap in ubuntu 20.04

Noticed that, when importing a large protobuf message which depends on google/protobuf, I got the following error 
```
google/protobuf/descriptor.proto: File not found
```
I assumed this was just a problem of needing to reference the path to these protos. However, this path selection through the plotjuggler GUI was unsuccessful.

Google'd the problem and found [this discussion](https://github.com/grpc-ecosystem/grpc-gateway/issues/422) which yielded the result of installing apt package `libprotobuf-dev`. Once this was installed, I did not need to add anything to my protobuf path to get the import to work.

I should probably dig deeper to figure out _why_ this package was needed instead of just `libprotobuf17`, but figured the solution might be valuable before that detail is solved.