### PR TITLE
Set the window title to the currently loaded log file name

### DIFF
--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -1527,6 +1527,8 @@ std::unordered_set<std::string> MainWindow::loadDataFromFile(const FileLoadInfo&
 
       if (dataloader->readDataFromFile(&new_info, mapped_data))
       {
+        setWindowTitle(info.filename);
+
         AddPrefixToPlotData(info.prefix.toStdString(), mapped_data.numeric);
         AddPrefixToPlotData(info.prefix.toStdString(), mapped_data.strings);
 


### PR DESCRIPTION
When I use multiple PlotJuggler applications, I am always confused about which PlotJuggler window is associated with the log I am looking for.

To alleviate discomfort, I set the window title to the loaded log file name. It's a simple function, but I believe it's incredibly helpful.