### PR TITLE
Fix missing '22' in the new snap core22 workflow

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -83,5 +83,5 @@ jobs:
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
       with:
-        snap: ${{needs.build.outputs.snap-file}}
+        snap: ${{needs.build22.outputs.snap-file}}
         release: humble/${{ startsWith(github.ref, 'refs/tags/') && 'candidate' || 'edge'}}


### PR DESCRIPTION
I am very sorry I missed that line when preparing the core22 snap workflow. 
Note that the store credentials need a refresh as described in https://github.com/facontidavide/PlotJuggler/actions/runs/6254336114/job/16982529217
```
Exported credentials are no longer valid for the Snap Store.
Recommended resolution: Run export-login and update SNAPCRAFT_STORE_CREDENTIALS.
For more information, check out: https://snapcraft.io/docs/snapcraft-authentication
```
So even with this fix the above secret has to be taken care of by @facontidavide directly in the secrets.STORE_LOGIN 