### PR TITLE
Add missing cstdint include

### DIFF
--- a/plotjuggler_base/include/PlotJuggler/special_messages.h
+++ b/plotjuggler_base/include/PlotJuggler/special_messages.h
@@ -6,6 +6,7 @@
 
 #include <vector>
 #include <string>
+#include <cstdint>
 
 namespace PJ::Msg
 {

--- a/plotjuggler_plugins/DataLoadULog/ulog_parser.h
+++ b/plotjuggler_plugins/DataLoadULog/ulog_parser.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <set>
 #include <string.h>
+#include <cstdint>
 
 #include "string_view.hpp"
 


### PR DESCRIPTION
Plotjuggler's fails to build on my machine. There seems to be a missing include of cstdint.

```
λ g++ --version
g++ (GCC) 13.1.1 20230429
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
```
[  0%] Automatic MOC and UIC for target plotjuggler_base
[  0%] Automatic MOC and UIC for target lz4_static
[  0%] Automatic MOC and UIC for target plotjuggler_qwt
[  0%] Automatic MOC and UIC for target plotjuggler_qwt_objects
[  0%] Automatic MOC and UIC for target lua_static
[  0%] Automatic MOC and UIC for target QCodeEditor
[  0%] Automatic MOC and UIC for target colorwidgets
[  0%] Automatic MOC and UIC for target qt_advanced_docking
[  0%] Built target plotjuggler_base_autogen
[  0%] Built target lz4_static_autogen
[  0%] Built target lua_static_autogen
[  0%] Built target colorwidgets_autogen
[  0%] Built target plotjuggler_qwt_autogen
[  0%] Built target plotjuggler_qwt_objects_autogen
[  0%] Built target qt_advanced_docking_autogen
[  0%] Built target QCodeEditor_autogen
[  1%] Automatic MOC and UIC for target lua_objects
[  1%] Automatic MOC and UIC for target backward_object
[  2%] Automatic MOC and UIC for target backward
[  3%] Automatic MOC and UIC for target fastcdr
[  3%] Automatic MOC and UIC for target kissfft
[  3%] Built target lua_objects_autogen
[  3%] Built target backward_object_autogen
[  3%] Built target backward_autogen
[  3%] Building CXX object CMakeFiles/plotjuggler_base.dir/plotjuggler_base/src/special_messages.cpp.o
[  3%] Built target kissfft_autogen
[  3%] Built target fastcdr_autogen
[  5%] Built target lz4_static
[  9%] Built target QCodeEditor
[ 11%] Built target colorwidgets
[ 17%] Built target lua_static
[ 35%] Built target plotjuggler_qwt
[ 40%] Built target qt_advanced_docking
[ 57%] Built target plotjuggler_qwt_objects
[ 63%] Built target lua_objects
[ 64%] Built target backward
[ 64%] Built target kissfft
[ 64%] Built target backward_object
[ 65%] Built target fastcdr
[ 66%] Automatic MOC and UIC for target rosx_introspection
[ 66%] Built target rosx_introspection_autogen
[ 67%] Built target rosx_introspection
In file included from /home/joaj/sources/PlotJuggler/plotjuggler_base/src/special_messages.cpp:1:
/home/joaj/sources/PlotJuggler/plotjuggler_base/include/PlotJuggler/special_messages.h:15:3: error: ‘uint32_t’ does not name a type
   15 |   uint32_t sec;
      |   ^~~~~~~~
/home/joaj/sources/PlotJuggler/plotjuggler_base/include/PlotJuggler/special_messages.h:9:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
    8 | #include <string>
  +++ |+#include <cstdint>
    9 |
/home/joaj/sources/PlotJuggler/plotjuggler_base/include/PlotJuggler/special_messages.h:16:3: error: ‘uint32_t’ does not name a type
   16 |   uint32_t nanosec;
      |   ^~~~~~~~
/home/joaj/sources/PlotJuggler/plotjuggler_base/include/PlotJuggler/special_messages.h:16:3: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/joaj/sources/PlotJuggler/plotjuggler_base/include/PlotJuggler/special_messages.h: In member function ‘double PJ::Msg::Time::toSec() const’:
/home/joaj/sources/PlotJuggler/plotjuggler_base/include/PlotJuggler/special_messages.h:20:19: error: ‘sec’ was not declared in this scope
   20 |     return double(sec) + double(nanosec)*1e-9;
      |                   ^~~
/home/joaj/sources/PlotJuggler/plotjuggler_base/include/PlotJuggler/special_messages.h:20:33: error: ‘nanosec’ was not declared in this scope
   20 |     return double(sec) + double(nanosec)*1e-9;
      |                                 ^~~~~~~
/home/joaj/sources/PlotJuggler/plotjuggler_base/include/PlotJuggler/special_messages.h: At global scope:
/home/joaj/sources/PlotJuggler/plotjuggler_base/include/PlotJuggler/special_messages.h:26:3: error: ‘uint32_t’ does not name a type
   26 |   uint32_t seq;
      |   ^~~~~~~~
/home/joaj/sources/PlotJuggler/plotjuggler_base/include/PlotJuggler/special_messages.h:26:3: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/joaj/sources/PlotJuggler/plotjuggler_base/include/PlotJuggler/special_messages.h:33:3: error: ‘uint8_t’ does not name a type
   33 |   uint8_t level;
      |   ^~~~~~~
/home/joaj/sources/PlotJuggler/plotjuggler_base/include/PlotJuggler/special_messages.h:33:3: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
make[2]: *** [CMakeFiles/plotjuggler_base.dir/build.make:254: CMakeFiles/plotjuggler_base.dir/plotjuggler_base/src/special_messages.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:637: CMakeFiles/plotjuggler_base.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```