### PR TITLE
Updating COMPILE dependencies to install

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -1,10 +1,11 @@
 # Compile in Linux
 
-On Ubuntu, the dependencies can be installed with the command:
+On Ubuntu (20.04/22.04), the dependencies can be installed with the command:
 
 ```shell
 sudo apt -y install qtbase5-dev libqt5svg5-dev libqt5websockets5-dev \
-      libqt5opengl5-dev libqt5x11extras5-dev libprotoc-dev libzmq-dev
+      libqt5opengl5-dev libqt5x11extras5-dev libprotoc-dev libzmq3-dev \
+      liblz4-dev libzstd-dev
 ```
 
 On Fedora:


### PR DESCRIPTION
Taken from CI: https://github.com/facontidavide/PlotJuggler/blob/main/.github/workflows/ubuntu.yaml#L20-L31

I tried to build the package from source with those instructions and needed to update the commands. I guess Ubuntu 18.04 has EOL 30 of April, so these instructions would be more useful updated?

Note that in https://github.com/PlotJuggler/plotjuggler-ros-plugins on the ros2 branches the instructions still say `catkin build` instead of `colcon build`. That may need an update too :)