### PR TITLE
Prevent runtime_error exceptions of plugins from crashing the main app

### DIFF
--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -618,7 +618,16 @@ QStringList MainWindow::initializePlugins(QString directory_name)
 
     QPluginLoader pluginLoader(pluginsDir.absoluteFilePath(filename), this);
 
-    QObject* plugin = pluginLoader.instance();
+    QObject* plugin;
+    try
+    {
+      plugin = pluginLoader.instance();
+    }
+    catch (std::runtime_error& err)
+    {
+      qDebug() << QString("%1: skipping, because it threw the following exception: %2").arg(filename).arg(err.what());
+      continue;
+    }
     if (plugin && dynamic_cast<PlotJugglerPlugin*>(plugin))
     {
       auto class_name = pluginLoader.metaData().value("className").toString();


### PR DESCRIPTION
If a plugin throws an exception, it crashes the main app. With this change, the exception is caught, and the throwing plugin is skipped so that the main app can continue its regular operation with the remaining plugins.

When the ROS2 plugins are being loaded without sourcing the ROS2 itself, the output after the proposed changes is as follows. Usually, this case should not be applicable, but I ran into it while I was playing with building an AppImage, and wanted to make a PR.
> ...
"libDataStreamROS2.so: skipping, because it throwed the following exception:"
"failed to initialize rcl init options: failed to get symbol 'rmw_init_options_init' due to Environment variable 'AMENT_PREFIX_PATH' is not set or empty, at ./src/functions.cpp:171, at ./src/rcl/init_options.c:75"
...
"libTopicPublisherROS2.so: skipping, because it threw the following exception:"
"failed to initialize rcl init options: failed to get symbol 'rmw_init_options_init' due to Environment variable 'AMENT_PREFIX_PATH' is not set or empty, at ./src/functions.cpp:171, at ./src/rcl/init_options.c:75"
...
