### PR TITLE
Fix for missing preferences

### DIFF
--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -3244,7 +3244,7 @@ void MainWindow::on_actionPreferences_triggered()
 
   QString theme = settings.value("Preferences::theme").toString();
 
-  if (theme != prev_style)
+  if (!theme.isEmpty() && theme != prev_style)
   {
     loadStyleSheet(tr(":/resources/stylesheet_%1.qss").arg(theme));
   }


### PR DESCRIPTION
This is a pretty obscure fix. But it can give new users a negative impression. Triggering the bug goes like this:

1. Either on a machine that has never run PJ or if you delete the preferences file (platform dependent: mac -> delete $HOME/.config/PlotJuggler/PlotJuggler-3.ini)
2. Start PJ
3. Go App -> Preferences
4. Click "Cancel"
5. The UI goes all weird, log states "QIODevice::read (QFile, ":/resources/stylesheet_.qss"): device not open"