### PR TITLE
Add support for building AppImage via docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+.git/

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -76,6 +76,12 @@ cp -v install/bin/* AppDir/usr/bin
     --plugin qt --output appimage
 ```
 
+## Deploy as an AppImage via Docker
+
+```shell
+docker buildx build -o . .
+```
+
 # Compile in Mac
 
 On Mac, the dependencies can be installed using [brew](https://brew.sh/) with the following command:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
-#Download base image ubuntu 18.04
-FROM ubuntu:18.04
+FROM ubuntu:22.04 as builder
 
-RUN apt update
+RUN apt-get update && \
+    apt-get -y install cmake build-essential wget file qtbase5-dev libqt5svg5-dev libqt5websockets5-dev libqt5opengl5-dev libqt5x11extras5-dev libprotoc-dev libzmq3-dev liblz4-dev libzstd-dev libmosquittopp-dev
 
-RUN apt install cmake git build-essential qtbase5-dev libqt5svg5-dev libqt5websockets5-dev libqt5opengl5-dev libqt5x11extras5-dev nano qt5-default -y && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt clean
+RUN mkdir -p /opt/plotjuggler
+COPY . /opt/plotjuggler
+RUN mkdir /opt/plotjuggler/build
+WORKDIR /opt/plotjuggler/build
+RUN cmake .. -DCMAKE_INSTALL_PREFIX=/usr 
+RUN make -j `nproc`
+RUN make install DESTDIR=AppDir
+RUN /opt/plotjuggler/appimage/AppImage.sh
 
+FROM scratch as exporter
+COPY --from=builder /opt/plotjuggler/build/PlotJuggler-x86_64.AppImage /
 

--- a/appimage/AppImage.sh
+++ b/appimage/AppImage.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+APPDIRPATH=../build/AppDir
+
+# Uses linuxdeploy with linuxdeploy-plugin-qt to generate an AppImage
+LINUXDEPLOY_URL="https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
+LINUXDEPLOY_QT_URL="https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
+
+LINUXDEPLOY_APPIMAGE="linuxdeploy-x86_64.AppImage"
+LINUXDEPLOY_QT_APPIMAGE="linuxdeploy-plugin-qt-x86_64.AppImage"
+
+# Get and extract linuxdeploy AppImage. Extraction is necessary since we are in a container without FUSE support
+wget ${LINUXDEPLOY_URL}
+chmod +x ${LINUXDEPLOY_APPIMAGE}
+mkdir linuxdeploy/
+mv ${LINUXDEPLOY_APPIMAGE} linuxdeploy/
+cd linuxdeploy
+./${LINUXDEPLOY_APPIMAGE} --appimage-extract
+cd -
+
+# Same for the plugin
+wget ${LINUXDEPLOY_QT_URL}
+chmod +x ${LINUXDEPLOY_QT_APPIMAGE}
+mkdir linuxdeploy-plugin-qt/
+mv ${LINUXDEPLOY_QT_APPIMAGE} linuxdeploy-plugin-qt/
+cd linuxdeploy-plugin-qt
+./${LINUXDEPLOY_QT_APPIMAGE} --appimage-extract
+# Rename the plugin to match linuxdeploy's expected format
+mv squashfs-root/AppRun squashfs-root/linuxdeploy-plugin-qt
+cd -
+
+PATH=$PATH:linuxdeploy-plugin-qt/squashfs-root ./linuxdeploy/squashfs-root/AppRun --appdir $APPDIRPATH -d ../PlotJuggler.desktop -i ../plotjuggler.png --plugin qt --output appimage 
+


### PR DESCRIPTION
## Changes

* Revise the Dockerfile to successfully compile PlotJuggler with MQTT & ZMQ plugins
* Adds a script to compile an AppImage from within the docker environment; this will also work standalone

## Test

`docker buildx build -o . .` results a in `PlotJuggler-x86_x64.AppImage` which has been tested to have a working MQTT client via mosquitto