### PR TITLE
Add "Steps" when drawing curves

### DIFF
--- a/plotjuggler_app/plotwidget.cpp
+++ b/plotjuggler_app/plotwidget.cpp
@@ -670,6 +670,10 @@ QDomElement PlotWidget::xmlSaveState(QDomDocument& doc) const
   {
     plot_el.setAttribute("style", "Sticks");
   }
+  else if (curveStyle() == PlotWidgetBase::STEPS)
+  {
+    plot_el.setAttribute("style", "Steps");
+  }
 
   for (auto& it : curveList())
   {
@@ -868,6 +872,10 @@ bool PlotWidget::xmlLoadState(QDomElement& plot_widget, bool autozoom)
     else if (style == "Sticks")
     {
       changeCurvesStyle(PlotWidgetBase::STICKS);
+    }
+    else if (style == "Steps")
+    {
+      changeCurvesStyle(PlotWidgetBase::STEPS);
     }
   }
 

--- a/plotjuggler_app/plotwidget_editor.cpp
+++ b/plotjuggler_app/plotwidget_editor.cpp
@@ -64,6 +64,10 @@ PlotwidgetEditor::PlotwidgetEditor(PlotWidget* plotwidget, QWidget* parent)
   {
     ui->radioSticks->setChecked(true);
   }
+  else if (_plotwidget->curveStyle() == PlotWidgetBase::STEPS)
+  {
+    ui->radioSteps->setChecked(true);
+  }
   else
   {
     ui->radioBoth->setChecked(true);
@@ -305,6 +309,14 @@ void PlotwidgetEditor::on_radioSticks_toggled(bool checked)
   if (checked)
   {
     _plotwidget->changeCurvesStyle(PlotWidgetBase::STICKS);
+  }
+}
+
+void PlotwidgetEditor::on_radioSteps_toggled(bool checked)
+{
+  if (checked)
+  {
+    _plotwidget->changeCurvesStyle(PlotWidgetBase::STEPS);
   }
 }
 

--- a/plotjuggler_app/plotwidget_editor.h
+++ b/plotjuggler_app/plotwidget_editor.h
@@ -84,6 +84,8 @@ private slots:
 
   void on_radioSticks_toggled(bool checked);
 
+  void on_radioSteps_toggled(bool checked);
+
 private:
   Ui::PlotWidgetEditor* ui;
 

--- a/plotjuggler_app/plotwidget_editor.ui
+++ b/plotjuggler_app/plotwidget_editor.ui
@@ -341,6 +341,13 @@
               </property>
              </widget>
             </item>
+             <item>
+             <widget class="QRadioButton" name="radioSteps">
+              <property name="text">
+               <string>Steps</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>

--- a/plotjuggler_base/include/PlotJuggler/plotwidget_base.h
+++ b/plotjuggler_base/include/PlotJuggler/plotwidget_base.h
@@ -32,7 +32,8 @@ public:
     LINES,
     DOTS,
     LINES_AND_DOTS,
-    STICKS
+    STICKS,
+    STEPS
   };
 
   struct CurveInfo

--- a/plotjuggler_base/src/plotwidget_base.cpp
+++ b/plotjuggler_base/src/plotwidget_base.cpp
@@ -720,6 +720,10 @@ void PlotWidgetBase::setStyle(QwtPlotCurve* curve, CurveStyle style)
       break;
     case STICKS:
       curve->setStyle(QwtPlotCurve::Sticks);
+      break;
+    case STEPS:
+      curve->setStyle(QwtPlotCurve::Steps);
+      break;
   }
 }
 


### PR DESCRIPTION
As requested by issue #866. Step-wise interpolation between points (already supported by qwt).

<img width="659" alt="pj_steps" src="https://github.com/facontidavide/PlotJuggler/assets/172684/940716eb-1004-4e71-a520-d0477ae472ee">
