### PR TITLE
fix(snap): add libzstd for mcap support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -78,12 +78,14 @@ parts:
       - libgl-dev
       - libmosquitto-dev
       - libzmq3-dev
+      - libzstd-dev
     stage-packages:
       - libdw1
       - libmosquitto1
       - libprotobuf17
       - libprotobuf-dev
       - libzmq5
+      - libzstd1
     override-pull: |
         snapcraftctl pull
 


### PR DESCRIPTION
Due to `libzstd` missing Plotjuggler was not building the `MCAP` plugin in the snap.

Partially solve: https://github.com/facontidavide/PlotJuggler/issues/783