### PR TITLE
Fix memory leak in protobuf parser

### DIFF
--- a/plotjuggler_plugins/ParserProtobuf/protobuf_parser.cpp
+++ b/plotjuggler_plugins/ParserProtobuf/protobuf_parser.cpp
@@ -228,7 +228,8 @@ bool ProtobufParser::parseMessage(const MessageRef serialized_msg,
 
   // start recursion
   ParseImpl(*mutable_msg, _topic_name, false);
-
+  
+  delete mutable_msg;
   return true;
 }
 


### PR DESCRIPTION
Here in `ProtobufParser::parseMessage()` we allocate with no further deallocation:
```
google::protobuf::Message* mutable_msg = prototype_msg->New();
```
