### PR TITLE
Add support for Protobuf message timestamp

### DIFF
--- a/plotjuggler_plugins/ParserProtobuf/protobuf_parser.cpp
+++ b/plotjuggler_plugins/ParserProtobuf/protobuf_parser.cpp
@@ -228,7 +228,8 @@ bool ProtobufParser::parseMessage(const MessageRef serialized_msg,
 
   // start recursion
   ParseImpl(*mutable_msg, _topic_name, false);
-
+  
+  delete mutable_msg;
   return true;
 }
 

--- a/plotjuggler_plugins/ParserProtobuf/protobuf_parser.h
+++ b/plotjuggler_plugins/ParserProtobuf/protobuf_parser.h
@@ -12,6 +12,7 @@
 
 #include "error_collectors.h"
 #include "PlotJuggler/messageparser_base.h"
+#include <optional>
 
 using namespace PJ;
 
@@ -19,13 +20,7 @@ class ProtobufParser : public MessageParser
 {
 public:
   ProtobufParser(const std::string& topic_name,
-                 const google::protobuf::Descriptor* descriptor,
-                 PlotDataMapRef& data)
-    : MessageParser(topic_name, data)
-    , _proto_pool(&_proto_database)
-    , _msg_descriptor(descriptor)
-  {
-  }
+                 const google::protobuf::Descriptor* descriptor, PlotDataMapRef& data);
 
   ProtobufParser(const std::string& topic_name,
                  const std::string type_name,
@@ -35,14 +30,11 @@ public:
   bool parseMessage(const MessageRef serialized_msg, double& timestamp) override;
 
 protected:
+  std::optional<unsigned int> _timestamp_field_id;
 
   google::protobuf::SimpleDescriptorDatabase _proto_database;
   google::protobuf::DescriptorPool _proto_pool;
 
   google::protobuf::DynamicMessageFactory _msg_factory;
   const google::protobuf::Descriptor* _msg_descriptor = nullptr;
-
 };
-
-
-


### PR DESCRIPTION
Please see #832 for description.

Now Protobuf Parser uses value from message "timestamp" field if such is available.