### PR TITLE
Fix the bug where the shared library Parquet is not linked

### DIFF
--- a/plotjuggler_plugins/DataLoadParquet/CMakeLists.txt
+++ b/plotjuggler_plugins/DataLoadParquet/CMakeLists.txt
@@ -35,7 +35,7 @@ if(Arrow_FOUND)
     target_link_libraries(DataLoadParquet
         ${Qt5Widgets_LIBRARIES}
         ${Qt5Xml_LIBRARIES}
-        ${PARQUET_LIBRARIES}
+        ${PARQUET_SHARED_LIB}
         plotjuggler_base)
 
 


### PR DESCRIPTION
The actual path to the shared library is in `${PARQUET_SHARED_LIB}` instead of in `${PARQUET_LIBRARIES}`.

Fixes #789 