### PR TITLE
remove deprecated msg from snapcraft

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -165,7 +165,6 @@ parts:
       - ros-foxy-ackermann-msgs
       - ros-foxy-action-msgs
       - ros-foxy-actionlib-msgs
-      - ros-foxy-astuff-sensor-msgs
       - ros-foxy-automotive-autonomy-msgs
       - ros-foxy-automotive-navigation-msgs
       - ros-foxy-automotive-platform-msgs


### PR DESCRIPTION
https://github.com/astuff/astuff_sensor_msgs/commit/583e90b4a97173d0f0d0c4b564a4d5879d6dcc4e  