### PR TITLE
BUGFIX: Parsing of Diagnostic Status Msg

### DIFF
--- a/plotjuggler_plugins/ParserROS/ros_parser.cpp
+++ b/plotjuggler_plugins/ParserROS/ros_parser.cpp
@@ -26,7 +26,7 @@ ParserROS::ParserROS(const std::string& topic_name, const std::string& type_name
 
   using std::placeholders::_1;
   using std::placeholders::_2;
-  if (Msg::DiagnosticStatus::id() == type_name)
+  if (Msg::DiagnosticArray::id() == type_name)
   {
     _customized_parser = std::bind(&ParserROS::parseDiagnosticMsg, this, _1, _2);
   }


### PR DESCRIPTION
With the current version, DataLoadRos2 throws a "Not Enough Memory in the Buffer Stream" Error when Loading
a `diagnostic_msgs/DiagnosticStatus.msg` from a rosbag.
![image](https://github.com/facontidavide/PlotJuggler/assets/103186148/74f99936-fa70-49ca-b0df-4398123caf6c)

This is IMO caused by typo while creating the specialized ros parsers. In there, the DiagnosticArray is mixed up with up the DiagnosticStatus message. As a result, the diagnostic status is tried to be deserialized as DiagnosticArray, which throws the aforementioned Exception.

Switching to the correct msg type fixes the issue for me.
