### PR TITLE
Include `plotjuggler_qwt` library in install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if( CATKIN_DEVEL_PREFIX OR catkin_FOUND OR CATKIN_BUILD_BINARY_PACKAGE)
 
     catkin_package(
         INCLUDE_DIRS  plotjuggler_base/include
-        LIBRARIES  plotjuggler_base
+        LIBRARIES  plotjuggler_base plotjuggler_qwt
         CATKIN_DEPENDS roslib roscpp
     )
 
@@ -286,11 +286,7 @@ install(
      TARGETS
         plotjuggler_base
         plotjuggler_qwt
-     EXPORT ${PROJECT_NAME}Targets
-     LIBRARY DESTINATION lib
-     ARCHIVE DESTINATION lib
-     RUNTIME DESTINATION bin
-     INCLUDES DESTINATION include)
+     EXPORT ${PROJECT_NAME}Targets)
 
 install(DIRECTORY plotjuggler_base/include/ DESTINATION include )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,7 @@ add_subdirectory( plotjuggler_plugins/ParserROS )
 install(
      TARGETS
         plotjuggler_base
+        plotjuggler_qwt
      EXPORT ${PROJECT_NAME}Targets
      LIBRARY DESTINATION lib
      ARCHIVE DESTINATION lib


### PR DESCRIPTION
This allows users to build toolboxes externally, like in this project: https://github.com/zdavkeos/balyrond