### PR TITLE
Introduce environment variables to skip dialogs to automate PlotJuggler usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ Note that this also affect the desktop launcher.
 
 You can find find the detailed instructions here: [COMPILE.md](COMPILE.md).
 
+## Auto start previously used streaming plugin
+When loading a layout that includes a streaming plugin, PlotJuggler asks `Start the previously used streaming plugin?`, in order to automatically
+click on `Yes`, you can set the environment variable: `PLOTJUGGLER_ACCEPT_PREVIOUSLY_USED_STREAMING_PLUGIN=1` and this dialog will be skipped.
+
+## Automatically choose 'Create empty placeholders' when data from a layout is missing
+When loading a layout some timeseries may be missing, PlotJuggler may ask `One or more timeseries in the layout haven't been loaded yet, What do you want to do?`, with the options: `Remove curves from plots` and `Create empty placeholders`. To automate choosing `Create empty placeholders` you can set the environment variable: `PLOTJUGGLER_CHOOSE_EMPTY_PLACEHOLDERS_ON_MISSING_TIMESERIES=1` and the dialog will be skipped chosing that option.
+
+
 # Sponsorship and commercial support
 
 PlotJuggler required a lot of work to be developed; my goal is to build the most 

--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -1071,8 +1071,20 @@ void MainWindow::checkAllCurvesFromLayout(const QDomElement& root)
     QPushButton* buttonPlaceholder =
         msgBox.addButton(tr("Create empty placeholders"), QMessageBox::YesRole);
     msgBox.setDefaultButton(buttonPlaceholder);
-    msgBox.exec();
-    if (msgBox.clickedButton() == buttonPlaceholder)
+
+    const char* env_var = std::getenv("PLOTJUGGLER_CHOOSE_EMPTY_PLACEHOLDERS_ON_MISSING_TIMESERIES");
+    bool skip_msg_box = (env_var != nullptr && env_var[0] == '1');
+    if(skip_msg_box){
+      qDebug() << "Environment variable PLOTJUGGLER_CHOOSE_EMPTY_PLACEHOLDERS_ON_MISSING_TIMESERIES set."
+          << " Skipping dialog.\n";
+      // To enable the user to choose manually in the future
+      setenv("PLOTJUGGLER_CHOOSE_EMPTY_PLACEHOLDERS_ON_MISSING_TIMESERIES", "0", 1);
+    }
+    if (!skip_msg_box){
+      msgBox.exec();
+    }
+
+    if (skip_msg_box || msgBox.clickedButton() == buttonPlaceholder)
     {
       for (auto& name : missing_curves)
       {
@@ -2059,9 +2071,18 @@ bool MainWindow::loadLayoutFromFile(QString filename)
     QPushButton* yes = msgBox.addButton(tr("Yes"), QMessageBox::YesRole);
     QPushButton* no = msgBox.addButton(tr("No"), QMessageBox::RejectRole);
     msgBox.setDefaultButton(yes);
-    msgBox.exec();
 
-    if (msgBox.clickedButton() == yes)
+    const char* env_var = std::getenv("PLOTJUGGLER_ACCEPT_PREVIOUSLY_USED_STREAMING_PLUGIN");
+    bool skip_msg_box = (env_var != nullptr && env_var[0] == '1');
+    if (skip_msg_box){
+      qDebug() << "Environment variable PLOTJUGGLER_ACCEPT_PREVIOUSLY_USED_STREAMING_PLUGIN set."
+          << " Skipping dialog.\n";
+    }
+    else{
+      msgBox.exec();
+    }
+
+    if (skip_msg_box || msgBox.clickedButton() == yes)
     {
       if (_data_streamer.count(streamer_name) != 0)
       {


### PR DESCRIPTION
First, @facontidavide let me apologize for doing this PR as I am the first one to see it is an ugly workaround, however, the functionality I think is great to have so...

Introducing the environment variables:
`PLOTJUGGLER_ACCEPT_PREVIOUSLY_USED_STREAMING_PLUGIN=1` to skip the dialog 'Start the previously used streaming plugin?' 
`PLOTJUGGLER_CHOOSE_EMPTY_PLACEHOLDERS_ON_MISSING_TIMESERIES=1` to skip the dialog 'One or more timeseries in the layout haven't been loaded yet, What do you want to do?'

Note that there is a sibling commit in plotjuggler-ros-plugins (https://github.com/PlotJuggler/plotjuggler-ros-plugins/pull/64) to skip the ROS topic selection dialog.
This is a workaround for https://github.com/facontidavide/PlotJuggler/issues/201 (passing commandline flags would require a lot of changes).

P.S.: I would have loved to pass it via commandline, but it required a lot of changes. And the plugin side would have needed many more to make it elegant. Maybe `PLOTJUGGLER_ACCEPT_PREVIOUSLY_USED_STREAMING_PLUGIN` could be implemented as a commandline plugin. Which, by the way, I did not understand what `--start_streamer` does... I thought it would do that, but I could make it do anything. My bad.
P.S.2: I do not expect this to be merged due to the lack of elegance, specially being the main PlotJuggler repo. But maybe people will want it enough to build from source. (I may).