### PR TITLE
Add multicast support to DataStreamUDP.

### DIFF
--- a/plotjuggler_plugins/DataStreamUDP/udp_client.py
+++ b/plotjuggler_plugins/DataStreamUDP/udp_client.py
@@ -1,9 +1,15 @@
 #!/usr/bin/python
 
+import argparse
 import socket
 import math
 import json
 from time import sleep
+
+parser = argparse.ArgumentParser(description="Send UDP test data.")
+parser.add_argument("--address", default="127.0.0.1", help="UDP address")
+parser.add_argument("--port", default=9870, type=int, help="UDP port")
+args = parser.parse_args()
 
 sock = socket.socket(socket.AF_INET, # Internet
                      socket.SOCK_DGRAM) # UDP
@@ -20,8 +26,8 @@ while True:
             "sin": math.sin(time)
         }
     }
-    sock.sendto( json.dumps(data).encode(), ("127.0.0.1", 9870) )
-    
+    sock.sendto( json.dumps(data).encode(), (args.address, args.port) )
+
     test_str = "{ \
 	  \"1252\": { \
 	    \"timestamp\": { \
@@ -35,7 +41,7 @@ while True:
 		\"volt\": 24.852617263793945 \
 	      }\
 	    }\
-	  } }" 
-   
-    sock.sendto( test_str.encode('utf-8'), ("127.0.0.1", 9870) )
+	  } }"
+
+    sock.sendto( test_str.encode("utf-8"), (args.address, args.port) )
 

--- a/plotjuggler_plugins/DataStreamUDP/udp_server.cpp
+++ b/plotjuggler_plugins/DataStreamUDP/udp_server.cpp
@@ -97,8 +97,10 @@ bool UDP_Server::start(QStringList*)
   // load previous values
   QSettings settings;
   QString protocol = settings.value("UDP_Server::protocol", "JSON").toString();
+  QString address_str = settings.value("UDP_Server::address", "127.0.0.1").toString();
   int port = settings.value("UDP_Server::port", 9870).toInt();
 
+  dialog.ui->lineEditAddress->setText(address_str);
   dialog.ui->lineEditPort->setText(QString::number(port));
 
   ParserFactoryPlugin::Ptr parser_creator;
@@ -130,6 +132,7 @@ bool UDP_Server::start(QStringList*)
     return false;
   }
 
+  address_str = dialog.ui->lineEditAddress->text();
   port = dialog.ui->lineEditPort->text().toUShort(&ok);
   protocol = dialog.ui->comboBoxProtocol->currentText();
 
@@ -137,23 +140,41 @@ bool UDP_Server::start(QStringList*)
 
   // save back to service
   settings.setValue("UDP_Server::protocol", protocol);
+  settings.setValue("UDP_Server::address", address_str);
   settings.setValue("UDP_Server::port", port);
 
+  QHostAddress address(address_str);
+
+  bool success = true;
+  success &= !address.isNull();
+
   _udp_socket = new QUdpSocket();
-  _udp_socket->bind(QHostAddress::Any, port);
+
+  if (!address.isMulticast())
+  {
+    success &= _udp_socket->bind(address, port);
+  }
+  else
+  {
+    success &= _udp_socket->bind(
+        address, port, QAbstractSocket::ShareAddress | QAbstractSocket::ReuseAddressHint);
+    success &= _udp_socket->joinMulticastGroup(address);
+  }
+
+  _running = true;
 
   connect(_udp_socket, &QUdpSocket::readyRead, this, &UDP_Server::processMessage);
 
-  if (_udp_socket)
+  if (success)
   {
-    qDebug() << "UDP listening on port" << port;
-    _running = true;
+    qDebug() << tr("UDP listening on (%1, %2)").arg(address_str).arg(port);
   }
   else
   {
     QMessageBox::warning(nullptr, tr("UDP Server"),
-                         tr("Couldn't bind UDP port %1").arg(port), QMessageBox::Ok);
-    _running = false;
+                         tr("Couldn't bind to UDP (%1, %2)").arg(address_str).arg(port),
+                         QMessageBox::Ok);
+    shutdown();
   }
 
   return _running;

--- a/plotjuggler_plugins/DataStreamUDP/udp_server.ui
+++ b/plotjuggler_plugins/DataStreamUDP/udp_server.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>293</width>
-    <height>232</height>
+    <width>298</width>
+    <height>312</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,24 +19,65 @@
      <property name="font">
       <font>
        <pointsize>12</pointsize>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
      <property name="text">
-      <string>Port of the UDP server:</string>
+      <string>UDP Server Settings:</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QLineEdit" name="lineEditPort"/>
+    <widget class="QWidget" name="widget_2" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <item>
+       <widget class="QLabel" name="label_5">
+        <property name="font">
+         <font>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>Address:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="lineEditAddress"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
+      <item>
+       <widget class="QLabel" name="label_4">
+        <property name="font">
+         <font>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>Port:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="lineEditPort">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
        <pointsize>12</pointsize>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -67,7 +108,6 @@
        <widget class="QLabel" name="label_3">
         <property name="font">
          <font>
-          <weight>75</weight>
           <bold>true</bold>
          </font>
         </property>


### PR DESCRIPTION
This adds the ability to specify a address other than 127.0.0.1 when starting DataStreamUDP.  If the address is a multicast address the UDP socket is configured to join the multicast group.