### PR TITLE
Remove deprecated messages from foxy

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -232,7 +232,6 @@ parts:
       - ros-foxy-object-recognition-msgs
       - ros-foxy-octomap-msgs
       - ros-foxy-ouster-msgs
-      - ros-foxy-pacmod-msgs
       - ros-foxy-pcl-msgs
       - ros-foxy-pendulum-msgs
       - ros-foxy-phidgets-msgs


### PR DESCRIPTION
It seems astuff/pacmod msgs are changing frequently and the original name is no longer present in the ppa