### PR TITLE
Allow multiple publishers to ZMQ Data Stream

### DIFF
--- a/plotjuggler_plugins/DataStreamZMQ/datastream_zmq.cpp
+++ b/plotjuggler_plugins/DataStreamZMQ/datastream_zmq.cpp
@@ -126,7 +126,7 @@ bool DataStreamZMQ::start(QStringList*)
       (dialog->ui->comboBox->currentText() + address + ":" + QString::number(port))
           .toStdString();
 
-  _zmq_socket.connect(_socket_address.c_str());
+  _zmq_socket.bind(_socket_address.c_str());
 
   parseTopicFilters(topics);
   subscribeTopics();

--- a/plotjuggler_plugins/DataStreamZMQ/datastream_zmq.cpp
+++ b/plotjuggler_plugins/DataStreamZMQ/datastream_zmq.cpp
@@ -126,7 +126,14 @@ bool DataStreamZMQ::start(QStringList*)
       (dialog->ui->comboBox->currentText() + address + ":" + QString::number(port))
           .toStdString();
 
-  _zmq_socket.bind(_socket_address.c_str());
+  if (dialog->ui->radioConnect->isChecked())
+  {
+    _zmq_socket.connect(_socket_address.c_str());
+  }
+  else
+  {
+    _zmq_socket.bind(_socket_address.c_str());
+  }
 
   parseTopicFilters(topics);
   subscribeTopics();

--- a/plotjuggler_plugins/DataStreamZMQ/datastream_zmq.ui
+++ b/plotjuggler_plugins/DataStreamZMQ/datastream_zmq.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -162,6 +162,42 @@
    </item>
    <item>
     <widget class="QLineEdit" name="lineEditTopics"/>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_7">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Socket Type:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QRadioButton" name="radioConnect">
+      <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+      </property>
+      <property name="text">
+        <string>Connect (Single Publisher / Multiple Subscribers)</string>
+      </property>
+      <property name="checked">
+        <bool>true</bool>
+      </property>
+    </widget>
+   </item>
+   <item>   
+    <widget class="QRadioButton" name="radioBind">
+      <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+      </property>
+      <property name="text">
+        <string>Bind (Multiple Publisher / Single Subscribers)</string>
+      </property>
+    </widget>
    </item>
    <item>
     <spacer name="verticalSpacer">

--- a/plotjuggler_plugins/DataStreamZMQ/datastream_zmq.ui
+++ b/plotjuggler_plugins/DataStreamZMQ/datastream_zmq.ui
@@ -182,7 +182,7 @@
         <enum>Qt::NoFocus</enum>
       </property>
       <property name="text">
-        <string>Connect (Single Publisher / Multiple Subscribers)</string>
+        <string>Connect (Single Data Source / Multiple PlotJugglers)</string>
       </property>
       <property name="checked">
         <bool>true</bool>
@@ -195,7 +195,7 @@
         <enum>Qt::NoFocus</enum>
       </property>
       <property name="text">
-        <string>Bind (Multiple Publisher / Single Subscribers)</string>
+        <string>Bind (Multiple Data Sources / Single PlotJuggler)</string>
       </property>
     </widget>
    </item>


### PR DESCRIPTION
I couldn't see a way for PlotJuggler to subscribe to multiple ZMQ publishers. However, if the PJ ZMQ Data Stream subscriber changes `connect` to `bind` then multiple publishers can use the same endpoint and PJ gets all the data (Stack Overflow question for [reference](https://stackoverflow.com/a/67752410)). 

This is feature is useful in a few scenarios. For example,
- when you have more than one application running and want to visualise data from both at the same time; or
- when you wish to run the same algorithm but with slightly different parameters and visualise the difference in real-time.

This implementation would require existing PlotJuggler users employing the ZMQ DataStream plugin to change their publisher from bind to connect in their code.

Can be tested using the following two Python Scripts

```python
# pub1.py
import math
import time
import zmq

if __name__ == "__main__":
    context = zmq.Context()
    publisher = context.socket(zmq.PUB)
    publisher.connect("tcp://127.0.0.1:12345") 

    idx = 0
    while True:
        time.sleep(1)
        val = math.sin(idx)
        data = {"idx1": idx, "val1": val}
        publisher.send_json(data)
        idx += 1
        print("Published:", data)
```

```python
# pub2.py
import math
import time
import zmq

if __name__ == "__main__":
    context = zmq.Context()
    publisher = context.socket(zmq.PUB)
    publisher.connect("tcp://127.0.0.1:12345") 

    idx = 0
    while True:
        time.sleep(1)
        val = math.cos(idx)
        data = {"idx2": idx, "val2": val}
        publisher.send_json(data)
        idx += 1
        print("Published:", data)
```