### PR TITLE
PlotJuggler with Fast-CDR-2.x.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.27.2)
+# cmake version constrained by Ubuntu 20.04
+cmake_minimum_required(VERSION 3.16.3)
 
 PROJECT(plotjuggler LANGUAGES C CXX VERSION 3.8.8)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.27.2)
 
 PROJECT(plotjuggler LANGUAGES C CXX VERSION 3.8.8)
 

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/Cdr.h
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/Cdr.h
@@ -15,3417 +15,3394 @@
 #ifndef _FASTCDR_CDR_H_
 #define _FASTCDR_CDR_H_
 
-#include "fastcdr_dll.h"
-#include "FastBuffer.h"
-#include "exceptions/NotEnoughMemoryException.h"
-#include <stdint.h>
-#include <string>
-#include <vector>
+#include <array>
+#include <bitset>
+#include <cassert>
+#include <cstdint>
+#include <functional>
 #include <map>
-#include <iostream>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "fastcdr_dll.h"
+
+#include "CdrEncoding.hpp"
+#include "cdr/fixed_size_string.hpp"
+#include "detail/container_recursive_inspector.hpp"
+#include "exceptions/BadParamException.h"
+#include "exceptions/Exception.h"
+#include "exceptions/NotEnoughMemoryException.h"
+#include "FastBuffer.h"
+#include "xcdr/external.hpp"
+#include "xcdr/MemberId.hpp"
+#include "xcdr/optional.hpp"
 
 #if !__APPLE__ && !__FreeBSD__ && !__VXWORKS__
 #include <malloc.h>
 #else
 #include <stdlib.h>
-#endif  // if !__APPLE__ && !__FreeBSD__ && !__VXWORKS__
+#endif // if !__APPLE__ && !__FreeBSD__ && !__VXWORKS__
 
-#if HAVE_CXX0X
-#include <array>
-#endif  // if HAVE_CXX0X
+namespace eprosima {
+namespace fastcdr {
 
-namespace eprosima
-{
-namespace fastcdr
-{
+class Cdr;
+
+template<class _T>
+extern void serialize(
+        Cdr&,
+        const _T&);
+
+template<class _T>
+extern void deserialize(
+        Cdr&,
+        _T&);
+
 /*!
- * @brief This class offers an interface to serialize/deserialize some basic types using
- * CDR protocol inside an eprosima::fastcdr::FastBuffer.
+ * @brief This class offers an interface to serialize/deserialize some basic types using CDR protocol inside an eprosima::fastcdr::FastBuffer.
  * @ingroup FASTCDRAPIREFERENCE
  */
-class Cdr_DllAPI Cdr
+class Cdr
 {
 public:
-  //! @brief This enumeration represents the two kinds of CDR serialization supported by
-  //! eprosima::fastcdr::CDR.
-  typedef enum
-  {
-    //! @brief Common CORBA CDR serialization.
-    CORBA_CDR,
-    //! @brief DDS CDR serialization.
-    DDS_CDR
-  } CdrType;
-
-  //! @brief This enumeration represents the two posible values of the flag that points if
-  //! the content is a parameter list (only in DDS CDR).
-
-#ifdef HAVE_CXX0X
-  typedef enum : uint8_t
-#else
-  typedef enum
-#endif  // ifdef HAVE_CXX0X
-  {
-    //! @brief Specifies that the content is not a parameter list.
-    DDS_CDR_WITHOUT_PL = 0x0,
-    //! @brief Specifies that the content is a parameter list.
-    DDS_CDR_WITH_PL = 0x2
-  } DDSCdrPlFlag;
-
-  /*!
-   * @brief This enumeration represents endianness types.
-   */
-#ifdef HAVE_CXX0X
-  typedef enum : uint8_t
-#else
-  typedef enum
-#endif  // ifdef HAVE_CXX0X
-  {
-    //! @brief Big endianness.
-    BIG_ENDIANNESS = 0x0,
-    //! @brief Little endianness.
-    LITTLE_ENDIANNESS = 0x1
-  } Endianness;
-
-  //! @brief Default endiness in the system.
-  static const Endianness DEFAULT_ENDIAN;
-
-  /*!
-   * @brief This class stores the current state of a CDR serialization.
-   */
-  class Cdr_DllAPI state
-  {
-    friend class Cdr;
-
-  public:
-    /*!
-     * @brief Default constructor.
-     */
-    state(const Cdr& cdr);
 
     /*!
-     * @brief Copy constructor.
+     * @brief This enumeration represents endianness types.
      */
-    state(const state&);
-
-  private:
-    state& operator=(const state&) = delete;
-
-    //! @brief The position in the buffer when the state was created.
-    const FastBuffer::iterator m_currentPosition;
-
-    //! @brief The position from the aligment is calculated,  when the state was created..
-    const FastBuffer::iterator m_alignPosition;
-
-    //! @brief This attribute specified if it is needed to swap the bytes when the state
-    //! was created..
-    bool m_swapBytes;
-
-    //! @brief Stores the last datasize serialized/deserialized when the state was
-    //! created.
-    size_t m_lastDataSize;
-  };
-
-  /*!
-   * @brief This constructor creates an eprosima::fastcdr::Cdr object that can
-   * serialize/deserialize the assigned buffer.
-   *
-   * @param cdrBuffer A reference to the buffer that contains (or will contain) the CDR
-   * representation.
-   * @param endianness The initial endianness that will be used. The default value is the
-   * endianness of the system.
-   * @param cdrType Represents the type of CDR that will be used in
-   * serialization/deserialization. The default value is CORBA CDR.
-   */
-  Cdr(FastBuffer& cdrBuffer, const Endianness endianness = DEFAULT_ENDIAN,
-      const CdrType cdrType = CORBA_CDR);
-
-  /*!
-   * @brief This function reads the encapsulation of the CDR stream.
-   *        If the CDR stream contains an encapsulation, then this function should be
-   * called before starting to deserialize.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   * @exception exception::BadParamException This exception is thrown when trying to
-   * deserialize an invalid value.
-   */
-  Cdr& read_encapsulation();
-
-  /*!
-   * @brief This function writes the encapsulation of the CDR stream.
-   *        If the CDR stream should contain an encapsulation, then this function should
-   * be called before starting to serialize.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize_encapsulation();
-
-  /*!
-   * @brief This function returns the parameter list flag when the CDR type is
-   * eprosima::fastcdr::DDS_CDR.
-   * @return The flag that specifies if the content is a parameter list.
-   */
-  DDSCdrPlFlag getDDSCdrPlFlag() const;
-
-  /*!
-   * @brief This function sets the parameter list flag when the CDR type is
-   * eprosima::fastcdr::DDS_CDR.
-   * @param plFlag New value for the flag that specifies if the content is a parameter
-   * list.
-   */
-  void setDDSCdrPlFlag(DDSCdrPlFlag plFlag);
-
-  /*!
-   * @brief This function returns the option flags when the CDR type is
-   * eprosima::fastcdr::DDS_CDR.
-   * @return The option flags.
-   */
-  uint16_t getDDSCdrOptions() const;
-
-  /*!
-   * @brief This function sets the option flags when the CDR type is
-   * eprosima::fastcdr::DDS_CDR.
-   * @param options New value for the option flags.
-   */
-  void setDDSCdrOptions(uint16_t options);
-
-  /*!
-   * @brief This function sets the current endianness used by the CDR type.
-   * @param endianness The new endianness value.
-   */
-  void changeEndianness(Endianness endianness);
-
-  /*!
-   * @brief This function returns the current endianness used by the CDR type.
-   * @return The endianness.
-   */
-  Endianness endianness() const
-  {
-    return static_cast<Endianness>(m_endianness);
-  }
-
-  /*!
-   * @brief This function skips a number of bytes in the CDR stream buffer.
-   * @param numBytes The number of bytes that will be jumped.
-   * @return True is returned when it works successfully. Otherwise, false is returned.
-   */
-  bool jump(size_t numBytes);
-
-  /*!
-   * @brief This function resets the current position in the buffer to the beginning.
-   */
-  void reset();
-
-  /*!
-   * @brief This function returns the pointer to the current used buffer.
-   * @return Pointer to the starting position of the buffer.
-   */
-  char* getBufferPointer();
-
-  /*!
-   * @brief This function returns the current position in the CDR stream.
-   * @return Pointer to the current position in the buffer.
-   */
-  char* getCurrentPosition();
-
-  /*!
-   * @brief This function returns the length of the serialized data inside the stream.
-   * @return The length of the serialized data.
-   */
-  inline size_t getSerializedDataLength() const
-  {
-    return m_currentPosition - m_cdrBuffer.begin();
-  }
-
-  /*!
-   * @brief Get the number of bytes needed to align a position to certain data size.
-   * @param current_alignment Position to be aligned.
-   * @param dataSize Size of next data to process (should be power of two).
-   * @return Number of required alignment bytes.
-   */
-  inline static size_t alignment(size_t current_alignment, size_t dataSize)
-  {
-    return (dataSize - (current_alignment % dataSize)) & (dataSize - 1);
-  }
-
-  /*!
-   * @brief This function returns the current state of the CDR serialization process.
-   * @return The current state of the CDR serialization process.
-   */
-  state getState();
-
-  /*!
-   * @brief This function sets a previous state of the CDR serialization process;
-   * @param state Previous state that will be set.
-   */
-  void setState(state& state);
-
-  /*!
-   * @brief This function moves the alignment forward.
-   * @param numBytes The number of bytes the alignment should advance.
-   * @return True If alignment was moved successfully.
-   */
-  bool moveAlignmentForward(size_t numBytes);
-
-  /*!
-   * @brief This function resets the alignment to the current position in the buffer.
-   */
-  inline void resetAlignment()
-  {
-    m_alignPosition = m_currentPosition;
-  }
-
-  /*!
-   * @brief This operator serializes an octet.
-   * @param octet_t The value of the octet that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const uint8_t octet_t)
-  {
-    return serialize(octet_t);
-  }
-
-  /*!
-   * @brief This operator serializes a character.
-   * @param char_t The value of the character that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const char char_t)
-  {
-    return serialize(char_t);
-  }
-
-  /*!
-   * @brief This operator serializes a int8_t.
-   * @param int8 The value of the int8_t that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const int8_t int8)
-  {
-    return serialize(int8);
-  }
-
-  /*!
-   * @brief This operator serializes an unsigned short.
-   * @param ushort_t The value of the unsigned short that will be serialized in the
-   * buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const uint16_t ushort_t)
-  {
-    return serialize(ushort_t);
-  }
-
-  /*!
-   * @brief This operator serializes a short.
-   * @param short_t The value of the short that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const int16_t short_t)
-  {
-    return serialize(short_t);
-  }
-
-  /*!
-   * @brief This operator serializes an unsigned long.
-   * @param ulong_t The value of the unsigned long that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const uint32_t ulong_t)
-  {
-    return serialize(ulong_t);
-  }
-
-  /*!
-   * @brief This operator serializes a long.
-   * @param long_t The value of the long that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const int32_t long_t)
-  {
-    return serialize(long_t);
-  }
-
-  /*!
-   * @brief This operator serializes a wide-char.
-   * @param wchar The value of the wide-char that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const wchar_t wchar)
-  {
-    return serialize(wchar);
-  }
-
-  /*!
-   * @brief This operator serializes an unsigned long long.
-   * @param ulonglong_t The value of the unsigned long long that will be serialized in the
-   * buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const uint64_t ulonglong_t)
-  {
-    return serialize(ulonglong_t);
-  }
-
-  /*!
-   * @brief This operator serializes a long long.
-   * @param longlong_t The value of the long long that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const int64_t longlong_t)
-  {
-    return serialize(longlong_t);
-  }
-
-  /*!
-   * @brief This operator serializes a float.
-   * @param float_t The value of the float that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const float float_t)
-  {
-    return serialize(float_t);
-  }
-
-  /*!
-   * @brief This operator serializes a double.
-   * @param double_t The value of the double that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const double double_t)
-  {
-    return serialize(double_t);
-  }
-
-  /*!
-   * @brief This operator serializes a long double.
-   * @param ldouble_t The value of the long double that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const long double ldouble_t)
-  {
-    return serialize(ldouble_t);
-  }
-
-  /*!
-   * @brief This operator serializes a boolean.
-   * @param bool_t The value of the boolean that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const bool bool_t)
-  {
-    return serialize(bool_t);
-  }
-
-  /*!
-   * @brief This operator serializes a null-terminated c-string.
-   * @param string_t Pointer to the begining of the string that will be serialized in the
-   * buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const char* string_t)
-  {
-    return serialize(string_t);
-  }
-
-  /*!
-   * @brief This operator serializes a null-terminated c-string.
-   * @param string_t Pointer to the begining of the string that will be serialized in the
-   * buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(char* string_t)
-  {
-    return serialize(string_t);
-  }
-
-  /*!
-   * @brief This operator serializes a string.
-   * @param string_t The string that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const std::string& string_t)
-  {
-    return serialize(string_t);
-  }
-
-  /*!
-   * @brief This operator serializes a wstring.
-   * @param string_t The wstring that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator<<(const std::wstring& string_t)
-  {
-    return serialize(string_t);
-  }
-
-#if HAVE_CXX0X
-  /*!
-   * @brief This operator template is used to serialize arrays.
-   * @param array_t The array that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T, size_t _Size>
-  inline Cdr& operator<<(const std::array<_T, _Size>& array_t)
-  {
-    return serialize<_T, _Size>(array_t);
-  }
-
-#endif  // if HAVE_CXX0X
-
-  /*!
-   * @brief This operator template is used to serialize sequences.
-   * @param vector_t The sequence that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  inline Cdr& operator<<(const std::vector<_T>& vector_t)
-  {
-    return serialize<_T>(vector_t);
-  }
-
-  /*!
-   * @brief This operator template is used to serialize maps.
-   * @param map_t The map that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _K, class _T>
-  inline Cdr& operator<<(const std::map<_K, _T>& map_t)
-  {
-    return serialize<_K, _T>(map_t);
-  }
-
-  /*!
-   * @brief This operator template is used to serialize any other non-basic type.
-   * @param type_t A reference to the object that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  inline Cdr& operator<<(const _T& type_t)
-  {
-    type_t.serialize(*this);
-    return *this;
-  }
-
-  /*!
-   * @brief This operator deserializes an octet.
-   * @param octet_t The variable that will store the octet read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator>>(uint8_t& octet_t)
-  {
-    return deserialize(octet_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a character.
-   * @param char_t The variable that will store the character read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator>>(char& char_t)
-  {
-    return deserialize(char_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a int8_t.
-   * @param int8 The variable that will store the int8_t read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator>>(int8_t& int8)
-  {
-    return deserialize(int8);
-  }
-
-  /*!
-   * @brief This operator deserializes an unsigned short.
-   * @param ushort_t The variable that will store the unsigned short read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator>>(uint16_t& ushort_t)
-  {
-    return deserialize(ushort_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a short.
-   * @param short_t The variable that will store the short read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator>>(int16_t& short_t)
-  {
-    return deserialize(short_t);
-  }
-
-  /*!
-   * @brief This operator deserializes an unsigned long.
-   * @param ulong_t The variable that will store the unsigned long read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator>>(uint32_t& ulong_t)
-  {
-    return deserialize(ulong_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a long.
-   * @param long_t The variable that will store the long read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator>>(int32_t& long_t)
-  {
-    return deserialize(long_t);
-  }
-
-  // TODO in FastCdr
-  /*!
-   * @brief This operator deserializes a wide-char.
-   * @param wchar The variable that will store the wide-char read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator>>(wchar_t& wchar)
-  {
-    return deserialize(wchar);
-  }
-
-  /*!
-   * @brief This operator deserializes a unsigned long long.
-   * @param ulonglong_t The variable that will store the unsigned long long read from the
-   * buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator>>(uint64_t& ulonglong_t)
-  {
-    return deserialize(ulonglong_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a long long.
-   * @param longlong_t The variable that will store the long long read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator>>(int64_t& longlong_t)
-  {
-    return deserialize(longlong_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a float.
-   * @param float_t The variable that will store the float read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator>>(float& float_t)
-  {
-    return deserialize(float_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a double.
-   * @param double_t The variable that will store the double read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator>>(double& double_t)
-  {
-    return deserialize(double_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a long double.
-   * @param ldouble_t The variable that will store the long double read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator>>(long double& ldouble_t)
-  {
-    return deserialize(ldouble_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a boolean.
-   * @param bool_t The variable that will store the boolean read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   * @exception exception::BadParamException This exception is thrown when trying to
-   * deserialize an invalid value.
-   */
-  inline Cdr& operator>>(bool& bool_t)
-  {
-    return deserialize(bool_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a null-terminated c-string.
-   * @param string_t The variable that will store the c-string read from the buffer.
-   *                 Please note that a newly allocated string will be returned.
-   *                 The caller should free the returned pointer when appropiate.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   * @exception exception::BadParamException This exception is thrown when trying to
-   * deserialize an invalid value.
-   */
-  inline Cdr& operator>>(char*& string_t)
-  {
-    return deserialize(string_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a string.
-   * @param string_t The variable that will store the string read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator>>(std::string& string_t)
-  {
-    return deserialize(string_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a string.
-   * @param string_t The variable that will store the string read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& operator>>(std::wstring& string_t)
-  {
-    return deserialize(string_t);
-  }
-
-#if HAVE_CXX0X
-  /*!
-   * @brief This operator template is used to deserialize arrays.
-   * @param array_t The variable that will store the array read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T, size_t _Size>
-  inline Cdr& operator>>(std::array<_T, _Size>& array_t)
-  {
-    return deserialize<_T, _Size>(array_t);
-  }
-
-#endif  // if HAVE_CXX0X
-
-  /*!
-   * @brief This operator template is used to deserialize sequences.
-   * @param vector_t The variable that will store the sequence read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  inline Cdr& operator>>(std::vector<_T>& vector_t)
-  {
-    return deserialize<_T>(vector_t);
-  }
-
-  /*!
-   * @brief This operator template is used to deserialize maps.
-   * @param map_t The variable that will store the map read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _K, class _T>
-  inline Cdr& operator>>(std::map<_K, _T>& map_t)
-  {
-    return deserialize<_K, _T>(map_t);
-  }
-
-  /*!
-   * @brief This operator template is used to deserialize any other non-basic type.
-   * @param type_t The variable that will store the object read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  inline Cdr& operator>>(_T& type_t)
-  {
-    type_t.deserialize(*this);
-    return *this;
-  }
-
-  /*!
-   * @brief This function serializes an octet.
-   * @param octet_t The value of the octet that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const uint8_t octet_t)
-  {
-    return serialize(static_cast<char>(octet_t));
-  }
-
-  /*!
-   * @brief This function serializes an octet with a different endianness.
-   * @param octet_t The value of the octet that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const uint8_t octet_t, Endianness endianness)
-  {
-    return serialize(static_cast<char>(octet_t), endianness);
-  }
-
-  /*!
-   * @brief This function serializes a character.
-   * @param char_t The value of the character that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize(const char char_t);
-
-  /*!
-   * @brief This function serializes a character with a different endianness.
-   * @param char_t The value of the character that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const char char_t, Endianness endianness)
-  {
-    (void)endianness;
-    return serialize(char_t);
-  }
-
-  /*!
-   * @brief This function serializes an int8_t.
-   * @param int8 The value of the int8_t that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const int8_t int8)
-  {
-    return serialize(static_cast<char>(int8));
-  }
-
-  /*!
-   * @brief This function serializes an int8_t with a different endianness.
-   * @param int8 The value of the int8_t that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const int8_t int8, Endianness endianness)
-  {
-    return serialize(static_cast<char>(int8), endianness);
-  }
-
-  /*!
-   * @brief This function serializes an unsigned short.
-   * @param ushort_t The value of the unsigned short that will be serialized in the
-   * buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const uint16_t ushort_t)
-  {
-    return serialize(static_cast<int16_t>(ushort_t));
-  }
-
-  /*!
-   * @brief This function serializes an unsigned short with a different endianness.
-   * @param ushort_t The value of the unsigned short that will be serialized in the
-   * buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const uint16_t ushort_t, Endianness endianness)
-  {
-    return serialize(static_cast<int16_t>(ushort_t), endianness);
-  }
-
-  /*!
-   * @brief This function serializes a short.
-   * @param short_t The value of the short that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize(const int16_t short_t);
-
-  /*!
-   * @brief This function serializes a short with a different endianness.
-   * @param short_t The value of the short that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize(const int16_t short_t, Endianness endianness);
-
-  /*!
-   * @brief This function serializes an unsigned long.
-   * @param ulong_t The value of the unsigned long that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const uint32_t ulong_t)
-  {
-    return serialize(static_cast<int32_t>(ulong_t));
-  }
-
-  /*!
-   * @brief This function serializes an unsigned long with a different endianness.
-   * @param ulong_t The value of the unsigned long that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const uint32_t ulong_t, Endianness endianness)
-  {
-    return serialize(static_cast<int32_t>(ulong_t), endianness);
-  }
-
-  /*!
-   * @brief This function serializes a long.
-   * @param long_t The value of the long that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize(const int32_t long_t);
-
-  /*!
-   * @brief This function serializes a long with a different endianness.
-   * @param long_t The value of the long that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize(const int32_t long_t, Endianness endianness);
-
-  /*!
-   * @brief This function serializes a wide-char.
-   * @param wchar The value of the wide-char that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const wchar_t wchar)
-  {
-    return serialize(static_cast<uint32_t>(wchar));
-  }
-
-  /*!
-   * @brief This function serializes a wide-char with a different endianness.
-   * @param wchar The value of the wide-char that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const wchar_t wchar, Endianness endianness)
-  {
-    return serialize(static_cast<uint32_t>(wchar), endianness);
-  }
-
-  /*!
-   * @brief This function serializes an unsigned long long.
-   * @param ulonglong_t The value of the unsigned long long that will be serialized in the
-   * buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const uint64_t ulonglong_t)
-  {
-    return serialize(static_cast<int64_t>(ulonglong_t));
-  }
-
-  /*!
-   * @brief This function serializes an unsigned long long with a different endianness.
-   * @param ulonglong_t The value of the unsigned long long that will be serialized in the
-   * buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const uint64_t ulonglong_t, Endianness endianness)
-  {
-    return serialize(static_cast<int64_t>(ulonglong_t), endianness);
-  }
-
-  /*!
-   * @brief This function serializes a long long.
-   * @param longlong_t The value of the long long that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize(const int64_t longlong_t);
-
-  /*!
-   * @brief This function serializes a long long with a different endianness.
-   * @param longlong_t The value of the long long that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize(const int64_t longlong_t, Endianness endianness);
-
-  /*!
-   * @brief This function serializes a float.
-   * @param float_t The value of the float that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize(const float float_t);
-
-  /*!
-   * @brief This function serializes a float with a different endianness.
-   * @param float_t The value of the float that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize(const float float_t, Endianness endianness);
-
-  /*!
-   * @brief This function serializes a double.
-   * @param double_t The value of the double that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize(const double double_t);
-
-  /*!
-   * @brief This function serializes a double with a different endianness.
-   * @param double_t The value of the double that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize(const double double_t, Endianness endianness);
-
-  /*!
-   * @brief This function serializes a long double.
-   * @param ldouble_t The value of the long double that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   * @note Due to internal representation differences, WIN32 and *NIX like systems are not
-   * compatible.
-   */
-  Cdr& serialize(const long double ldouble_t);
-
-  /*!
-   * @brief This function serializes a long double with a different endianness.
-   * @param ldouble_t The value of the long double that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   * @note Due to internal representation differences, WIN32 and *NIX like systems are not
-   * compatible.
-   */
-  Cdr& serialize(const long double ldouble_t, Endianness endianness);
-
-  /*!
-   * @brief This function serializes a boolean.
-   * @param bool_t The value of the boolean that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize(const bool bool_t);
-
-  /*!
-   * @brief This function serializes a boolean with a different endianness.
-   * @param bool_t The value of the boolean that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const bool bool_t, Endianness endianness)
-  {
-    (void)endianness;
-    return serialize(bool_t);
-  }
-
-  /*!
-   * @brief This function serializes a string.
-   * @param string_t The pointer to the string that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(char* string_t)
-  {
-    return serialize(static_cast<const char*>(string_t));
-  }
-
-  /*!
-   * @brief This function serializes a string.
-   * @param string_t The pointer to the string that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize(const char* string_t);
-
-  /*!
-   * @brief This function serializes a wstring.
-   * @param string_t The pointer to the wstring that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize(const wchar_t* string_t);
-
-  /*!
-   * @brief This function serializes a string with a different endianness.
-   * @param string_t The pointer to the string that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize(const char* string_t, Endianness endianness);
-
-  /*!
-   * @brief This function serializes a wstring with a different endianness.
-   * @param string_t The pointer to the wstring that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serialize(const wchar_t* string_t, Endianness endianness);
-
-  /*!
-   * @brief This function serializes a std::string.
-   * @param string_t The string that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const std::string& string_t)
-  {
-    return serialize(string_t.c_str());
-  }
-
-  /*!
-   * @brief This function serializes a std::wstring.
-   * @param string_t The wstring that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const std::wstring& string_t)
-  {
-    return serialize(string_t.c_str());
-  }
-
-  /*!
-   * @brief This function serializes a std::string with a different endianness.
-   * @param string_t The string that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serialize(const std::string& string_t, Endianness endianness)
-  {
-    return serialize(string_t.c_str(), endianness);
-  }
-
-#if HAVE_CXX0X
-  /*!
-   * @brief This function template serializes an array.
-   * @param array_t The array that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T, size_t _Size>
-  inline Cdr& serialize(const std::array<_T, _Size>& array_t)
-  {
-    return serializeArray(array_t.data(), array_t.size());
-  }
-
-  /*!
-   * @brief This function template serializes an array with a different endianness.
-   * @param array_t The array that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T, size_t _Size>
-  inline Cdr& serialize(const std::array<_T, _Size>& array_t, Endianness endianness)
-  {
-    return serializeArray(array_t.data(), array_t.size(), endianness);
-  }
-
-#endif  // if HAVE_CXX0X
-
-#if !defined(_MSC_VER) && HAVE_CXX0X
-  /*!
-   * @brief This function template serializes a sequence of booleans.
-   * @param vector_t The sequence that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T = bool>
-  Cdr& serialize(const std::vector<bool>& vector_t)
-  {
-    return serializeBoolSequence(vector_t);
-  }
-
-#endif  // if !defined(_MSC_VER) && HAVE_CXX0X
-
-  /*!
-   * @brief This function template serializes a sequence.
-   * @param vector_t The sequence that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  Cdr& serialize(const std::vector<_T>& vector_t)
-  {
-    state state_before_error(*this);
-
-    *this << static_cast<int32_t>(vector_t.size());
-
-    try
+    typedef enum : uint8_t
     {
-      return serializeArray(vector_t.data(), vector_t.size());
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
+        //! @brief Big endianness.
+        BIG_ENDIANNESS = 0x0,
+        //! @brief Little endianness.
+        LITTLE_ENDIANNESS = 0x1
+    } Endianness;
+
+    //! Default endianess in the system.
+    Cdr_DllAPI static const Endianness DEFAULT_ENDIAN;
+
+    /*!
+     * Used to decide, in encoding algorithms where member headers support a short header version and a long header
+     * version, which one will be used.
+     */
+    typedef enum
     {
-      setState(state_before_error);
-      ex.raise();
+        //! Initially a short member header is allocated and cannot be changed. This option may cause an exception.
+        SHORT_HEADER,
+        //! Initially a long member header is allocated and cannot be changed.
+        LONG_HEADER,
+        //! Initially a short member header is allocated but can be changed to the longer version.
+        AUTO_WITH_SHORT_HEADER_BY_DEFAULT,
+        //! Initially a long member header is allocated but can be changed to the shorter version.
+        AUTO_WITH_LONG_HEADER_BY_DEFAULT
+    } XCdrHeaderSelection;
+
+    /*!
+     * @brief This class stores the current state of a CDR serialization.
+     */
+    class state
+    {
+        friend class Cdr;
+
+    public:
+
+        //! Default constructor.
+        Cdr_DllAPI state(
+                const Cdr& cdr);
+
+        //! Copy constructor.
+        Cdr_DllAPI state(
+                const state& state);
+
+
+        //! Compares two states.
+        Cdr_DllAPI bool operator ==(
+                const state& other_state) const;
+
+    private:
+
+        state& operator =(
+                const state& state) = delete;
+
+        //! The position in the buffer when the state was created.
+        const FastBuffer::iterator offset_;
+
+        //! The position from the alignment is calculated, when the state was created.
+        const FastBuffer::iterator origin_;
+
+        //! This attribute specifies if it is needed to swap the bytes when the state is created.
+        bool swap_bytes_ {false};
+
+        //! Stores the last datasize serialized/deserialized when the state was created.
+        size_t last_data_size_ {0};
+
+        //! Not related with the state. Next member id which will be encoded.
+        MemberId next_member_id_;
+
+        //! Not related with the state. Used by encoding algorithms to set the encoded member size.
+        uint32_t member_size_ {0};
+
+        //! Not related with the state. Used by encoding algorithms to store the selected member header version.
+        XCdrHeaderSelection header_selection_ {XCdrHeaderSelection::AUTO_WITH_SHORT_HEADER_BY_DEFAULT};
+
+        //! Not related with the state. Used by encoding algorithms to store the allocated member header version.
+        XCdrHeaderSelection header_serialized_ {XCdrHeaderSelection::SHORT_HEADER};
+
+        //! Not related with the state. Used by encoding algorithms to store the previous encoding algorithm.
+        EncodingAlgorithmFlag previous_encoding_ {EncodingAlgorithmFlag::PLAIN_CDR2};
+    };
+
+    /*!
+     * @brief This constructor creates an eprosima::fastcdr::Cdr object that can serialize/deserialize
+     * the assigned buffer.
+     * @param cdr_buffer A reference to the buffer that contains (or will contain) the CDR representation.
+     * @param endianness The initial endianness that will be used. The default value is the endianness of the system.
+     * @param cdr_version Represents the type of encoding algorithm that will be used for the encoding.
+     * The default value is CdrVersion::XCDRv2.
+     */
+    Cdr_DllAPI Cdr(
+            FastBuffer& cdr_buffer,
+            const Endianness endianness = DEFAULT_ENDIAN,
+            const CdrVersion cdr_version = XCDRv2);
+
+    /*!
+     * @brief This function reads the encapsulation of the CDR stream.
+     *        If the CDR stream contains an encapsulation, then this function should be called before starting to deserialize.
+     *        CdrVersion and EncodingAlgorithmFlag internal values will be changed to the ones specified by the
+     *        encapsulation.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     * @exception exception::BadParamException This exception is thrown when trying to deserialize an invalid value.
+     */
+    Cdr_DllAPI Cdr& read_encapsulation();
+
+    /*!
+     * @brief This function writes the encapsulation of the CDR stream.
+     *        If the CDR stream should contain an encapsulation, then this function should be called before starting to serialize.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize_encapsulation();
+
+    /*!
+     * @brief Retrieves the CdrVersion used by the instance.
+     * @return Configured CdrVersion.
+     */
+    Cdr_DllAPI CdrVersion get_cdr_version() const;
+
+    /*!
+     * @brief Returns the EncodingAlgorithmFlag set in the encapsulation when the CDR type is
+     * CdrVersion::DDS_CDR, CdrVersion::XCDRv1 or CdrVersion::XCDRv2.
+     * @return The specified flag in the encapsulation.
+     */
+    Cdr_DllAPI EncodingAlgorithmFlag get_encoding_flag() const;
+
+    /*!
+     * @brief Sets the EncodingAlgorithmFlag for the encapsulation when the CDR type is
+     * CdrVersion::DDS_CDR, CdrVersion::XCDRv1 or CdrVersion::XCDRv2.
+     * This function only works when is called before starting the encoding/decoding.
+     * @param[in] encoding_flag Value to be used in the encapsulation.
+     * @return Indicates whether the setting was successful.
+     */
+    Cdr_DllAPI bool set_encoding_flag(
+            EncodingAlgorithmFlag encoding_flag);
+
+    /*!
+     * @brief This function returns the option flags when the CDR type is eprosima::fastcdr::DDS_CDR.
+     * @return The option flags.
+     */
+    Cdr_DllAPI std::array<uint8_t, 2> get_dds_cdr_options() const;
+
+    /*!
+     * @brief This function sets the option flags when the CDR type is eprosima::fastcdr::DDS_CDR.
+     * @param options New value for the option flags.
+     */
+    Cdr_DllAPI void set_dds_cdr_options(
+            const std::array<uint8_t, 2>& options);
+
+    /*!
+     * @brief This function sets the current endianness used by the CDR type.
+     * @param endianness The new endianness value.
+     */
+    Cdr_DllAPI void change_endianness(
+            Endianness endianness);
+
+    /*!
+     * @brief This function returns the current endianness used by the CDR type.
+     * @return The endianness.
+     */
+    Cdr_DllAPI Endianness endianness() const;
+
+    /*!
+     * @brief This function skips a number of bytes in the CDR stream buffer.
+     * @param num_bytes The number of bytes that will be jumped.
+     * @return True is returned when it works successfully. Otherwise, false is returned.
+     */
+    Cdr_DllAPI bool jump(
+            size_t num_bytes);
+
+    /*!
+     * @brief This function resets the current position in the buffer to the beginning.
+     */
+    Cdr_DllAPI void reset();
+
+    /*!
+     * @brief This function returns the pointer to the current used buffer.
+     * @return Pointer to the starting position of the buffer.
+     */
+    Cdr_DllAPI char* get_buffer_pointer();
+
+    /*!
+     * @brief This function returns the current position in the CDR stream.
+     * @return Pointer to the current position in the buffer.
+     */
+    Cdr_DllAPI char* get_current_position();
+
+    /*!
+     * @brief This function returns the length of the serialized data inside the stream.
+     * @return The length of the serialized data.
+     */
+    Cdr_DllAPI size_t get_serialized_data_length() const;
+
+    /*!
+     * @brief Get the number of bytes needed to align a position to certain data size.
+     * @param current_alignment Position to be aligned.
+     * @param data_size Size of next data to process (should be power of two).
+     * @return Number of required alignment bytes.
+     */
+    inline static size_t alignment(
+            size_t current_alignment,
+            size_t data_size)
+    {
+        return (data_size - (current_alignment % data_size)) & (data_size - 1);
     }
 
-    return *this;
-  }
+    /*!
+     * @brief Returns the current state of the CDR serialization process.
+     * @return The current state of the CDR serialization process.
+     */
+    Cdr_DllAPI state get_state() const;
 
-  /*!
-   * @brief This function template serializes a map.
-   * @param map_t The map that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _K, class _T>
-  Cdr& serialize(const std::map<_K, _T>& map_t)
-  {
-    state state_(*this);
+    /*!
+     * @brief Sets a previous state of the CDR serialization process;
+     * @param state Previous state that will be set.
+     */
+    Cdr_DllAPI void set_state(
+            const state& state);
 
-    *this << static_cast<int32_t>(map_t.size());
+    /*!
+     * @brief This function moves the alignment forward.
+     * @param num_bytes The number of bytes the alignment should advance.
+     * @return True If alignment was moved successfully.
+     */
+    Cdr_DllAPI bool move_alignment_forward(
+            size_t num_bytes);
 
-    try
+    /*!
+     * @brief This function resets the alignment to the current position in the buffer.
+     */
+    inline void reset_alignment()
     {
-      for (auto it_pair = map_t.begin(); it_pair != map_t.end(); ++it_pair)
-      {
-        *this << it_pair->first;
-        *this << it_pair->second;
-      }
-      // return serializeArray(map_t.data(), map_t.size());
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      setState(state_);
-      ex.raise();
+        origin_ = offset_;
+        last_data_size_ = 0;
     }
 
-    return *this;
-  }
-
-#ifdef _MSC_VER
-  /*!
-   * @brief This function template serializes a sequence of booleans.
-   * @param vector_t The sequence that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <>
-  Cdr& serialize<bool>(const std::vector<bool>& vector_t)
-  {
-    return serializeBoolSequence(vector_t);
-  }
-
-#endif  // ifdef _MSC_VER
-
-  /*!
-   * @brief This function template serializes a sequence with a different endianness.
-   * @param vector_t The sequence that will be serialized in the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  Cdr& serialize(const std::vector<_T>& vector_t, Endianness endianness)
-  {
-    bool auxSwap = m_swapBytes;
-    m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                  (!m_swapBytes && (m_endianness != endianness));
-
-    try
+    /*!
+     * @brief Encodes the value into the buffer.
+     *
+     * If previously a MemberId was set using operator<<, this operator will encode the value as a member of a type
+     * consistent with the set member identifier and according to the encoding algorithm used.
+     *
+     * In other case, the operator will simply encode the value.
+     *
+     * @param[in] value A reference to the value which will be encoded in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T>
+    inline Cdr& operator <<(
+            const _T& value)
     {
-      serialize(vector_t);
-      m_swapBytes = auxSwap;
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      m_swapBytes = auxSwap;
-      ex.raise();
+        if (MEMBER_ID_INVALID == next_member_id_)
+        {
+            serialize(value);
+        }
+        else
+        {
+            serialize_member(next_member_id_, value);
+
+        }
+
+        return *this;
     }
 
-    return *this;
-  }
-
-  /*!
-   * @brief This function template serializes a non-basic object.
-   * @param type_t The object that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  inline Cdr& serialize(const _T& type_t)
-  {
-    type_t.serialize(*this);
-    return *this;
-  }
-
-  /*!
-   * @brief This function serializes an array of octets.
-   * @param octet_t The sequence of octets that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serializeArray(const uint8_t* octet_t, size_t numElements)
-  {
-    return serializeArray(reinterpret_cast<const char*>(octet_t), numElements);
-  }
-
-  /*!
-   * @brief This function serializes an array of octets with a different endianness.
-   * @param octet_t The array of octets that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serializeArray(const uint8_t* octet_t, size_t numElements,
-                             Endianness endianness)
-  {
-    (void)endianness;
-    return serializeArray(reinterpret_cast<const char*>(octet_t), numElements);
-  }
-
-  /*!
-   * @brief This function serializes an array of characters.
-   * @param char_t The array of characters that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serializeArray(const char* char_t, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of characters with a different endianness.
-   * @param char_t The array of characters that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serializeArray(const char* char_t, size_t numElements,
-                             Endianness endianness)
-  {
-    (void)endianness;
-    return serializeArray(char_t, numElements);
-  }
-
-  /*!
-   * @brief This function serializes an array of int8_t.
-   * @param int8 The sequence of int8_t that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serializeArray(const int8_t* int8, size_t numElements)
-  {
-    return serializeArray(reinterpret_cast<const char*>(int8), numElements);
-  }
-
-  /*!
-   * @brief This function serializes an array of int8_t with a different endianness.
-   * @param int8 The array of int8_t that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serializeArray(const int8_t* int8, size_t numElements,
-                             Endianness endianness)
-  {
-    (void)endianness;
-    return serializeArray(reinterpret_cast<const char*>(int8), numElements);
-  }
-
-  /*!
-   * @brief This function serializes an array of unsigned shorts.
-   * @param ushort_t The array of unsigned shorts that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serializeArray(const uint16_t* ushort_t, size_t numElements)
-  {
-    return serializeArray(reinterpret_cast<const int16_t*>(ushort_t), numElements);
-  }
-
-  /*!
-   * @brief This function serializes an array of unsigned shorts with a different
-   * endianness.
-   * @param ushort_t The array of unsigned shorts that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serializeArray(const uint16_t* ushort_t, size_t numElements,
-                             Endianness endianness)
-  {
-    return serializeArray(reinterpret_cast<const int16_t*>(ushort_t), numElements,
-                          endianness);
-  }
-
-  /*!
-   * @brief This function serializes an array of shorts.
-   * @param short_t The array of shorts that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serializeArray(const int16_t* short_t, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of shorts with a different endianness.
-   * @param short_t The array of shorts that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serializeArray(const int16_t* short_t, size_t numElements, Endianness endianness);
-
-  /*!
-   * @brief This function serializes an array of unsigned longs.
-   * @param ulong_t The array of unsigned longs that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serializeArray(const uint32_t* ulong_t, size_t numElements)
-  {
-    return serializeArray(reinterpret_cast<const int32_t*>(ulong_t), numElements);
-  }
-
-  /*!
-   * @brief This function serializes an array of unsigned longs with a different
-   * endianness.
-   * @param ulong_t The array of unsigned longs that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serializeArray(const uint32_t* ulong_t, size_t numElements,
-                             Endianness endianness)
-  {
-    return serializeArray(reinterpret_cast<const int32_t*>(ulong_t), numElements,
-                          endianness);
-  }
-
-  /*!
-   * @brief This function serializes an array of longs.
-   * @param long_t The array of longs that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serializeArray(const int32_t* long_t, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of longs with a different endianness.
-   * @param long_t The array of longs that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serializeArray(const int32_t* long_t, size_t numElements, Endianness endianness);
-
-  /*!
-   * @brief This function serializes an array of wide-chars.
-   * @param wchar The array of wide-chars that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serializeArray(const wchar_t* wchar, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of wide-chars with a different endianness.
-   * @param wchar The array of longs that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serializeArray(const wchar_t* wchar, size_t numElements, Endianness endianness);
-
-  /*!
-   * @brief This function serializes an array of unsigned long longs.
-   * @param ulonglong_t The array of unsigned long longs that will be serialized in the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serializeArray(const uint64_t* ulonglong_t, size_t numElements)
-  {
-    return serializeArray(reinterpret_cast<const int64_t*>(ulonglong_t), numElements);
-  }
-
-  /*!
-   * @brief This function serializes an array of unsigned long longs with a different
-   * endianness.
-   * @param ulonglong_t The array of unsigned long longs that will be serialized in the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serializeArray(const uint64_t* ulonglong_t, size_t numElements,
-                             Endianness endianness)
-  {
-    return serializeArray(reinterpret_cast<const int64_t*>(ulonglong_t), numElements,
-                          endianness);
-  }
-
-  /*!
-   * @brief This function serializes an array of long longs.
-   * @param longlong_t The array of long longs that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serializeArray(const int64_t* longlong_t, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of long longs with a different endianness.
-   * @param longlong_t The array of long longs that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serializeArray(const int64_t* longlong_t, size_t numElements,
-                      Endianness endianness);
-
-  /*!
-   * @brief This function serializes an array of floats.
-   * @param float_t The array of floats that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serializeArray(const float* float_t, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of floats with a different endianness.
-   * @param float_t The array of floats that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serializeArray(const float* float_t, size_t numElements, Endianness endianness);
-
-  /*!
-   * @brief This function serializes an array of doubles.
-   * @param double_t The array of doubles that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serializeArray(const double* double_t, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of doubles with a different endianness.
-   * @param double_t The array of doubles that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serializeArray(const double* double_t, size_t numElements, Endianness endianness);
-
-  /*!
-   * @brief This function serializes an array of long doubles.
-   * @param ldouble_t The array of long doubles that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serializeArray(const long double* ldouble_t, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of long doubles with a different endianness.
-   * @param ldouble_t The array of long doubles that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serializeArray(const long double* ldouble_t, size_t numElements,
-                      Endianness endianness);
-
-  /*!
-   * @brief This function serializes an array of booleans.
-   * @param bool_t The array of booleans that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  Cdr& serializeArray(const bool* bool_t, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of booleans with a different endianness.
-   * @param bool_t The array of booleans that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serializeArray(const bool* bool_t, size_t numElements,
-                             Endianness endianness)
-  {
-    (void)endianness;
-    return serializeArray(bool_t, numElements);
-  }
-
-  /*!
-   * @brief This function serializes an array of strings.
-   * @param string_t The array of strings that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serializeArray(const std::string* string_t, size_t numElements)
-  {
-    for (size_t count = 0; count < numElements; ++count)
+    /*!
+     * @brief Decodes the value from the buffer.
+     *
+     * If this operator is called while decoding members of a type, this operator will decode the value as a member
+     * according to the encoding algorithm used.
+     *
+     * In other case, the operator will simply decode the value.
+     *
+     * @param[out] value Reference to the variable where the value will be stored after decoding from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a position
+     * that exceeds the internal memory size.
+     */
+    template<class _T>
+    inline Cdr& operator >>(
+            _T& value)
     {
-      serialize(string_t[count].c_str());
-    }
-    return *this;
-  }
-
-  /*!
-   * @brief This function serializes an array of wide-strings.
-   * @param string_t The array of wide-strings that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serializeArray(const std::wstring* string_t, size_t numElements)
-  {
-    for (size_t count = 0; count < numElements; ++count)
-    {
-      serialize(string_t[count].c_str());
-    }
-    return *this;
-  }
-
-  /*!
-   * @brief This function serializes an array of strings with a different endianness.
-   * @param string_t The array of strings that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serializeArray(const std::string* string_t, size_t numElements,
-                             Endianness endianness)
-  {
-    bool auxSwap = m_swapBytes;
-    m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                  (!m_swapBytes && (m_endianness != endianness));
-
-    try
-    {
-      serializeArray(string_t, numElements);
-      m_swapBytes = auxSwap;
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      m_swapBytes = auxSwap;
-      ex.raise();
+        if (MEMBER_ID_INVALID == next_member_id_)
+        {
+            deserialize(value);
+        }
+        else
+        {
+            deserialize_member(value);
+        }
+        return *this;
     }
 
-    return *this;
-  }
-
-  /*!
-   * @brief This function serializes an array of wide-strings with a different endianness.
-   * @param string_t The array of wide-strings that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& serializeArray(const std::wstring* string_t, size_t numElements,
-                             Endianness endianness)
-  {
-    bool auxSwap = m_swapBytes;
-    m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                  (!m_swapBytes && (m_endianness != endianness));
-
-    try
+    /*!
+     * @brief Encodes the value of a type into the buffer.
+     *
+     * To do that, the encoder expects a function `serialize` to be provided by the type.
+     *
+     * @param[in] value A reference to the value which will be encoded in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T, typename std::enable_if<!std::is_enum<_T>::value>::type* = nullptr, typename = void>
+    Cdr& serialize(
+            const _T& value)
     {
-      serializeArray(string_t, numElements);
-      m_swapBytes = auxSwap;
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      m_swapBytes = auxSwap;
-      ex.raise();
+        eprosima::fastcdr::serialize(*this, value);
+        return *this;
     }
 
-    return *this;
-  }
-
-  /*!
-   * @brief This function template serializes an array of sequences of objects.
-   * @param vector_t The array of sequences of objects that will be serialized in the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  Cdr& serializeArray(const std::vector<_T>* vector_t, size_t numElements)
-  {
-    for (size_t count = 0; count < numElements; ++count)
+    /*!
+     * @brief Encodes the value of a type with a different endianness.
+     * @param[in] value A reference to the value which will be encoded in the buffer.
+     * @param endianness Endianness that will be used in the serialization of this value.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& serialize(
+            const _T& value,
+            Endianness endianness)
     {
-      serialize(vector_t[count]);
-    }
-    return *this;
-  }
+        bool aux_swap = swap_bytes_;
+        swap_bytes_ = (swap_bytes_ && (static_cast<Endianness>(endianness_) == endianness)) ||
+                (!swap_bytes_ && (static_cast<Endianness>(endianness_) != endianness));
 
-  /*!
-   * @brief This function template serializes an array of non-basic objects.
-   * @param type_t The array of objects that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  Cdr& serializeArray(const _T* type_t, size_t numElements)
-  {
-    for (size_t count = 0; count < numElements; ++count)
-    {
-      type_t[count].serialize(*this);
-    }
-    return *this;
-  }
+        try
+        {
+            serialize(value);
+            swap_bytes_ = aux_swap;
+        }
+        catch (exception::Exception& ex)
+        {
+            swap_bytes_ = aux_swap;
+            ex.raise();
+        }
 
-  /*!
-   * @brief This function template serializes an array of non-basic objects with a
-   * different endianness.
-   * @param type_t The array of objects that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  Cdr& serializeArray(const _T* type_t, size_t numElements, Endianness endianness)
-  {
-    bool auxSwap = m_swapBytes;
-    m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                  (!m_swapBytes && (m_endianness != endianness));
-
-    try
-    {
-      serializeArray(type_t, numElements);
-      m_swapBytes = auxSwap;
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      m_swapBytes = auxSwap;
-      ex.raise();
+        return *this;
     }
 
-    return *this;
-  }
-
-  /*!
-   * @brief This function template serializes a raw sequence.
-   * @param sequence_t Pointer to the sequence that will be serialized in the buffer.
-   * @param numElements The number of elements contained in the sequence.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  Cdr& serializeSequence(const _T* sequence_t, size_t numElements)
-  {
-    state state_before_error(*this);
-
-    serialize(static_cast<int32_t>(numElements));
-
-    try
+    /*!
+     * @brief Encodes the value of a enumerator into the buffer.
+     *
+     * @param[in] value A reference to the value which will be encoded in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            int32_t>::value>::type* = nullptr>
+    Cdr& serialize(
+            const _T& value)
     {
-      return serializeArray(sequence_t, numElements);
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      setState(state_before_error);
-      ex.raise();
+        return serialize(static_cast<int32_t>(value));
     }
 
-    return *this;
-  }
-
-  /*!
-   * @brief This function template serializes a raw sequence with a different endianness.
-   * @param sequence_t Pointer to the sequence that will be serialized in the buffer.
-   * @param numElements The number of elements contained in the sequence.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  Cdr& serializeSequence(const _T* sequence_t, size_t numElements, Endianness endianness)
-  {
-    bool auxSwap = m_swapBytes;
-    m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                  (!m_swapBytes && (m_endianness != endianness));
-
-    try
+    /*!
+     * @brief Encodes the value of a enumerator into the buffer.
+     *
+     * @param[in] value A reference to the value which will be encoded in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            uint32_t>::value>::type* = nullptr>
+    Cdr& serialize(
+            const _T& value)
     {
-      serializeSequence(sequence_t, numElements);
-      m_swapBytes = auxSwap;
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      m_swapBytes = auxSwap;
-      ex.raise();
+        return serialize(static_cast<uint32_t>(value));
     }
 
-    return *this;
-  }
-
-  /*!
-   * @brief This function deserializes an octet.
-   * @param octet_t The variable that will store the octet read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(uint8_t& octet_t)
-  {
-    return deserialize(reinterpret_cast<char&>(octet_t));
-  }
-
-  /*!
-   * @brief This function deserializes an octet with a different endianness.
-   * @param octet_t The variable that will store the octet read from the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(uint8_t& octet_t, Endianness endianness)
-  {
-    return deserialize(reinterpret_cast<char&>(octet_t), endianness);
-  }
-
-  /*!
-   * @brief This function deserializes a character.
-   * @param char_t The variable that will store the character read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserialize(char& char_t);
-
-  /*!
-   * @brief This function deserializes a character with a different endianness.
-   * @param char_t The variable that will store the character read from the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(char& char_t, Endianness endianness)
-  {
-    (void)endianness;
-    return deserialize(char_t);
-  }
-
-  /*!
-   * @brief This function deserializes an int8_t.
-   * @param int8 The variable that will store the int8_t read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(int8_t& int8)
-  {
-    return deserialize(reinterpret_cast<char&>(int8));
-  }
-
-  /*!
-   * @brief This function deserializes an int8_t with a different endianness.
-   * @param int8 The variable that will store the int8_t read from the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(int8_t& int8, Endianness endianness)
-  {
-    return deserialize(reinterpret_cast<char&>(int8), endianness);
-  }
-
-  /*!
-   * @brief This function deserializes an unsigned short.
-   * @param ushort_t The variable that will store the unsigned short read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(uint16_t& ushort_t)
-  {
-    return deserialize(reinterpret_cast<int16_t&>(ushort_t));
-  }
-
-  /*!
-   * @brief This function deserializes an unsigned short with a different endianness.
-   * @param ushort_t The variable that will store the unsigned short read from the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(uint16_t& ushort_t, Endianness endianness)
-  {
-    return deserialize(reinterpret_cast<int16_t&>(ushort_t), endianness);
-  }
-
-  /*!
-   * @brief This function deserializes a short.
-   * @param short_t The variable that will store the short read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserialize(int16_t& short_t);
-
-  /*!
-   * @brief This function deserializes a short with a different endianness.
-   * @param short_t The variable that will store the short read from the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserialize(int16_t& short_t, Endianness endianness);
-
-  /*!
-   * @brief This function deserializes an unsigned long.
-   * @param ulong_t The variable that will store the unsigned long read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(uint32_t& ulong_t)
-  {
-    return deserialize(reinterpret_cast<int32_t&>(ulong_t));
-  }
-
-  /*!
-   * @brief This function deserializes an unsigned long with a different endianness.
-   * @param ulong_t The variable that will store the unsigned long read from the buffer..
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(uint32_t& ulong_t, Endianness endianness)
-  {
-    return deserialize(reinterpret_cast<int32_t&>(ulong_t), endianness);
-  }
-
-  /*!
-   * @brief This function deserializes a long.
-   * @param long_t The variable that will store the long read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserialize(int32_t& long_t);
-
-  /*!
-   * @brief This function deserializes a long with a different endianness.
-   * @param long_t The variable that will store the long read from the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserialize(int32_t& long_t, Endianness endianness);
-
-  /*!
-   * @brief This function deserializes a wide-char.
-   * @param wchar The variable that will store the wide-char read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(wchar_t& wchar)
-  {
-    uint32_t ret;
-    deserialize(ret);
-    wchar = static_cast<wchar_t>(ret);
-    return *this;
-  }
-
-  /*!
-   * @brief This function deserializes a wide-char with a different endianness.
-   * @param wchar The variable that will store the wide-char read from the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(wchar_t& wchar, Endianness endianness)
-  {
-    uint32_t ret;
-    deserialize(ret, endianness);
-    wchar = static_cast<wchar_t>(ret);
-    return *this;
-  }
-
-  /*!
-   * @brief This function deserializes an unsigned long long.
-   * @param ulonglong_t The variable that will store the unsigned long long read from the
-   * buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(uint64_t& ulonglong_t)
-  {
-    return deserialize(reinterpret_cast<int64_t&>(ulonglong_t));
-  }
-
-  /*!
-   * @brief This function deserializes an unsigned long long with a different endianness.
-   * @param ulonglong_t The variable that will store the unsigned long long read from the
-   * buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(uint64_t& ulonglong_t, Endianness endianness)
-  {
-    return deserialize(reinterpret_cast<int64_t&>(ulonglong_t), endianness);
-  }
-
-  /*!
-   * @brief This function deserializes a long long.
-   * @param longlong_t The variable that will store the long long read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserialize(int64_t& longlong_t);
-
-  /*!
-   * @brief This function deserializes a long long with a different endianness.
-   * @param longlong_t The variable that will store the long long read from the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserialize(int64_t& longlong_t, Endianness endianness);
-
-  /*!
-   * @brief This function deserializes a float.
-   * @param float_t The variable that will store the float read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserialize(float& float_t);
-
-  /*!
-   * @brief This function deserializes a float with a different endianness.
-   * @param float_t The variable that will store the float read from the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserialize(float& float_t, Endianness endianness);
-
-  /*!
-   * @brief This function deserializes a double.
-   * @param double_t The variable that will store the double read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserialize(double& double_t);
-
-  /*!
-   * @brief This function deserializes a double with a different endianness.
-   * @param double_t The variable that will store the double read from the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserialize(double& double_t, Endianness endianness);
-
-  /*!
-   * @brief This function deserializes a long double.
-   * @param ldouble_t The variable that will store the long double read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   * @note Due to internal representation differences, WIN32 and *NIX like systems are not
-   * compatible.
-   */
-  Cdr& deserialize(long double& ldouble_t);
-
-  /*!
-   * @brief This function deserializes a long double with a different endianness.
-   * @param ldouble_t The variable that will store the long double read from the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   * @note Due to internal representation differences, WIN32 and *NIX like systems are not
-   * compatible.
-   */
-  Cdr& deserialize(long double& ldouble_t, Endianness endianness);
-
-  /*!
-   * @brief This function deserializes a boolean.
-   * @param bool_t The variable that will store the boolean read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   * @exception exception::BadParamException This exception is thrown when trying to
-   * deserialize an invalid value.
-   */
-  Cdr& deserialize(bool& bool_t);
-
-  /*!
-   * @brief This function deserializes a boolean with a different endianness.
-   * @param bool_t The variable that will store the boolean read from the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   * @exception exception::BadParamException This exception is thrown when trying to
-   * deserialize an invalid value.
-   */
-  inline Cdr& deserialize(bool& bool_t, Endianness endianness)
-  {
-    (void)endianness;
-    return deserialize(bool_t);
-  }
-
-  /*!
-   * @brief This function deserializes a string.
-   * This function allocates memory to store the string. The user pointer will be set to
-   * point this allocated memory. The user will have to free this allocated memory using
-   * free()
-   * @param string_t The pointer that will point to the string read from the buffer.
-   * The user will have to free the allocated memory using free()
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserialize(char*& string_t);
-
-  /*!
-   * @brief This function deserializes a wide string.
-   * This function allocates memory to store the wide string. The user pointer will be set
-   * to point this allocated memory. The user will have to free this allocated memory
-   * using free()
-   * @param string_t The pointer that will point to the wide string read from the buffer.
-   * The user will have to free the allocated memory using free()
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserialize(wchar_t*& string_t);
-
-  /*!
-   * @brief This function deserializes a string with a different endianness.
-   * This function allocates memory to store the string. The user pointer will be set to
-   * point this allocated memory. The user will have to free this allocated memory using
-   * free()
-   * @param string_t The pointer that will point to the string read from the buffer.
-   * @param endianness Endianness that will be used in the deserialization of this value.
-   * The user will have to free the allocated memory using free()
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserialize(char*& string_t, Endianness endianness);
-
-  /*!
-   * @brief This function deserializes a wide string with a different endianness.
-   * This function allocates memory to store the wide string. The user pointer will be set
-   * to point this allocated memory. The user will have to free this allocated memory
-   * using free()
-   * @param string_t The pointer that will point to the wide string read from the buffer.
-   * @param endianness Endianness that will be used in the deserialization of this value.
-   * The user will have to free the allocated memory using free()
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserialize(wchar_t*& string_t, Endianness endianness);
-
-  /*!
-   * @brief This function deserializes a std::string.
-   * @param string_t The variable that will store the string read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(std::string& string_t)
-  {
-    uint32_t length = 0;
-    const char* str = readString(length);
-    string_t = std::string(str, length);
-    return *this;
-  }
-
-  /*!
-   * @brief This function deserializes a std::string.
-   * @param string_t The variable that will store the string read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(std::wstring& string_t)
-  {
-    uint32_t length = 0;
-    string_t = readWString(length);
-    return *this;
-  }
-
-  /*!
-   * @brief This function deserializes a string with a different endianness.
-   * @param string_t The variable that will store the string read from the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(std::string& string_t, Endianness endianness)
-  {
-    bool auxSwap = m_swapBytes;
-    m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                  (!m_swapBytes && (m_endianness != endianness));
-
-    try
+    /*!
+     * @brief Encodes the value of a enumerator into the buffer.
+     *
+     * @param[in] value A reference to the value which will be encoded in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            int16_t>::value>::type* = nullptr>
+    Cdr& serialize(
+            const _T& value)
     {
-      deserialize(string_t);
-      m_swapBytes = auxSwap;
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      m_swapBytes = auxSwap;
-      ex.raise();
+        return serialize(static_cast<int16_t>(value));
     }
 
-    return *this;
-  }
-
-  /*!
-   * @brief This function deserializes a string with a different endianness.
-   * @param string_t The variable that will store the string read from the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserialize(std::wstring& string_t, Endianness endianness)
-  {
-    bool auxSwap = m_swapBytes;
-    m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                  (!m_swapBytes && (m_endianness != endianness));
-
-    try
+    /*!
+     * @brief Encodes the value of a enumerator into the buffer.
+     *
+     * @param[in] value A reference to the value which will be encoded in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            uint16_t>::value>::type* = nullptr>
+    Cdr& serialize(
+            const _T& value)
     {
-      deserialize(string_t);
-      m_swapBytes = auxSwap;
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      m_swapBytes = auxSwap;
-      ex.raise();
+        return serialize(static_cast<uint16_t>(value));
     }
 
-    return *this;
-  }
-
-#if HAVE_CXX0X
-  /*!
-   * @brief This function template deserializes an array.
-   * @param array_t The variable that will store the array read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T, size_t _Size>
-  inline Cdr& deserialize(std::array<_T, _Size>& array_t)
-  {
-    return deserializeArray(array_t.data(), array_t.size());
-  }
-
-  /*!
-   * @brief This function template deserializes an array with a different endianness.
-   * @param array_t The variable that will store the array read from the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T, size_t _Size>
-  inline Cdr& deserialize(std::array<_T, _Size>& array_t, Endianness endianness)
-  {
-    return deserializeArray(array_t.data(), array_t.size(), endianness);
-  }
-
-#endif  // if HAVE_CXX0X
-
-#if !defined(_MSC_VER) && HAVE_CXX0X
-  /*!
-   * @brief This function template deserializes a sequence.
-   * @param vector_t The variable that will store the sequence read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T = bool>
-  Cdr& deserialize(std::vector<bool>& vector_t)
-  {
-    return deserializeBoolSequence(vector_t);
-  }
-
-#endif  // if !defined(_MSC_VER) && HAVE_CXX0X
-
-  /*!
-   * @brief This function template deserializes a sequence.
-   * @param vector_t The variable that will store the sequence read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  Cdr& deserialize(std::vector<_T>& vector_t)
-  {
-    uint32_t seqLength = 0;
-    state state_before_error(*this);
-
-    *this >> seqLength;
-
-    if (seqLength == 0)
+    /*!
+     * @brief Encodes the value of a enumerator into the buffer.
+     *
+     * @param[in] value A reference to the value which will be encoded in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            int8_t>::value>::type* = nullptr>
+    Cdr& serialize(
+            const _T& value)
     {
-      vector_t.clear();
-      return *this;
+        return serialize(static_cast<int8_t>(value));
     }
 
-    if ((m_lastPosition - m_currentPosition) < seqLength)
+    /*!
+     * @brief Encodes the value of a enumerator into the buffer.
+     *
+     * @param[in] value A reference to the value which will be encoded in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            uint8_t>::value>::type* = nullptr>
+    Cdr& serialize(
+            const _T& value)
     {
-      setState(state_before_error);
-      throw eprosima::fastcdr::exception::NotEnoughMemoryException(
-          eprosima::fastcdr::exception::NotEnoughMemoryException::
-              NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        return serialize(static_cast<uint8_t>(value));
     }
 
-    try
+    /*!
+     * @brief This function serializes an octet.
+     * @param octet_t The value of the octet that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            const uint8_t& octet_t)
     {
-      vector_t.resize(seqLength);
-      return deserializeArray(vector_t.data(), vector_t.size());
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      setState(state_before_error);
-      ex.raise();
-    }
-
-    return *this;
-  }
-
-  /*!
-   * @brief This function template deserializes a map.
-   * @param map_t The variable that will store the map read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _K, class _T>
-  Cdr& deserialize(std::map<_K, _T>& map_t)
-  {
-    uint32_t seqLength = 0;
-    state state_(*this);
-
-    *this >> seqLength;
-
-    try
-    {
-      for (uint32_t i = 0; i < seqLength; ++i)
-      {
-        _K key;
-        _T value;
-        *this >> key;
-        *this >> value;
-        map_t.emplace(std::pair<_K, _T>(std::move(key), std::move(value)));
-      }
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      setState(state_);
-      ex.raise();
+        return serialize(static_cast<char>(octet_t));
     }
 
-    return *this;
-  }
+    /*!
+     * @brief This function serializes a character.
+     * @param char_t The value of the character that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            const char char_t);
 
-#ifdef _MSC_VER
-  /*!
-   * @brief This function template deserializes a sequence.
-   * @param vector_t The variable that will store the sequence read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <>
-  Cdr& deserialize<bool>(std::vector<bool>& vector_t)
-  {
-    return deserializeBoolSequence(vector_t);
-  }
-
-#endif  // ifdef _MSC_VER
-
-  /*!
-   * @brief This function template deserializes a sequence with a different endianness.
-   * @param vector_t The variable that will store the sequence read from the buffer.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  Cdr& deserialize(std::vector<_T>& vector_t, Endianness endianness)
-  {
-    bool auxSwap = m_swapBytes;
-    m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                  (!m_swapBytes && (m_endianness != endianness));
-
-    try
+    /*!
+     * @brief This function serializes an int8_t.
+     * @param int8 The value of the int8_t that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            const int8_t int8)
     {
-      deserialize(vector_t);
-      m_swapBytes = auxSwap;
-    }
-    catch (exception::Exception& ex)
-    {
-      m_swapBytes = auxSwap;
-      ex.raise();
+        return serialize(static_cast<char>(int8));
     }
 
-    return *this;
-  }
-
-  /*!
-   * @brief This function template deserializes a non-basic object.
-   * @param type_t The variable that will store the object read from the buffer.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  inline Cdr& deserialize(_T& type_t)
-  {
-    type_t.deserialize(*this);
-    return *this;
-  }
-
-  /*!
-   * @brief This function deserializes an array of octets.
-   * @param octet_t The variable that will store the array of octets read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserializeArray(uint8_t* octet_t, size_t numElements)
-  {
-    return deserializeArray(reinterpret_cast<char*>(octet_t), numElements);
-  }
-
-  /*!
-   * @brief This function deserializes an array of octets with a different endianness.
-   * @param octet_t The variable that will store the array of octets read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserializeArray(uint8_t* octet_t, size_t numElements,
-                               Endianness endianness)
-  {
-    return deserializeArray(reinterpret_cast<char*>(octet_t), numElements, endianness);
-  }
-
-  /*!
-   * @brief This function deserializes an array of characters.
-   * @param char_t The variable that will store the array of characters read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserializeArray(char* char_t, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of characters with a different endianness.
-   * @param char_t The variable that will store the array of characters read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserializeArray(char* char_t, size_t numElements, Endianness endianness)
-  {
-    (void)endianness;
-    return deserializeArray(char_t, numElements);
-  }
-
-  /*!
-   * @brief This function deserializes an array of int8_t.
-   * @param int8 The variable that will store the array of int8_t read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserializeArray(int8_t* int8, size_t numElements)
-  {
-    return deserializeArray(reinterpret_cast<char*>(int8), numElements);
-  }
-
-  /*!
-   * @brief This function deserializes an array of int8_t with a different endianness.
-   * @param int8 The variable that will store the array of int8_t read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserializeArray(int8_t* int8, size_t numElements, Endianness endianness)
-  {
-    return deserializeArray(reinterpret_cast<char*>(int8), numElements, endianness);
-  }
-
-  /*!
-   * @brief This function deserializes an array of unsigned shorts.
-   * @param ushort_t The variable that will store the array of unsigned shorts read from
-   * the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserializeArray(uint16_t* ushort_t, size_t numElements)
-  {
-    return deserializeArray(reinterpret_cast<int16_t*>(ushort_t), numElements);
-  }
-
-  /*!
-   * @brief This function deserializes an array of unsigned shorts with a different
-   * endianness.
-   * @param ushort_t The variable that will store the array of unsigned shorts read from
-   * the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserializeArray(uint16_t* ushort_t, size_t numElements,
-                               Endianness endianness)
-  {
-    return deserializeArray(reinterpret_cast<int16_t*>(ushort_t), numElements,
-                            endianness);
-  }
-
-  /*!
-   * @brief This function deserializes an array of shorts.
-   * @param short_t The variable that will store the array of shorts read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserializeArray(int16_t* short_t, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of shorts with a different endianness.
-   * @param short_t The variable that will store the array of shorts read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserializeArray(int16_t* short_t, size_t numElements, Endianness endianness);
-
-  /*!
-   * @brief This function deserializes an array of unsigned longs.
-   * @param ulong_t The variable that will store the array of unsigned longs read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserializeArray(uint32_t* ulong_t, size_t numElements)
-  {
-    return deserializeArray(reinterpret_cast<int32_t*>(ulong_t), numElements);
-  }
-
-  /*!
-   * @brief This function deserializes an array of unsigned longs with a different
-   * endianness.
-   * @param ulong_t The variable that will store the array of unsigned longs read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserializeArray(uint32_t* ulong_t, size_t numElements,
-                               Endianness endianness)
-  {
-    return deserializeArray(reinterpret_cast<int32_t*>(ulong_t), numElements, endianness);
-  }
-
-  /*!
-   * @brief This function deserializes an array of longs.
-   * @param long_t The variable that will store the array of longs read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserializeArray(int32_t* long_t, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of longs with a different endianness.
-   * @param long_t The variable that will store the array of longs read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserializeArray(int32_t* long_t, size_t numElements, Endianness endianness);
-
-  /*!
-   * @brief This function deserializes an array of wide-chars.
-   * @param wchar The variable that will store the array of wide-chars read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserializeArray(wchar_t* wchar, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of wide-chars with a different endianness.
-   * @param wchar The variable that will store the array of wide-chars read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserializeArray(wchar_t* wchar, size_t numElements, Endianness endianness);
-
-  /*!
-   * @brief This function deserializes an array of unsigned long longs.
-   * @param ulonglong_t The variable that will store the array of unsigned long longs read
-   * from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserializeArray(uint64_t* ulonglong_t, size_t numElements)
-  {
-    return deserializeArray(reinterpret_cast<int64_t*>(ulonglong_t), numElements);
-  }
-
-  /*!
-   * @brief This function deserializes an array of unsigned long longs with a different
-   * endianness.
-   * @param ulonglong_t The variable that will store the array of unsigned long longs read
-   * from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserializeArray(uint64_t* ulonglong_t, size_t numElements,
-                               Endianness endianness)
-  {
-    return deserializeArray(reinterpret_cast<int64_t*>(ulonglong_t), numElements,
-                            endianness);
-  }
-
-  /*!
-   * @brief This function deserializes an array of long longs.
-   * @param longlong_t The variable that will store the array of long longs read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserializeArray(int64_t* longlong_t, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of long longs with a different endianness.
-   * @param longlong_t The variable that will store the array of long longs read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserializeArray(int64_t* longlong_t, size_t numElements, Endianness endianness);
-
-  /*!
-   * @brief This function deserializes an array of floats.
-   * @param float_t The variable that will store the array of floats read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserializeArray(float* float_t, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of floats with a different endianness.
-   * @param float_t The variable that will store the array of floats read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserializeArray(float* float_t, size_t numElements, Endianness endianness);
-
-  /*!
-   * @brief This function deserializes an array of doubles.
-   * @param double_t The variable that will store the array of doubles read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserializeArray(double* double_t, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of doubles with a different endianness.
-   * @param double_t The variable that will store the array of doubles read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserializeArray(double* double_t, size_t numElements, Endianness endianness);
-
-  /*!
-   * @brief This function deserializes an array of long doubles.
-   * @param ldouble_t The variable that will store the array of long doubles read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserializeArray(long double* ldouble_t, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of long doubles with a different
-   * endianness.
-   * @param ldouble_t The variable that will store the array of long doubles read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserializeArray(long double* ldouble_t, size_t numElements,
-                        Endianness endianness);
-
-  /*!
-   * @brief This function deserializes an array of booleans.
-   * @param bool_t The variable that will store the array of booleans read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  Cdr& deserializeArray(bool* bool_t, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of booleans with a different endianness.
-   * @param bool_t The variable that will store the array of booleans read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserializeArray(bool* bool_t, size_t numElements, Endianness endianness)
-  {
-    (void)endianness;
-    return deserializeArray(bool_t, numElements);
-  }
-
-  /*!
-   * @brief This function deserializes an array of strings.
-   * @param string_t The variable that will store the array of strings read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserializeArray(std::string* string_t, size_t numElements)
-  {
-    for (size_t count = 0; count < numElements; ++count)
+    /*!
+     * @brief This function serializes an unsigned short.
+     * @param ushort_t The value of the unsigned short that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            const uint16_t ushort_t)
     {
-      deserialize(string_t[count]);
-    }
-    return *this;
-  }
-
-  /*!
-   * @brief This function deserializes an array of wide-strings.
-   * @param string_t The variable that will store the array of wide-strings read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserializeArray(std::wstring* string_t, size_t numElements)
-  {
-    for (size_t count = 0; count < numElements; ++count)
-    {
-      deserialize(string_t[count]);
-    }
-    return *this;
-  }
-
-  /*!
-   * @brief This function deserializes an array of strings with a different endianness.
-   * @param string_t The variable that will store the array of strings read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserializeArray(std::string* string_t, size_t numElements,
-                               Endianness endianness)
-  {
-    bool auxSwap = m_swapBytes;
-    m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                  (!m_swapBytes && (m_endianness != endianness));
-
-    try
-    {
-      deserializeArray(string_t, numElements);
-      m_swapBytes = auxSwap;
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      m_swapBytes = auxSwap;
-      ex.raise();
+        return serialize(static_cast<int16_t>(ushort_t));
     }
 
-    return *this;
-  }
+    /*!
+     * @brief This function serializes a short.
+     * @param short_t The value of the short that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            const int16_t short_t);
 
-  /*!
-   * @brief This function deserializes an array of wide-strings with a different
-   * endianness.
-   * @param string_t The variable that will store the array of wide-strings read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  inline Cdr& deserializeArray(std::wstring* string_t, size_t numElements,
-                               Endianness endianness)
-  {
-    bool auxSwap = m_swapBytes;
-    m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                  (!m_swapBytes && (m_endianness != endianness));
-
-    try
+    /*!
+     * @brief This function serializes an unsigned long.
+     * @param ulong_t The value of the unsigned long that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            const uint32_t ulong_t)
     {
-      deserializeArray(string_t, numElements);
-      m_swapBytes = auxSwap;
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      m_swapBytes = auxSwap;
-      ex.raise();
+        return serialize(static_cast<int32_t>(ulong_t));
     }
 
-    return *this;
-  }
+    /*!
+     * @brief This function serializes a long.
+     * @param long_t The value of the long that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            const int32_t long_t);
 
-  /*!
-   * @brief This function deserializes an array of sequences of objects.
-   * @param vector_t The variable that will store the array of sequences of objects read
-   * from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  Cdr& deserializeArray(std::vector<_T>* vector_t, size_t numElements)
-  {
-    for (size_t count = 0; count < numElements; ++count)
+    /*!
+     * @brief This function serializes a wide-char.
+     * @param wchar The value of the wide-char that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            const wchar_t wchar)
     {
-      deserialize(vector_t[count]);
-    }
-    return *this;
-  }
-
-  /*!
-   * @brief This function template deserializes an array of non-basic objects.
-   * @param type_t The variable that will store the array of objects read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  Cdr& deserializeArray(_T* type_t, size_t numElements)
-  {
-    for (size_t count = 0; count < numElements; ++count)
-    {
-      type_t[count].deserialize(*this);
-    }
-    return *this;
-  }
-
-  /*!
-   * @brief This function template deserializes an array of non-basic objects with a
-   * different endianness.
-   * @param type_t The variable that will store the array of objects read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  Cdr& deserializeArray(_T* type_t, size_t numElements, Endianness endianness)
-  {
-    bool auxSwap = m_swapBytes;
-    m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                  (!m_swapBytes && (m_endianness != endianness));
-
-    try
-    {
-      deserializeArray(type_t, numElements);
-      m_swapBytes = auxSwap;
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      m_swapBytes = auxSwap;
-      ex.raise();
+        return serialize(static_cast<uint16_t>(wchar));
     }
 
-    return *this;
-  }
-
-#if !defined(_MSC_VER) && HAVE_CXX0X
-  /*!
-   * @brief This function template deserializes a string sequence.
-   * This function allocates memory to store the sequence. The user pointer will be set to
-   * point this allocated memory. The user will have to free this allocated memory using
-   * free()
-   * @param sequence_t The pointer that will store the sequence read from the buffer.
-   * @param numElements This variable return the number of elements of the sequence.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T = std::string>
-  Cdr& deserializeSequence(std::string*& sequence_t, size_t& numElements)
-  {
-    return deserializeStringSequence(sequence_t, numElements);
-  }
-
-  /*!
-   * @brief This function template deserializes a wide-string sequence.
-   * This function allocates memory to store the sequence. The user pointer will be set to
-   * point this allocated memory. The user will have to free this allocated memory using
-   * free()
-   * @param sequence_t The pointer that will store the sequence read from the buffer.
-   * @param numElements This variable return the number of elements of the sequence.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T = std::wstring>
-  Cdr& deserializeSequence(std::wstring*& sequence_t, size_t& numElements)
-  {
-    return deserializeWStringSequence(sequence_t, numElements);
-  }
-
-#endif  // if !defined(_MSC_VER) && HAVE_CXX0X
-
-  /*!
-   * @brief This function template deserializes a raw sequence.
-   * This function allocates memory to store the sequence. The user pointer will be set to
-   * point this allocated memory. The user will have to free this allocated memory using
-   * free()
-   * @param sequence_t The pointer that will store the sequence read from the buffer.
-   * @param numElements This variable return the number of elements of the sequence.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  Cdr& deserializeSequence(_T*& sequence_t, size_t& numElements)
-  {
-    uint32_t seqLength = 0;
-    state state_before_error(*this);
-
-    deserialize(seqLength);
-
-    try
+    /*!
+     * @brief This function serializes an unsigned long long.
+     * @param ulonglong_t The value of the unsigned long long that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            const uint64_t ulonglong_t)
     {
-      sequence_t = reinterpret_cast<_T*>(calloc(seqLength, sizeof(_T)));
-      deserializeArray(sequence_t, seqLength);
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      free(sequence_t);
-      sequence_t = NULL;
-      setState(state_before_error);
-      ex.raise();
+        return serialize(static_cast<int64_t>(ulonglong_t));
     }
 
-    numElements = seqLength;
-    return *this;
-  }
+    /*!
+     * @brief This function serializes a long long.
+     * @param longlong_t The value of the long long that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            const int64_t longlong_t);
 
-#ifdef _MSC_VER
-  /*!
-   * @brief This function template deserializes a string sequence.
-   * This function allocates memory to store the sequence. The user pointer will be set to
-   * point this allocated memory. The user will have to free this allocated memory using
-   * free()
-   * @param sequence_t The pointer that will store the sequence read from the buffer.
-   * @param numElements This variable return the number of elements of the sequence.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <>
-  Cdr& deserializeSequence<std::string>(std::string*& sequence_t, size_t& numElements)
-  {
-    return deserializeStringSequence(sequence_t, numElements);
-  }
+    /*!
+     * @brief This function serializes a float.
+     * @param float_t The value of the float that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            const float float_t);
 
-  /*!
-   * @brief This function template deserializes a wide-string sequence.
-   * This function allocates memory to store the sequence. The user pointer will be set to
-   * point this allocated memory. The user will have to free this allocated memory using
-   * free()
-   * @param sequence_t The pointer that will store the sequence read from the buffer.
-   * @param numElements This variable return the number of elements of the sequence.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <>
-  Cdr& deserializeSequence<std::wstring>(std::wstring*& sequence_t, size_t& numElements)
-  {
-    return deserializeWStringSequence(sequence_t, numElements);
-  }
+    /*!
+     * @brief This function serializes a double.
+     * @param double_t The value of the double that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            const double double_t);
 
-#endif  // ifdef _MSC_VER
+    /*!
+     * @brief This function serializes a long double.
+     * @param ldouble_t The value of the long double that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     * @note Due to internal representation differences, WIN32 and *NIX like systems are not compatible.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            const long double ldouble_t);
 
-  /*!
-   * @brief This function template deserializes a raw sequence with a different
-   * endianness. This function allocates memory to store the sequence. The user pointer
-   * will be set to point this allocated memory. The user will have to free this allocated
-   * memory using free()
-   * @param sequence_t The pointer that will store the sequence read from the buffer.
-   * @param numElements This variable return the number of elements of the sequence.
-   * @param endianness Endianness that will be used in the deserialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  Cdr& deserializeSequence(_T*& sequence_t, size_t& numElements, Endianness endianness)
-  {
-    bool auxSwap = m_swapBytes;
-    m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                  (!m_swapBytes && (m_endianness != endianness));
+    /*!
+     * @brief This function serializes a boolean.
+     * @param bool_t The value of the boolean that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            const bool bool_t);
 
-    try
+    /*!
+     * @brief This function serializes a string.
+     * @param string_t The pointer to the string that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            char* string_t)
     {
-      deserializeSequence(sequence_t, numElements);
-      m_swapBytes = auxSwap;
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      m_swapBytes = auxSwap;
-      ex.raise();
+        return serialize(static_cast<const char*>(string_t));
     }
 
-    return *this;
-  }
+    /*!
+     * @brief This function serializes a string.
+     * @param string_t The pointer to the string that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            const char* string_t);
+
+    /*!
+     * @brief This function serializes a wstring.
+     * @param string_t The pointer to the wstring that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize(
+            const wchar_t* string_t);
+
+    /*!
+     * @brief This function serializes a std::string.
+     * @param string_t The string that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& serialize(
+            const std::string& string_t)
+    {
+        return serialize(string_t.c_str());
+    }
+
+    /*!
+     * @brief This function serializes a std::wstring.
+     * @param string_t The wstring that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& serialize(
+            const std::wstring& string_t)
+    {
+        return serialize(string_t.c_str());
+    }
+
+    /*!
+     * @brief Encodes a eprosima::fastcdr::fixed_string in the buffer.
+     * @param[in] value A reference to the fixed string which will be encoded in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template <size_t MAX_CHARS>
+    Cdr& serialize(
+            const fixed_string<MAX_CHARS>& value)
+    {
+        return serialize(value.c_str());
+    }
+
+    /*!
+     * @brief This function template serializes an array.
+     * @param array_t The array that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    template<class _T, size_t _Size>
+    Cdr& serialize(
+            const std::array<_T, _Size>& array_t)
+    {
+        Cdr::state dheader_state(*this);
+
+        if (CdrVersion::XCDRv2 == cdr_version_ && !is_multi_array_primitive(&array_t))
+        {
+            // Serialize DHEADER
+            uint32_t dheader {0};
+            serialize(dheader);
+        }
+
+        serialize_array(array_t.data(), array_t.size());
+
+        if (CdrVersion::XCDRv2 == cdr_version_ && !is_multi_array_primitive(&array_t))
+        {
+            auto offset = offset_;
+            Cdr::state state_after(*this);
+            set_state(dheader_state);
+            size_t dheader = offset - offset_ - (4 + alignment(sizeof(uint32_t)));/* DHEADER */
+            serialize(static_cast<uint32_t>(dheader));
+            set_state(state_after);
+            serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief This function template serializes a sequence of non-primitive.
+     * @param vector_t The sequence that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    template<class _T, typename std::enable_if<!std::is_enum<_T>::value &&
+            !std::is_arithmetic<_T>::value>::type* = nullptr>
+    Cdr& serialize(
+            const std::vector<_T>& vector_t)
+    {
+        Cdr::state dheader_state(*this);
+
+        if (CdrVersion::XCDRv2 == cdr_version_)
+        {
+            // Serialize DHEADER
+            uint32_t dheader {0};
+            serialize(dheader);
+        }
+
+        serialize(static_cast<int32_t>(vector_t.size()));
+
+        try
+        {
+            serialize_array(vector_t.data(), vector_t.size());
+        }
+        catch (exception::Exception& ex)
+        {
+            set_state(dheader_state);
+            ex.raise();
+        }
+
+        if (CdrVersion::XCDRv2 == cdr_version_)
+        {
+            auto offset = offset_;
+            Cdr::state state_after(*this);
+            set_state(dheader_state);
+            size_t dheader = offset - offset_ - (4 + alignment(sizeof(uint32_t)));/* DHEADER */
+            serialize(static_cast<uint32_t>(dheader));
+            set_state(state_after);
+            serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief This function template serializes a sequence of primitive.
+     * @param vector_t The sequence that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    template<class _T, typename std::enable_if<std::is_enum<_T>::value ||
+            std::is_arithmetic<_T>::value>::type* = nullptr>
+    Cdr& serialize(
+            const std::vector<_T>& vector_t)
+    {
+        state state_before_error(*this);
+
+        serialize(static_cast<int32_t>(vector_t.size()));
+
+        try
+        {
+            serialize_array(vector_t.data(), vector_t.size());
+        }
+        catch (exception::Exception& ex)
+        {
+            set_state(state_before_error);
+            ex.raise();
+        }
+
+        if (CdrVersion::XCDRv2 == cdr_version_)
+        {
+            serialized_member_size_ = get_serialized_member_size<_T>();
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief This function template serializes a sequence of booleans.
+     * @param vector_t The sequence that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& serialize(
+            const std::vector<bool>& vector_t)
+    {
+        return serialize_bool_sequence(vector_t);
+    }
+
+    /*!
+     * @brief This function template serializes a map of non-primitive.
+     * @param map_t The map that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    template<class _K, class _T, typename std::enable_if<!std::is_enum<_T>::value &&
+            !std::is_arithmetic<_T>::value>::type* = nullptr>
+    Cdr& serialize(
+            const std::map<_K, _T>& map_t)
+    {
+        Cdr::state dheader_state(*this);
+
+        if (CdrVersion::XCDRv2 == cdr_version_)
+        {
+            // Serialize DHEADER
+            uint32_t dheader {0};
+            serialize(dheader);
+        }
+
+        serialize(static_cast<int32_t>(map_t.size()));
+
+        try
+        {
+            for (auto it_pair = map_t.begin(); it_pair != map_t.end(); ++it_pair)
+            {
+                serialize(it_pair->first);
+                serialize(it_pair->second);
+            }
+        }
+        catch (exception::Exception& ex)
+        {
+            set_state(dheader_state);
+            ex.raise();
+        }
+
+        if (CdrVersion::XCDRv2 == cdr_version_)
+        {
+            auto offset = offset_;
+            Cdr::state state_after(*this);
+            set_state(dheader_state);
+            size_t dheader = offset - offset_ - (4 + alignment(sizeof(uint32_t)));/* DHEADER */
+            serialize(static_cast<uint32_t>(dheader));
+            set_state(state_after);
+            serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief This function template serializes a map of primitive.
+     * @param map_t The map that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    template<class _K, class _T, typename std::enable_if<std::is_enum<_T>::value ||
+            std::is_arithmetic<_T>::value>::type* = nullptr>
+    Cdr& serialize(
+            const std::map<_K, _T>& map_t)
+    {
+        state state_(*this);
+
+        serialize(static_cast<int32_t>(map_t.size()));
+
+        try
+        {
+            for (auto it_pair = map_t.begin(); it_pair != map_t.end(); ++it_pair)
+            {
+                serialize(it_pair->first);
+                serialize(it_pair->second);
+            }
+        }
+        catch (exception::Exception& ex)
+        {
+            set_state(state_);
+            ex.raise();
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief Encodes the value of a bitset into the buffer.
+     *
+     * @param[in] value A reference to the value which will be encoded in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<size_t N, typename std::enable_if < (N < 9) > ::type* = nullptr>
+    Cdr& serialize(
+            const std::bitset<N>& value)
+    {
+        return serialize(static_cast<uint8_t>(value.to_ulong()));
+    }
+
+    template<size_t N, typename std::enable_if < (8 < N && N < 17) > ::type* = nullptr>
+    Cdr& serialize(
+            const std::bitset<N>& value)
+    {
+        return serialize(static_cast<uint16_t>(value.to_ulong()));
+    }
+
+    template<size_t N, typename std::enable_if < (16 < N && N < 33) > ::type* = nullptr>
+    Cdr& serialize(
+            const std::bitset<N>& value)
+    {
+        return serialize(static_cast<uint32_t>(value.to_ulong()));
+    }
+
+    template<size_t N, typename std::enable_if < (32 < N && N < 65) > ::type* = nullptr>
+    Cdr& serialize(
+            const std::bitset<N>& value)
+    {
+        return serialize(static_cast<uint64_t>(value.to_ullong()));
+    }
+
+    /*!
+     * @brief Encodes an array of a type not managed by this encoder into the buffer.
+     *
+     * To do that, the encoder expects a function `serialize` to be provided by the type.
+     *
+     * @param[in] value Array which will be encoded in the buffer.
+     * @param[in] num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& serialize_array(
+            const _T* value,
+            size_t num_elements)
+    {
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            serialize(value[count]);
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief This function template serializes an array of non-basic objects with a different endianness.
+     * @param type_t The array of objects that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @param endianness Endianness that will be used in the serialization of this value.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& serialize_array(
+            const _T* type_t,
+            size_t num_elements,
+            Endianness endianness)
+    {
+        bool aux_swap = swap_bytes_;
+        swap_bytes_ = (swap_bytes_ && (static_cast<Endianness>(endianness_) == endianness)) ||
+                (!swap_bytes_ && (static_cast<Endianness>(endianness_) != endianness));
+
+        try
+        {
+            serialize_array(type_t, num_elements);
+            swap_bytes_ = aux_swap;
+        }
+        catch (exception::Exception& ex)
+        {
+            swap_bytes_ = aux_swap;
+            ex.raise();
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief This function serializes an array of octets.
+     * @param octet_t The sequence of octets that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& serialize_array(
+            const uint8_t* octet_t,
+            size_t num_elements)
+    {
+        return serialize_array(reinterpret_cast<const char*>(octet_t), num_elements);
+    }
+
+    /*!
+     * @brief This function serializes an array of characters.
+     * @param char_t The array of characters that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize_array(
+            const char* char_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function serializes an array of int8_t.
+     * @param int8 The sequence of int8_t that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& serialize_array(
+            const int8_t* int8,
+            size_t num_elements)
+    {
+        return serialize_array(reinterpret_cast<const char*>(int8), num_elements);
+    }
+
+    /*!
+     * @brief This function serializes an array of unsigned shorts.
+     * @param ushort_t The array of unsigned shorts that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& serialize_array(
+            const uint16_t* ushort_t,
+            size_t num_elements)
+    {
+        return serialize_array(reinterpret_cast<const int16_t*>(ushort_t), num_elements);
+    }
+
+    /*!
+     * @brief This function serializes an array of shorts.
+     * @param short_t The array of shorts that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize_array(
+            const int16_t* short_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function serializes an array of unsigned longs.
+     * @param ulong_t The array of unsigned longs that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& serialize_array(
+            const uint32_t* ulong_t,
+            size_t num_elements)
+    {
+        return serialize_array(reinterpret_cast<const int32_t*>(ulong_t), num_elements);
+    }
+
+    /*!
+     * @brief This function serializes an array of longs.
+     * @param long_t The array of longs that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize_array(
+            const int32_t* long_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function serializes an array of wide-chars.
+     * @param wchar The array of wide-chars that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize_array(
+            const wchar_t* wchar,
+            size_t num_elements);
+
+    /*!
+     * @brief This function serializes an array of unsigned long longs.
+     * @param ulonglong_t The array of unsigned long longs that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& serialize_array(
+            const uint64_t* ulonglong_t,
+            size_t num_elements)
+    {
+        return serialize_array(reinterpret_cast<const int64_t*>(ulonglong_t), num_elements);
+    }
+
+    /*!
+     * @brief This function serializes an array of long longs.
+     * @param longlong_t The array of long longs that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize_array(
+            const int64_t* longlong_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function serializes an array of floats.
+     * @param float_t The array of floats that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize_array(
+            const float* float_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function serializes an array of doubles.
+     * @param double_t The array of doubles that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize_array(
+            const double* double_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function serializes an array of long doubles.
+     * @param ldouble_t The array of long doubles that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     * @note Due to internal representation differences, WIN32 and *NIX like systems are not compatible.
+     */
+    Cdr_DllAPI Cdr& serialize_array(
+            const long double* ldouble_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function serializes an array of booleans.
+     * @param bool_t The array of booleans that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& serialize_array(
+            const bool* bool_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function serializes an array of strings.
+     * @param string_t The array of strings that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& serialize_array(
+            const std::string* string_t,
+            size_t num_elements)
+    {
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            serialize(string_t[count].c_str());
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief This function serializes an array of wide-strings.
+     * @param string_t The array of wide-strings that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& serialize_array(
+            const std::wstring* string_t,
+            size_t num_elements)
+    {
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            serialize(string_t[count].c_str());
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief Encodes an array of fixed strings.
+     * @param[in] value Array of fixed strings which will be encoded in the buffer.
+     * @param[in] num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<size_t MAX_CHARS>
+    Cdr& serialize_array(
+            const fixed_string<MAX_CHARS>* value,
+            size_t num_elements)
+    {
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            serialize(value[count].c_str());
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief This function template serializes a raw sequence of non-primitives
+     * @param sequence_t Pointer to the sequence that will be serialized in the buffer.
+     * @param num_elements The number of elements contained in the sequence.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    template<class _T, typename std::enable_if<!std::is_enum<_T>::value &&
+            !std::is_arithmetic<_T>::value>::type* = nullptr>
+    Cdr& serialize_sequence(
+            const _T* sequence_t,
+            size_t num_elements)
+    {
+        Cdr::state dheader_state(*this);
+
+        if (CdrVersion::XCDRv2 == cdr_version_)
+        {
+            // Serialize DHEADER
+            uint32_t dheader {0};
+            serialize(dheader);
+        }
+
+        serialize(static_cast<int32_t>(num_elements));
+
+        try
+        {
+            serialize_array(sequence_t, num_elements);
+        }
+        catch (exception::Exception& ex)
+        {
+            set_state(dheader_state);
+            ex.raise();
+        }
+
+        if (CdrVersion::XCDRv2 == cdr_version_)
+        {
+            auto offset = offset_;
+            Cdr::state state_after(*this);
+            set_state(dheader_state);
+            size_t dheader = offset - offset_ - (4 + alignment(sizeof(uint32_t)));/* DHEADER */
+            serialize(static_cast<uint32_t>(dheader));
+            set_state(state_after);
+            serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief This function template serializes a raw sequence of primitives
+     * @param sequence_t Pointer to the sequence that will be serialized in the buffer.
+     * @param num_elements The number of elements contained in the sequence.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    template<class _T, typename std::enable_if<std::is_enum<_T>::value ||
+            std::is_arithmetic<_T>::value>::type* = nullptr>
+    Cdr& serialize_sequence(
+            const _T* sequence_t,
+            size_t num_elements)
+    {
+        state state_before_error(*this);
+
+        serialize(static_cast<int32_t>(num_elements));
+
+        try
+        {
+            serialize_array(sequence_t, num_elements);
+        }
+        catch (exception::Exception& ex)
+        {
+            set_state(state_before_error);
+            ex.raise();
+        }
+
+        if (CdrVersion::XCDRv2 == cdr_version_)
+        {
+            serialized_member_size_ = get_serialized_member_size<_T>();
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief This function template serializes a raw sequence with a different endianness.
+     * @param sequence_t Pointer to the sequence that will be serialized in the buffer.
+     * @param num_elements The number of elements contained in the sequence.
+     * @param endianness Endianness that will be used in the serialization of this value.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& serialize_sequence(
+            const _T* sequence_t,
+            size_t num_elements,
+            Endianness endianness)
+    {
+        bool aux_swap = swap_bytes_;
+        swap_bytes_ = (swap_bytes_ && (static_cast<Endianness>(endianness_) == endianness)) ||
+                (!swap_bytes_ && (static_cast<Endianness>(endianness_) != endianness));
+
+        try
+        {
+            serialize_sequence(sequence_t, num_elements);
+            swap_bytes_ = aux_swap;
+        }
+        catch (exception::Exception& ex)
+        {
+            swap_bytes_ = aux_swap;
+            ex.raise();
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief Decodes the value of a type from the buffer.
+     *
+     * To do that, the encoder expects a function `deserialize` to be provided by the type.
+     *
+     * @param[out] value Reference to the variable where the value will be stored after decoding from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T, typename std::enable_if<!std::is_enum<_T>::value>::type* = nullptr, typename = void>
+    Cdr& deserialize(
+            _T& value)
+    {
+        eprosima::fastcdr::deserialize(*this, value);
+        return *this;
+    }
+
+    /*!
+     * @brief Decodes the value of a type with a different endianness.
+     * @param[out] value Reference to the variable where the value will be stored after decoding from the buffer.
+     * @param endianness Endianness that will be used in the deserialization of this value.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& deserialize(
+            _T& value,
+            Endianness endianness)
+    {
+        bool aux_swap = swap_bytes_;
+        swap_bytes_ = (swap_bytes_ && (static_cast<Endianness>(endianness_) == endianness)) ||
+                (!swap_bytes_ && (static_cast<Endianness>(endianness_) != endianness));
+
+        try
+        {
+            deserialize(value);
+            swap_bytes_ = aux_swap;
+        }
+        catch (exception::Exception& ex)
+        {
+            swap_bytes_ = aux_swap;
+            ex.raise();
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief Decodes an enumeration from the buffer.
+     * @param[out] value Reference to the variable where the enumeration will be stored after decoding from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            int32_t>::value>::type* = nullptr>
+    Cdr& deserialize(
+            _T& value)
+    {
+        int32_t decode_value {0};
+        deserialize(decode_value);
+        value = static_cast<_T>(decode_value);
+        return *this;
+    }
+
+    /*!
+     * @brief Decodes an enumeration from the buffer.
+     * @param[out] value Reference to the variable where the enumeration will be stored after decoding from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            uint32_t>::value>::type* = nullptr>
+    Cdr& deserialize(
+            _T& value)
+    {
+        uint32_t decode_value {0};
+        deserialize(decode_value);
+        value = static_cast<_T>(decode_value);
+        return *this;
+    }
+
+    /*!
+     * @brief Decodes an enumeration from the buffer.
+     * @param[out] value Reference to the variable where the enumeration will be stored after decoding from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            int16_t>::value>::type* = nullptr>
+    Cdr& deserialize(
+            _T& value)
+    {
+        int16_t decode_value {0};
+        deserialize(decode_value);
+        value = static_cast<_T>(decode_value);
+        return *this;
+    }
+
+    /*!
+     * @brief Decodes an enumeration from the buffer.
+     * @param[out] value Reference to the variable where the enumeration will be stored after decoding from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            uint16_t>::value>::type* = nullptr>
+    Cdr& deserialize(
+            _T& value)
+    {
+        uint16_t decode_value {0};
+        deserialize(decode_value);
+        value = static_cast<_T>(decode_value);
+        return *this;
+    }
+
+    /*!
+     * @brief Decodes an enumeration from the buffer.
+     * @param[out] value Reference to the variable where the enumeration will be stored after decoding from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            int8_t>::value>::type* = nullptr>
+    Cdr& deserialize(
+            _T& value)
+    {
+        int8_t decode_value {0};
+        deserialize(decode_value);
+        value = static_cast<_T>(decode_value);
+        return *this;
+    }
+
+    /*!
+     * @brief Decodes an enumeration from the buffer.
+     * @param[out] value Reference to the variable where the enumeration will be stored after decoding from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            uint8_t>::value>::type* = nullptr>
+    Cdr& deserialize(
+            _T& value)
+    {
+        uint8_t decode_value {0};
+        deserialize(decode_value);
+        value = static_cast<_T>(decode_value);
+        return *this;
+    }
+
+    /*!
+     * @brief This function deserializes an octet.
+     * @param octet_t The variable that will store the octet read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& deserialize(
+            uint8_t& octet_t)
+    {
+        return deserialize(reinterpret_cast<char&>(octet_t));
+    }
+
+    /*!
+     * @brief This function deserializes a character.
+     * @param char_t The variable that will store the character read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize(
+            char& char_t);
+
+    /*!
+     * @brief This function deserializes an int8_t.
+     * @param int8 The variable that will store the int8_t read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& deserialize(
+            int8_t& int8)
+    {
+        return deserialize(reinterpret_cast<char&>(int8));
+    }
+
+    /*!
+     * @brief This function deserializes an unsigned short.
+     * @param ushort_t The variable that will store the unsigned short read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& deserialize(
+            uint16_t& ushort_t)
+    {
+        return deserialize(reinterpret_cast<int16_t&>(ushort_t));
+    }
+
+    /*!
+     * @brief This function deserializes a short.
+     * @param short_t The variable that will store the short read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize(
+            int16_t& short_t);
+
+    /*!
+     * @brief This function deserializes an unsigned long.
+     * @param ulong_t The variable that will store the unsigned long read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& deserialize(
+            uint32_t& ulong_t)
+    {
+        return deserialize(reinterpret_cast<int32_t&>(ulong_t));
+    }
+
+    /*!
+     * @brief This function deserializes a long.
+     * @param long_t The variable that will store the long read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize(
+            int32_t& long_t);
+
+    /*!
+     * @brief This function deserializes a wide-char.
+     * @param wchar The variable that will store the wide-char read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& deserialize(
+            wchar_t& wchar)
+    {
+        uint16_t ret;
+        deserialize(ret);
+        wchar = static_cast<wchar_t>(ret);
+        return *this;
+    }
+
+    /*!
+     * @brief This function deserializes an unsigned long long.
+     * @param ulonglong_t The variable that will store the unsigned long long read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& deserialize(
+            uint64_t& ulonglong_t)
+    {
+        return deserialize(reinterpret_cast<int64_t&>(ulonglong_t));
+    }
+
+    /*!
+     * @brief This function deserializes a long long.
+     * @param longlong_t The variable that will store the long long read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize(
+            int64_t& longlong_t);
+
+    /*!
+     * @brief This function deserializes a float.
+     * @param float_t The variable that will store the float read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize(
+            float& float_t);
+
+    /*!
+     * @brief This function deserializes a double.
+     * @param double_t The variable that will store the double read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize(
+            double& double_t);
+
+    /*!
+     * @brief This function deserializes a long double.
+     * @param ldouble_t The variable that will store the long double read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     * @note Due to internal representation differences, WIN32 and *NIX like systems are not compatible.
+     */
+    Cdr_DllAPI Cdr& deserialize(
+            long double& ldouble_t);
+
+    /*!
+     * @brief This function deserializes a boolean.
+     * @param bool_t The variable that will store the boolean read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     * @exception exception::BadParamException This exception is thrown when trying to deserialize an invalid value.
+     */
+    Cdr_DllAPI Cdr& deserialize(
+            bool& bool_t);
+
+    /*!
+     * @brief This function deserializes a string.
+     * This function allocates memory to store the string. The user pointer will be set to point this allocated memory.
+     * The user will have to free this allocated memory using free()
+     * @param string_t The pointer that will point to the string read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize(
+            char*& string_t);
+
+    /*!
+     * @brief This function deserializes a wide-string.
+     * This function allocates memory to store the wide string. The user pointer will be set to point this allocated memory.
+     * The user will have to free this allocated memory using free()
+     * @param string_t The pointer that will point to the wide string read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize(
+            wchar_t*& string_t);
+
+    /*!
+     * @brief This function deserializes a std::string.
+     * @param string_t The variable that will store the string read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& deserialize(
+            std::string& string_t)
+    {
+        uint32_t length = 0;
+        const char* str = read_string(length);
+        string_t.assign(str, length);
+        return *this;
+    }
+
+    /*!
+     * @brief This function deserializes a std::wstring.
+     * @param string_t The variable that will store the string read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& deserialize(
+            std::wstring& string_t)
+    {
+        uint32_t length = 0;
+        string_t = read_wstring(length);
+        return *this;
+    }
+
+    /*!
+     * @brief Decodes a fixed string.
+     * @param[out] value Reference to the variable where the fixed string will be stored after decoding from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template <size_t MAX_CHARS>
+    Cdr& deserialize(
+            fixed_string<MAX_CHARS>& value)
+    {
+        uint32_t length = 0;
+        const char* str = read_string(length);
+        value = std::string(str, length);
+        return *this;
+    }
+
+    /*!
+     * @brief This function template deserializes an array.
+     * @param array_t The variable that will store the array read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    template<class _T, size_t _Size>
+    Cdr& deserialize(
+            std::array<_T, _Size>& array_t)
+    {
+        if (CdrVersion::XCDRv2 == cdr_version_ && !is_multi_array_primitive(&array_t))
+        {
+            uint32_t dheader {0};
+            deserialize(dheader);
+
+            uint32_t count {0};
+            auto offset = offset_;
+            while (offset_ - offset < dheader && count < _Size)
+            {
+                deserialize_array(&array_t.data()[count], 1);
+                ++count;
+            }
+
+            if (offset_ - offset != dheader)
+            {
+                throw exception::BadParamException("Member size greater than size specified by DHEADER");
+            }
+        }
+        else
+        {
+            return deserialize_array(array_t.data(), array_t.size());
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief This function template deserializes a sequence of non-primitive.
+     * @param vector_t The variable that will store the sequence read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    template<class _T, typename std::enable_if<!std::is_enum<_T>::value &&
+            !std::is_arithmetic<_T>::value>::type* = nullptr>
+    Cdr& deserialize(
+            std::vector<_T>& vector_t)
+    {
+        uint32_t sequence_length {0};
+
+        if (CdrVersion::XCDRv2 == cdr_version_)
+        {
+            uint32_t dheader {0};
+            deserialize(dheader);
+
+            auto offset = offset_;
+
+            deserialize(sequence_length);
+
+            if (0 == sequence_length)
+            {
+                vector_t.clear();
+                return *this;
+            }
+            else
+            {
+                vector_t.resize(sequence_length);
+            }
+
+            uint32_t count {0};
+            while (offset_ - offset < dheader && count < sequence_length)
+            {
+                deserialize(vector_t.data()[count]);
+                ++count;
+            }
+
+            if (offset_ - offset != dheader)
+            {
+                throw exception::BadParamException("Member size differs from the size specified by DHEADER");
+            }
+        }
+        else
+        {
+            state state_before_error(*this);
+
+            deserialize(sequence_length);
+
+            if (sequence_length == 0)
+            {
+                vector_t.clear();
+                return *this;
+            }
+
+            if ((end_ - offset_) < sequence_length)
+            {
+                set_state(state_before_error);
+                throw exception::NotEnoughMemoryException(
+                          exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+            }
+
+            try
+            {
+                vector_t.resize(sequence_length);
+                return deserialize_array(vector_t.data(), vector_t.size());
+            }
+            catch (exception::Exception& ex)
+            {
+                set_state(state_before_error);
+                ex.raise();
+            }
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief This function template deserializes a sequence of primitive.
+     * @param vector_t The variable that will store the sequence read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    template<class _T, typename std::enable_if<std::is_enum<_T>::value ||
+            std::is_arithmetic<_T>::value>::type* = nullptr>
+    Cdr& deserialize(
+            std::vector<_T>& vector_t)
+    {
+        uint32_t sequence_length = 0;
+        state state_before_error(*this);
+
+        deserialize(sequence_length);
+
+        if (sequence_length == 0)
+        {
+            vector_t.clear();
+            return *this;
+        }
+
+        if ((end_ - offset_) < sequence_length)
+        {
+            set_state(state_before_error);
+            throw exception::NotEnoughMemoryException(
+                      exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        }
+
+        try
+        {
+            vector_t.resize(sequence_length);
+            return deserialize_array(vector_t.data(), vector_t.size());
+        }
+        catch (exception::Exception& ex)
+        {
+            set_state(state_before_error);
+            ex.raise();
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief This function template deserializes a sequence.
+     * @param vector_t The variable that will store the sequence read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& deserialize(
+            std::vector<bool>& vector_t)
+    {
+        return deserialize_bool_sequence(vector_t);
+    }
+
+    /*!
+     * @brief This function template deserializes a map of non-primitive.
+     * @param map_t The variable that will store the map read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    template<class _K, class _T, typename std::enable_if<!std::is_enum<_T>::value &&
+            !std::is_arithmetic<_T>::value>::type* = nullptr>
+    Cdr& deserialize(
+            std::map<_K, _T>& map_t)
+    {
+        if (CdrVersion::XCDRv2 == cdr_version_)
+        {
+            uint32_t dheader {0};
+            deserialize(dheader);
+
+            auto offset = offset_;
+
+            uint32_t map_length {0};
+            deserialize(map_length);
+
+            map_t.clear();
+
+            uint32_t count {0};
+            while (offset_ - offset < dheader && count < map_length)
+            {
+                _K key;
+                _T val;
+                deserialize(key);
+                deserialize(val);
+                map_t.emplace(std::pair<_K, _T>(std::move(key), std::move(val)));
+                ++count;
+            }
+
+            if (offset_ - offset != dheader)
+            {
+                throw exception::BadParamException("Member size greater than size specified by DHEADER");
+            }
+        }
+        else
+        {
+            uint32_t sequence_length = 0;
+            state state_(*this);
+
+            deserialize(sequence_length);
+
+            try
+            {
+                for (uint32_t i = 0; i < sequence_length; ++i)
+                {
+                    _K key;
+                    _T value;
+                    deserialize(key);
+                    deserialize(value);
+                    map_t.emplace(std::pair<_K, _T>(std::move(key), std::move(value)));
+                }
+            }
+            catch (exception::Exception& ex)
+            {
+                set_state(state_);
+                ex.raise();
+            }
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief This function template deserializes a map of primitive.
+     * @param map_t The variable that will store the map read from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    template<class _K, class _T, typename std::enable_if<std::is_enum<_T>::value ||
+            std::is_arithmetic<_T>::value>::type* = nullptr>
+    Cdr& deserialize(
+            std::map<_K, _T>& map_t)
+    {
+        uint32_t sequence_length = 0;
+        state state_(*this);
+
+        deserialize(sequence_length);
+
+        try
+        {
+            for (uint32_t i = 0; i < sequence_length; ++i)
+            {
+                _K key;
+                _T value;
+                deserialize(key);
+                deserialize(value);
+                map_t.emplace(std::pair<_K, _T>(std::move(key), std::move(value)));
+            }
+        }
+        catch (exception::Exception& ex)
+        {
+            set_state(state_);
+            ex.raise();
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief Decodes a bitset from the buffer.
+     * @param[out] value Reference to the variable where the bitset will be stored after decoding from the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<size_t N, typename std::enable_if < (N < 9) > ::type* = nullptr>
+    Cdr& deserialize(
+            std::bitset<N>& value)
+    {
+        uint8_t decode_value {0};
+        deserialize(decode_value);
+        value = decode_value;
+        return *this;
+    }
+
+    template<size_t N, typename std::enable_if < (8 < N && N < 17) > ::type* = nullptr>
+    Cdr& deserialize(
+            std::bitset<N>& value)
+    {
+        uint16_t decode_value {0};
+        deserialize(decode_value);
+        value = decode_value;
+        return *this;
+    }
+
+    template<size_t N, typename std::enable_if < (16 < N && N < 33) > ::type* = nullptr>
+    Cdr& deserialize(
+            std::bitset<N>& value)
+    {
+        uint32_t decode_value {0};
+        deserialize(decode_value);
+        value = decode_value;
+        return *this;
+    }
+
+    template<size_t N, typename std::enable_if < (32 < N && N < 65) > ::type* = nullptr>
+    Cdr& deserialize(
+            std::bitset<N>& value)
+    {
+        uint64_t decode_value {0};
+        deserialize(decode_value);
+        value = decode_value;
+        return *this;
+    }
+
+    /*!
+     * @brief Decodes an array of a type not managed by this encoder from the buffer.
+     *
+     * To do that, the encoder expects a function `deserialize` to be provided by the type.
+     *
+     * @param[out] value Reference to the variable where the array will be stored after decoding from the buffer.
+     * @param[in] num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& deserialize_array(
+            _T* value,
+            size_t num_elements)
+    {
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            deserialize(value[count]);
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief This function template deserializes an array of non-basic objects with a different endianness.
+     * @param type_t The variable that will store the array of objects read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @param endianness Endianness that will be used in the deserialization of this value.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& deserialize_array(
+            _T* type_t,
+            size_t num_elements,
+            Endianness endianness)
+    {
+        bool aux_swap = swap_bytes_;
+        swap_bytes_ = (swap_bytes_ && (static_cast<Endianness>(endianness_) == endianness)) ||
+                (!swap_bytes_ && (static_cast<Endianness>(endianness_) != endianness));
+
+        try
+        {
+            deserialize_array(type_t, num_elements);
+            swap_bytes_ = aux_swap;
+        }
+        catch (exception::Exception& ex)
+        {
+            swap_bytes_ = aux_swap;
+            ex.raise();
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief This function deserializes an array of octets.
+     * @param octet_t The variable that will store the array of octets read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& deserialize_array(
+            uint8_t* octet_t,
+            size_t num_elements)
+    {
+        return deserialize_array(reinterpret_cast<char*>(octet_t), num_elements);
+    }
+
+    /*!
+     * @brief This function deserializes an array of characters.
+     * @param char_t The variable that will store the array of characters read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize_array(
+            char* char_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of int8_t.
+     * @param int8 The variable that will store the array of int8_t read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& deserialize_array(
+            int8_t* int8,
+            size_t num_elements)
+    {
+        return deserialize_array(reinterpret_cast<char*>(int8), num_elements);
+    }
+
+    /*!
+     * @brief This function deserializes an array of unsigned shorts.
+     * @param ushort_t The variable that will store the array of unsigned shorts read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& deserialize_array(
+            uint16_t* ushort_t,
+            size_t num_elements)
+    {
+        return deserialize_array(reinterpret_cast<int16_t*>(ushort_t), num_elements);
+    }
+
+    /*!
+     * @brief This function deserializes an array of shorts.
+     * @param short_t The variable that will store the array of shorts read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize_array(
+            int16_t* short_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of unsigned longs.
+     * @param ulong_t The variable that will store the array of unsigned longs read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& deserialize_array(
+            uint32_t* ulong_t,
+            size_t num_elements)
+    {
+        return deserialize_array(reinterpret_cast<int32_t*>(ulong_t), num_elements);
+    }
+
+    /*!
+     * @brief This function deserializes an array of longs.
+     * @param long_t The variable that will store the array of longs read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize_array(
+            int32_t* long_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of wide-chars.
+     * @param wchar The variable that will store the array of wide-chars read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize_array(
+            wchar_t* wchar,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of unsigned long longs.
+     * @param ulonglong_t The variable that will store the array of unsigned long longs read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& deserialize_array(
+            uint64_t* ulonglong_t,
+            size_t num_elements)
+    {
+        return deserialize_array(reinterpret_cast<int64_t*>(ulonglong_t), num_elements);
+    }
+
+    /*!
+     * @brief This function deserializes an array of long longs.
+     * @param longlong_t The variable that will store the array of long longs read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize_array(
+            int64_t* longlong_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of floats.
+     * @param float_t The variable that will store the array of floats read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize_array(
+            float* float_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of doubles.
+     * @param double_t The variable that will store the array of doubles read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize_array(
+            double* double_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of long doubles.
+     * @param ldouble_t The variable that will store the array of long doubles read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     * @note Due to internal representation differences, WIN32 and *NIX like systems are not compatible.
+     */
+    Cdr_DllAPI Cdr& deserialize_array(
+            long double* ldouble_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of booleans.
+     * @param bool_t The variable that will store the array of booleans read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize_array(
+            bool* bool_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function template deserializes a raw sequence of non-primitives.
+     * This function allocates memory to store the sequence. The user pointer will be set to point this allocated memory.
+     * The user will have to free this allocated memory using free()
+     * @param sequence_t The pointer that will store the sequence read from the buffer.
+     * @param num_elements This variable return the number of elements of the sequence.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    template<class _T, typename std::enable_if<!std::is_enum<_T>::value &&
+            !std::is_arithmetic<_T>::value>::type* = nullptr>
+    Cdr& deserialize_sequence(
+            _T*& sequence_t,
+            size_t& num_elements)
+    {
+        uint32_t sequence_length {0};
+
+        if (CdrVersion::XCDRv2 == cdr_version_)
+        {
+            uint32_t dheader {0};
+            deserialize(dheader);
+
+            auto offset = offset_;
+
+            deserialize(sequence_length);
+
+            try
+            {
+                sequence_t = reinterpret_cast<_T*>(calloc(sequence_length, sizeof(_T)));
+
+                uint32_t count {0};
+                while (offset_ - offset < dheader && count < sequence_length)
+                {
+                    deserialize(sequence_t[count]);
+                    ++count;
+                }
+
+                if (offset_ - offset != dheader)
+                {
+                    throw exception::BadParamException("Member size greater than size specified by DHEADER");
+                }
+            }
+            catch (exception::Exception& ex)
+            {
+                free(sequence_t);
+                sequence_t = NULL;
+                ex.raise();
+            }
+        }
+        else
+        {
+            state state_before_error(*this);
+
+            deserialize(sequence_length);
+
+            if ((end_ - offset_) < sequence_length)
+            {
+                set_state(state_before_error);
+                throw exception::NotEnoughMemoryException(
+                          exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+            }
+
+            try
+            {
+                sequence_t = reinterpret_cast<_T*>(calloc(sequence_length, sizeof(_T)));
+                deserialize_array(sequence_t, sequence_length);
+            }
+            catch (exception::Exception& ex)
+            {
+                free(sequence_t);
+                sequence_t = NULL;
+                set_state(state_before_error);
+                ex.raise();
+            }
+        }
+
+        num_elements = sequence_length;
+        return *this;
+    }
+
+    /*!
+     * @brief This function template deserializes a raw sequence of primitives.
+     * This function allocates memory to store the sequence. The user pointer will be set to point this allocated memory.
+     * The user will have to free this allocated memory using free()
+     * @param sequence_t The pointer that will store the sequence read from the buffer.
+     * @param num_elements This variable return the number of elements of the sequence.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    template<class _T, typename std::enable_if<std::is_enum<_T>::value ||
+            std::is_arithmetic<_T>::value>::type* = nullptr>
+    Cdr& deserialize_sequence(
+            _T*& sequence_t,
+            size_t& num_elements)
+    {
+        uint32_t sequence_length = 0;
+        state state_before_error(*this);
+
+        deserialize(sequence_length);
+
+        try
+        {
+            sequence_t = reinterpret_cast<_T*>(calloc(sequence_length, sizeof(_T)));
+            deserialize_array(sequence_t, sequence_length);
+        }
+        catch (exception::Exception& ex)
+        {
+            free(sequence_t);
+            sequence_t = NULL;
+            set_state(state_before_error);
+            ex.raise();
+        }
+
+        num_elements = sequence_length;
+        return *this;
+    }
+
+    /*!
+     * @brief This function template deserializes a raw sequence with a different endianness.
+     * This function allocates memory to store the sequence. The user pointer will be set to point this allocated memory.
+     * The user will have to free this allocated memory using free()
+     * @param sequence_t The pointer that will store the sequence read from the buffer.
+     * @param num_elements This variable return the number of elements of the sequence.
+     * @param endianness Endianness that will be used in the deserialization of this value.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& deserialize_sequence(
+            _T*& sequence_t,
+            size_t& num_elements,
+            Endianness endianness)
+    {
+        bool aux_swap = swap_bytes_;
+        swap_bytes_ = (swap_bytes_ && (static_cast<Endianness>(endianness_) == endianness)) ||
+                (!swap_bytes_ && (static_cast<Endianness>(endianness_) != endianness));
+
+        try
+        {
+            deserialize_sequence(sequence_t, num_elements);
+            swap_bytes_ = aux_swap;
+        }
+        catch (exception::Exception& ex)
+        {
+            swap_bytes_ = aux_swap;
+            ex.raise();
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief This function template deserializes a string sequence.
+     * This function allocates memory to store the sequence. The user pointer will be set to point this allocated memory.
+     * The user will have to free this allocated memory using free()
+     * @param sequence_t The pointer that will store the sequence read from the buffer.
+     * @param num_elements This variable return the number of elements of the sequence.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& deserialize_sequence(
+            std::string*& sequence_t,
+            size_t& num_elements)
+    {
+        return deserialize_string_sequence(sequence_t, num_elements);
+    }
+
+    /*!
+     * @brief This function template deserializes a wide-string sequence.
+     * This function allocates memory to store the sequence. The user pointer will be set to point this allocated memory.
+     * The user will have to free this allocated memory using free()
+     * @param sequence_t The pointer that will store the sequence read from the buffer.
+     * @param num_elements This variable return the number of elements of the sequence.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    TEMPLATE_SPEC
+    Cdr& deserialize_sequence(
+            std::wstring*& sequence_t,
+            size_t& num_elements)
+    {
+        return deserialize_wstring_sequence(sequence_t, num_elements);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    /// XCDR extensions
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /*!
+     * @brief Encodes a member of a type according to the encoding algorithm used.
+     * @param[in] member_id Member identifier.
+     * @param[in] member_value Member value.
+     * @param[in] header_selection Selects which member header will be used to allocate space.
+     * Default: XCdrHeaderSelection::AUTO_WITH_SHORT_HEADER_BY_DEFAULT.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& serialize_member(
+            const MemberId& member_id,
+            const _T& member_value,
+            XCdrHeaderSelection header_selection = XCdrHeaderSelection::AUTO_WITH_SHORT_HEADER_BY_DEFAULT)
+    {
+        Cdr::state current_state(*this);
+        (this->*begin_serialize_member_)(member_id, true, current_state, header_selection);
+        serialize(member_value);
+        return (this->*end_serialize_member_)(current_state);
+    }
+
+    /*!
+     * @brief Encodes an optional member of a type according to the encoding algorithm used.
+     * @param[in] member_id Member identifier.
+     * @param[in] member_value Optional member value.
+     * @param[in] header_selection Selects which member header will be used to allocate space.
+     * Default: XCdrHeaderSelection::AUTO_WITH_SHORT_HEADER_BY_DEFAULT.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& serialize_member(
+            const MemberId& member_id,
+            const optional<_T>& member_value,
+            XCdrHeaderSelection header_selection = XCdrHeaderSelection::AUTO_WITH_SHORT_HEADER_BY_DEFAULT)
+    {
+        Cdr::state current_state(*this);
+        (this->*begin_serialize_opt_member_)(member_id, member_value.has_value(), current_state, header_selection);
+        serialize(member_value);
+        return (this->*end_serialize_opt_member_)(current_state);
+    }
+
+    /*!
+     * @brief Decodes a member of a type according to the encoding algorithm used.
+     * @param[out] member_value A reference of the variable where the member value will be stored.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& deserialize_member(
+            _T& member_value)
+    {
+        return deserialize(member_value);
+    }
+
+    /*!
+     * @brief Decodes an optional member of a type according to the encoding algorithm used.
+     * @param[out] member_value A reference of the variable where the optional member value will be stored.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& deserialize_member(
+            optional<_T>& member_value)
+    {
+        if (EncodingAlgorithmFlag::PLAIN_CDR == current_encoding_)
+        {
+            Cdr::state current_state(*this);
+            MemberId member_id;
+            xcdr1_deserialize_member_header(member_id, current_state);
+            auto prev_offset = offset_;
+            if (0 < current_state.member_size_)
+            {
+                deserialize(member_value);
+            }
+            if (current_state.member_size_ != offset_ - prev_offset)
+            {
+                throw exception::BadParamException(
+                          "Member size provided by member header is not equal to the real decoded member size");
+            }
+        }
+        else
+        {
+            deserialize(member_value);
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief Tells to the encoder a new type and its members starts to be encoded.
+     * @param[in,out] current_state State of the encoder previous of calling this function.
+     * @param[in] type_encoding The encoding algorithm used to encode the type and its members.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& begin_serialize_type(
+            Cdr::state& current_state,
+            EncodingAlgorithmFlag type_encoding)
+    {
+        return (this->*begin_serialize_type_)(current_state, type_encoding);
+    }
+
+    /*!
+     * @brief Tells to the encoder the encoding of the type finishes.
+     * @param[in] current_state State of the encoder previous of calling the function begin_serialize_type.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& end_serialize_type(
+            Cdr::state& current_state)
+    {
+        return (this->*end_serialize_type_)(current_state);
+    }
+
+    /*!
+     * @brief Tells to the encoder a new type and its members starts to be decoded.
+     * @param[in] type_encoding The encoding algorithm used to decode the type and its members.
+     * @param[in] functor Functor called each time a member has to be decoded.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    Cdr_DllAPI Cdr& deserialize_type(
+            EncodingAlgorithmFlag type_encoding,
+            std::function<bool (Cdr&, const MemberId&)> functor)
+    {
+        return (this->*deserialize_type_)(type_encoding, functor);
+    }
+
+    /*!
+     * @brief Encodes an optional in the buffer.
+     * @param[in] value A reference to the optional which will be encoded in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& serialize(
+            const optional<_T>& value)
+    {
+        if (CdrVersion::XCDRv2 == cdr_version_ && EncodingAlgorithmFlag::PL_CDR2 != current_encoding_)
+        {
+            serialize(value.has_value());
+        }
+
+        if (value.has_value())
+        {
+            serialize(*value);
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief Encodes an external in the buffer.
+     * @param[in] value A reference to the external which will be encoded in the buffer.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::BadParamException This exception is thrown when external is null.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& serialize(
+            const external<_T>& value)
+    {
+        if (!value)
+        {
+            throw exception::BadParamException("External member is null");
+        }
+
+        serialize(*value);
+        return *this;
+    }
+
+    /*!
+     * @brief Tells the encoder the member identifier for the next member to be encoded.
+     * @param[in] member_id Member identifier.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::BadParamException This exception is thrown when a member id is already set without being
+     * encoded.
+     */
+    Cdr_DllAPI Cdr& operator <<(
+            const MemberId& member_id)
+    {
+        if (next_member_id_ != MEMBER_ID_INVALID)
+        {
+            throw exception::BadParamException("Member id already set and not encoded");
+        }
+
+        next_member_id_ = member_id;
+        return *this;
+    }
+
+    /*!
+     * @brief Decodes an optional from the buffer.
+     * @param[out] value A reference to the variable where the optional will be stored.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& deserialize(
+            optional<_T>& value)
+    {
+        bool is_present = true;
+        if (CdrVersion::XCDRv2 == cdr_version_ && EncodingAlgorithmFlag::PL_CDR2 != current_encoding_)
+        {
+            deserialize(is_present);
+        }
+        value.reset(is_present);
+        if (is_present)
+        {
+            deserialize(*value);
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief Decodes an external from the buffer.
+     * @param[out] value A reference to the variable where the external will be stored.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::BadParamException This exception is thrown when the external is locked.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& deserialize(
+            external<_T>& value)
+    {
+        if (value.is_locked())
+        {
+            throw exception::BadParamException("External member is locked");
+        }
+
+        if (!value)
+        {
+            value = external<_T>{new
+#if !defined(_MSC_VER) || _MSC_VER >= 1920
+                                 _T()
+#else
+                                 external<_T>::type()
+#endif // if _MSC_VER >= 1920
+            };
+        }
+
+        deserialize(*value);
+        return *this;
+    }
+
+    /*!
+     * @brief Decodes an optional of an external from the buffer.
+     * @param[out] value A reference to the variable where the optional will be stored.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::BadParamException This exception is thrown when the external is locked.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& deserialize(
+            optional<external<_T>>& value)
+    {
+        if (value.has_value() && value.value().is_locked())
+        {
+            throw exception::BadParamException("External member is locked");
+        }
+
+        bool is_present = true;
+        if (CdrVersion::XCDRv2 == cdr_version_ && EncodingAlgorithmFlag::PL_CDR2 != current_encoding_)
+        {
+            deserialize(is_present);
+        }
+        value.reset(is_present);
+        if (is_present)
+        {
+            deserialize(*value);
+        }
+        return *this;
+    }
 
 private:
-  Cdr(const Cdr&) = delete;
 
-  Cdr& operator=(const Cdr&) = delete;
+    Cdr(
+            const Cdr&) = delete;
 
-  Cdr& serializeBoolSequence(const std::vector<bool>& vector_t);
+    Cdr& operator =(
+            const Cdr&) = delete;
 
-  Cdr& deserializeBoolSequence(std::vector<bool>& vector_t);
+    Cdr_DllAPI Cdr& serialize_bool_sequence(
+            const std::vector<bool>& vector_t);
 
-  Cdr& deserializeStringSequence(std::string*& sequence_t, size_t& numElements);
+    Cdr_DllAPI Cdr& deserialize_bool_sequence(
+            std::vector<bool>& vector_t);
 
-  Cdr& deserializeWStringSequence(std::wstring*& sequence_t, size_t& numElements);
+    Cdr_DllAPI Cdr& deserialize_string_sequence(
+            std::string*& sequence_t,
+            size_t& num_elements);
 
-#if HAVE_CXX0X
-  /*!
-   * @brief This function template detects the content type of the STD container array and
-   * serializes the array.
-   * @param array_t The array that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T, size_t _Size>
-  Cdr& serializeArray(const std::array<_T, _Size>* array_t, size_t numElements)
-  {
-    return serializeArray(array_t->data(), numElements * array_t->size());
-  }
+    Cdr_DllAPI Cdr& deserialize_wstring_sequence(
+            std::wstring*& sequence_t,
+            size_t& num_elements);
 
-  /*!
-   * @brief This function template detects the content type of the STD container array and
-   * serializes the array with a different endianness.
-   * @param array_t The array that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize a position that exceeds the internal memory size.
-   */
-  template <class _T, size_t _Size>
-  Cdr& serializeArray(const std::array<_T, _Size>* array_t, size_t numElements,
-                      Endianness endianness)
-  {
-    return serializeArray(array_t->data(), numElements * array_t->size(), endianness);
-  }
+    /*!
+     * @brief This function template detects the content type of the STD container array and serializes the array.
+     * @param array_t The array that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    template<class _T, size_t _Size>
+    Cdr& serialize_array(
+            const std::array<_T, _Size>* array_t,
+            size_t num_elements)
+    {
+        return serialize_array(array_t->data(), num_elements * array_t->size());
+    }
 
-  /*!
-   * @brief This function template detects the content type of the STD container array and
-   * deserializes the array.
-   * @param array_t The variable that will store the array read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T, size_t _Size>
-  Cdr& deserializeArray(std::array<_T, _Size>* array_t, size_t numElements)
-  {
-    return deserializeArray(array_t->data(), numElements * array_t->size());
-  }
+    /*!
+     * @brief This function template detects the content type of the STD container array and deserializes the array.
+     * @param array_t The variable that will store the array read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    template<class _T, size_t _Size>
+    Cdr& deserialize_array(
+            std::array<_T, _Size>* array_t,
+            size_t num_elements)
+    {
+        return deserialize_array(array_t->data(), num_elements * array_t->size());
+    }
 
-  /*!
-   * @brief This function template detects the content type of STD container array and
-   * deserializes the array with a different endianness.
-   * @param array_t The variable that will store the array read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @param endianness Endianness that will be used in the serialization of this value.
-   * @return Reference to the eprosima::fastcdr::Cdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   */
-  template <class _T, size_t _Size>
-  Cdr& deserializeArray(std::array<_T, _Size>* array_t, size_t numElements,
-                        Endianness endianness)
-  {
-    return deserializeArray(array_t->data(), numElements * array_t->size(), endianness);
-  }
+    /*!
+     * @brief This function template detects the content type of STD container array and deserializes the array with a different endianness.
+     * @param array_t The variable that will store the array read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @param endianness Endianness that will be used in the deserialization of this value.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     */
+    template<class _T, size_t _Size>
+    Cdr& deserialize_array(
+            std::array<_T, _Size>* array_t,
+            size_t num_elements,
+            Endianness endianness)
+    {
+        return deserialize_array(array_t->data(), num_elements * array_t->size(), endianness);
+    }
 
-#endif  // if HAVE_CXX0X
+    /*!
+     * @brief This function returns the extra bytes regarding the allignment.
+     * @param data_size The size of the data that will be serialized.
+     * @return The size needed for the alignment.
+     */
+    inline size_t alignment(
+            size_t data_size) const
+    {
+        return data_size > last_data_size_ ? (data_size - ((offset_ - origin_) % data_size)) & (data_size - 1) : 0;
+    }
 
-  /*!
-   * @brief This function returns the extra bytes regarding the allignment.
-   * @param dataSize The size of the data that will be serialized.
-   * @return The size needed for the aligment.
-   */
-  inline size_t alignment(size_t dataSize) const
-  {
-    return dataSize > m_lastDataSize ?
-               (dataSize - ((m_currentPosition - m_alignPosition) % dataSize)) &
-                   (dataSize - 1) :
-               0;
-  }
+    /*!
+     * @brief This function jumps the number of bytes of the alignment. These bytes should be calculated with the function eprosima::fastcdr::Cdr::alignment.
+     * @param align The number of bytes to be skipped.
+     */
+    inline void make_alignment(
+            size_t align)
+    {
+        offset_ += align;
+        last_data_size_ = 0;
+    }
 
-  /*!
-   * @brief This function jumps the number of bytes of the alignment. These bytes should
-   * be calculated with the function eprosima::fastcdr::Cdr::alignment.
-   * @param align The number of bytes to be skipped.
-   */
-  inline void makeAlign(size_t align)
-  {
-    m_currentPosition += align;
-  }
+    /*!
+     * @brief This function resizes the internal buffer. It only applies if the FastBuffer object was created with the default constructor.
+     * @param min_size_inc Minimun size increase for the internal buffer
+     * @return True if the resize was succesful, false if it was not
+     */
+    bool resize(
+            size_t min_size_inc);
 
-  /*!
-   * @brief This function resizes the internal buffer. It only applies if the FastBuffer
-   * object was created with the default constructor.
-   * @param minSizeInc Minimun size increase for the internal buffer
-   * @return True if the resize was succesful, false if it was not
-   */
-  bool resize(size_t minSizeInc);
+    Cdr_DllAPI const char* read_string(
+            uint32_t& length);
+    Cdr_DllAPI const std::wstring read_wstring(
+            uint32_t& length);
 
-  // TODO
-  const char* readString(uint32_t& length);
-  const std::wstring readWString(uint32_t& length);
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    /// XCDR extensions
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    /*!
+     * @brief Encodes a short member header of a member according to XCDRv1.
+     * @param[in] member_id Member identifier.
+     * @pre Member identifier less than 0x3F00.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    void xcdr1_serialize_short_member_header(
+            const MemberId& member_id);
 
-  //! @brief Reference to the buffer that will be serialized/deserialized.
-  FastBuffer& m_cdrBuffer;
+    /*!
+     * @brief Finish the encoding of a short member header of a member according to XCDRv1.
+     * @param[in] member_id Member identifier.
+     * @pre Member identifier less than 0x3F00.
+     * @param[in] member_serialized_size Size of the serialized member.
+     * @pre Serialized size equal or less than 0xFFFF.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    void xcdr1_end_short_member_header(
+            const MemberId& member_id,
+            size_t member_serialized_size);
 
-  //! @brief The type of CDR that will be use in serialization/deserialization.
-  CdrType m_cdrType;
+    /*!
+     * @brief Encodes a long member header of a member according to XCDRv1.
+     * @param[in] member_id Member identifier.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    void xcdr1_serialize_long_member_header(
+            const MemberId& member_id);
 
-  //! @brief Using DDS_CDR type, this attribute stores if the stream buffer contains a
-  //! parameter list or not.
-  DDSCdrPlFlag m_plFlag;
+    /*!
+     * @brief Finish the encoding of a long member header of a member according to XCDRv1.
+     * @param[in] member_id Member identifier.
+     * @param[in] member_serialized_size Size of the serialized member.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    void xcdr1_end_long_member_header(
+            const MemberId& member_id,
+            size_t member_serialized_size);
 
-  //! @brief This attribute stores the option flags when the CDR type is DDS_CDR;
-  uint16_t m_options;
+    /*!
+     * @brief Changes the previous encoded long header to a short header according to XCDRv1.
+     * @param[in] member_id Member identifier.
+     * @pre Member identifier less than 0x3F00.
+     * @param[in] member_serialized_size Size of the serialized member.
+     * @pre Serialized size equal or less than 0xFFFF.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    void xcdr1_change_to_short_member_header(
+            const MemberId& member_id,
+            size_t member_serialized_size);
 
-  //! @brief The endianness that will be applied over the buffer.
-  uint8_t m_endianness;
+    /*!
+     * @brief Changes the previous encoded short header to a long header according to XCDRv1.
+     * @param[in] member_id Member identifier.
+     * @param[in] member_serialized_size Size of the serialized member.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    void xcdr1_change_to_long_member_header(
+            const MemberId& member_id,
+            size_t member_serialized_size);
 
-  //! @brief This attribute specifies if it is needed to swap the bytes.
-  bool m_swapBytes;
+    /*!
+     * @brief Decodes a member header according to XCDRv1.
+     * @param[out] member_id Member identifier.
+     * @param[in,out] current_state State of the encoder previous to call this function.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     * @exception exception::BadParamException This exception is thrown when trying to decode an invalid value.
+     */
+    Cdr_DllAPI bool xcdr1_deserialize_member_header(
+            MemberId& member_id,
+            Cdr::state& current_state);
 
-  //! @brief Stores the last datasize serialized/deserialized. It's used to optimize.
-  size_t m_lastDataSize;
+    /*!
+     * @brief Encodes a short member header of a member according to XCDRv2.
+     * @param[in] member_id Member identifier.
+     * @pre Member identifier less than 0x10000000.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    void xcdr2_serialize_short_member_header(
+            const MemberId& member_id);
 
-  //! @brief The current position in the serialization/deserialization process.
-  FastBuffer::iterator m_currentPosition;
+    /*!
+     * @brief Finish the encoding of a short member header of a member according to XCDRv2.
+     * @param[in] member_id Member identifier.
+     * @pre Member identifier less than 0x10000000.
+     * @param[in] member_serialized_size Size of the serialized member.
+     * @pre Serialized size equal or less than 0x8.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    void xcdr2_end_short_member_header(
+            const MemberId& member_id,
+            size_t member_serialized_size);
 
-  //! @brief The position from where the aligment is calculated.
-  FastBuffer::iterator m_alignPosition;
+    /*!
+     * @brief Encodes a long member header of a member according to XCDRv2.
+     * @param[in] member_id Member identifier.
+     * @pre Member identifier less than 0x10000000.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    void xcdr2_serialize_long_member_header(
+            const MemberId& member_id);
 
-  //! @brief The last position in the buffer;
-  FastBuffer::iterator m_lastPosition;
+    /*!
+     * @brief Finish the encoding of a long member header of a member according to XCDRv2.
+     * @param[in] member_id Member identifier.
+     * @pre Member identifier less than 0x10000000.
+     * @param[in] member_serialized_size Size of the serialized member.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    void xcdr2_end_long_member_header(
+            const MemberId& member_id,
+            size_t member_serialized_size);
+
+    /*!
+     * @brief Changes the previous encoded long header to a short header according to XCDRv2.
+     * @param[in] member_id Member identifier.
+     * @pre Member identifier less than 0x10000000.
+     * @param[in] member_serialized_size Size of the serialized member.
+     * @pre Serialized size equal or less than 8.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    void xcdr2_change_to_short_member_header(
+            const MemberId& member_id,
+            size_t member_serialized_size);
+
+    /*!
+     * @brief Changes the previous encoded long header to a short header according to XCDRv2.
+     * @param[in] member_id Member identifier.
+     * @pre Member identifier less than 0x10000000.
+     * @param[in] member_serialized_size Size of the serialized member.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    void xcdr2_change_to_long_member_header(
+            const MemberId& member_id,
+            size_t member_serialized_size);
+
+    /*!
+     * @brief Join the previous encoded long header with the next DHEADER which was serialized after.
+     * @param[in] member_id Member identifier.
+     * @pre Member identifier less than 0x10000000.
+     * @param[in] offset The last offset of the buffer previous to call this function.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    void xcdr2_shrink_to_long_member_header(
+            const MemberId& member_id,
+            const FastBuffer::iterator& offset);
+
+    /*!
+     * @brief Decodes a member header according to XCDRv2.
+     * @param[out] member_id Member identifier.
+     * @param[in,out] current_state State of the encoder previous to call this function.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     * @exception exception::BadParamException This exception is thrown when trying to decode an invalid value.
+     */
+    void xcdr2_deserialize_member_header(
+            MemberId& member_id,
+            Cdr::state& current_state);
+
+    /*!
+     * @brief Tells to the encoder a member starts to be encoded according to XCDRv1.
+     * @param[in] member_id Member identifier.
+     * @pre Member identifier cannot be MEMBER_ID_INVALID and next_member_id_ must be equal to the member identifier or
+     * MEMBER_ID_INVALID.
+     * @param[in] is_present If the member is present.
+     * @pre When XCDRv1, is_present must be always true.
+     * @param[in,out] current_state State of the encoder previous to call this function.
+     * @pre Current encoding algorithm must be EncodingAlgorithmFlag::PLAIN_CDR or EncodingAlgorithmFlag::PL_CDR.
+     * @param[in] header_selection Selects which member header will be used to allocate space.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     * @exception exception::BadParamException This exception is thrown when trying to encode a long header when
+     * header_selection is XCdrHeaderSelection::SHORT_HEADER.
+     */
+    Cdr& xcdr1_begin_serialize_member(
+            const MemberId& member_id,
+            bool is_present,
+            Cdr::state& current_state,
+            XCdrHeaderSelection header_selection);
+
+    /*!
+     * @brief Tells to the encoder to finish the encoding of the member.
+     * @param[in] current_state State of the encoder previous to call xcdr1_begin_serialize_member function.
+     * @pre next_member_id_ cannot be MEMBER_ID_INVALID.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     * @exception exception::BadParamException This exception is thrown when trying to encode a long header when
+     * header_selection is XCdrHeaderSelection::SHORT_HEADER.
+     */
+    Cdr& xcdr1_end_serialize_member(
+            const Cdr::state& current_state);
+
+    /*!
+     * @brief Tells to the encoder a member starts to be encoded according to XCDRv1.
+     * @param[in] member_id Member identifier.
+     * @pre Member identifier cannot be MEMBER_ID_INVALID and next_member_id_ must be equal to the member identifier or
+     * MEMBER_ID_INVALID.
+     * @param[in] is_present If the member is present.
+     * @param[in,out] current_state State of the encoder previous to call this function.
+     * @pre Current encoding algorithm must be EncodingAlgorithmFlag::PLAIN_CDR or EncodingAlgorithmFlag::PL_CDR.
+     * @param[in] header_selection Selects which member header will be used to allocate space.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     * @exception exception::BadParamException This exception is thrown when trying to encode a long header when
+     * header_selection is XCdrHeaderSelection::SHORT_HEADER.
+     */
+    Cdr& xcdr1_begin_serialize_opt_member(
+            const MemberId& member_id,
+            bool is_present,
+            Cdr::state& current_state,
+            XCdrHeaderSelection header_selection);
+
+    /*!
+     * @brief Tells to the encoder to finish the encoding of the member.
+     * @param[in] current_state State of the encoder previous to call xcdr1_begin_serialize_opt_member function.
+     * @pre next_member_id_ cannot be MEMBER_ID_INVALID.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     * @exception exception::BadParamException This exception is thrown when trying to encode a long header when
+     * header_selection is XCdrHeaderSelection::SHORT_HEADER.
+     */
+    Cdr& xcdr1_end_serialize_opt_member(
+            const Cdr::state& current_state);
+
+    /*!
+     * @brief Tells to the encoder a member starts to be encoded according to XCDRv2.
+     * @param[in] member_id Member identifier.
+     * @pre Member identifier cannot be MEMBER_ID_INVALID and next_member_id_ must be equal to the member identifier or
+     * MEMBER_ID_INVALID.
+     * @param[in] is_present If the member is present.
+     * @param[in,out] current_state State of the encoder previous to call this function.
+     * @pre Current encoding algorithm must be EncodingAlgorithmFlag::PLAIN_CDR2, EncodingAlgorithmFlag::DELIMIT_CDR2 or
+     * EncodingAlgorithmFlag::PL_CDR2.
+     * @param[in] header_selection Selects which member header will be used to allocate space.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     * @exception exception::BadParamException This exception is thrown when trying to encode member identifier equal or
+     * greater than 0x10000000.
+     */
+    Cdr& xcdr2_begin_serialize_member(
+            const MemberId& member_id,
+            bool is_present,
+            Cdr::state& current_state,
+            XCdrHeaderSelection header_selection);
+
+    /*!
+     * @brief Tells to the encoder to finish the encoding of the member.
+     * @param[in] current_state State of the encoder previous to call xcdr2_begin_serialize_member function.
+     * @pre next_member_id_ cannot be MEMBER_ID_INVALID.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     * @exception exception::BadParamException This exception is thrown when trying to encode a long header when
+     * header_selection is XCdrHeaderSelection::SHORT_HEADER.
+     */
+    Cdr& xcdr2_end_serialize_member(
+            const Cdr::state& current_state);
+
+    /*!
+     * @brief Tells to the encoder a new type and its members start to be encoded according to XCDRv1.
+     * @param[in,out] current_state State of the encoder previous to call this function.
+     * @pre Current encoding algorithm must be EncodingAlgorithmFlag::PLAIN_CDR or EncodingAlgorithmFlag::PL_CDR.
+     * @param[in] type_encoding Encoding algorithm used to encode the type and its members.
+     * @pre Type encoding algorithm must be EncodingAlgorithmFlag::PLAIN_CDR or EncodingAlgorithmFlag::PL_CDR.
+     * @pre If it is the beginning of the whole encoding, current encoding must be equal to type encoding.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     */
+    Cdr& xcdr1_begin_serialize_type(
+            Cdr::state& current_state,
+            EncodingAlgorithmFlag type_encoding) noexcept;
+
+    /*!
+     * @brief Tells to the encoder to finish the encoding of the type.
+     * @param[in] current_state State of the encoder previous to call xcdr1_begin_serialize_type function.
+     * @pre Current encoding algorithm must be EncodingAlgorithmFlag::PLAIN_CDR or EncodingAlgorithmFlag::PL_CDR.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    Cdr& xcdr1_end_serialize_type(
+            const Cdr::state& current_state);
+
+    /*!
+     * @brief Tells to the encoder a new type and its members start to be encoded according to XCDRv2.
+     * @param[in,out] current_state State of the encoder previous to call this function.
+     * @pre Current encoding algorithm must be EncodingAlgorithmFlag::PLAIN_CDR2, EncodingAlgorithmFlag::DELIMIT_CDR2 or
+     * EncodingAlgorithmFlag::PL_CDR2.
+     * @param[in] type_encoding Encoding algorithm used to encode the type and its members.
+     * @pre Type encoding algorithm must be EncodingAlgorithmFlag::PLAIN_CDR2, EncodingAlgorithmFlag::DELIMIT_CDR2 or
+     * EncodingAlgorithmFlag::PL_CDR2.
+     * @pre If it is the beginning of the whole encoding, current encoding must be equal to type encoding.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    Cdr& xcdr2_begin_serialize_type(
+            Cdr::state& current_state,
+            EncodingAlgorithmFlag type_encoding);
+
+    /*!
+     * @brief Tells to the encoder to finish the encoding of the type.
+     * @param[in] current_state State of the encoder previous to call xcdr2_begin_serialize_type function.
+     * @pre Current encoding algorithm must be EncodingAlgorithmFlag::PLAIN_CDR2, EncodingAlgorithmFlag::DELIMIT_CDR2 or
+     * EncodingAlgorithmFlag::PL_CDR2.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     */
+    Cdr& xcdr2_end_serialize_type(
+            const Cdr::state& current_state);
+
+    /*!
+     * @brief Tells to the encoder a new type and its members start to be decoded according to XCDRv1.
+     * @param[in] type_encoding Encoding algorithm used to encode the type and its members.
+     * @pre Type encoding algorithm must be EncodingAlgorithmFlag::PLAIN_CDR or EncodingAlgorithmFlag::PL_CDR.
+     * @pre If it is the beginning of the whole encoding, current encoding must be equal to type encoding.
+     * @param[in] functor Functor called each time a member has to be decoded.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     * @exception exception::BadParamException This exception is thrown when an incorrect behaviour happens when
+     * trying to decode.
+     */
+    Cdr& xcdr1_deserialize_type(
+            EncodingAlgorithmFlag type_encoding,
+            std::function<bool (Cdr&, const MemberId&)> functor);
+
+    /*!
+     * @brief Tells to the encoder a new type and its members start to be decoded according to XCDRv2.
+     * @param[in] type_encoding Encoding algorithm used to encode the type and its members.
+     * @pre Type encoding algorithm must be EncodingAlgorithmFlag::PLAIN_CDR2, EncodingAlgorithmFlag::DELIMIT_CDR2 or
+     * EncodingAlgorithmFlag::PL_CDR2.
+     * @pre If it is the beginning of the whole encoding, current encoding must be equal to type encoding.
+     * @param[in] functor Functor called each time a member has to be decoded.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
+     * position that exceeds the internal memory size.
+     * @exception exception::BadParamException This exception is thrown when an incorrect behaviour happens when
+     * trying to decode.
+     */
+    Cdr& xcdr2_deserialize_type(
+            EncodingAlgorithmFlag type_encoding,
+            std::function<bool (Cdr&, const MemberId&)> functor);
+
+    Cdr& cdr_begin_serialize_member(
+            const MemberId& member_id,
+            bool is_present,
+            Cdr::state& current_state,
+            XCdrHeaderSelection header_selection);
+
+    Cdr& cdr_end_serialize_member(
+            const Cdr::state& current_state);
+
+    Cdr& cdr_begin_serialize_type(
+            Cdr::state& current_state,
+            EncodingAlgorithmFlag type_encoding);
+
+    Cdr& cdr_end_serialize_type(
+            const Cdr::state& current_state);
+
+    Cdr& cdr_deserialize_type(
+            EncodingAlgorithmFlag type_encoding,
+            std::function<bool (Cdr&, const MemberId&)> functor);
+
+    /*!
+     * @brief Resets the internal callbacks depending on the current selected Cdr version.
+     */
+    void reset_callbacks();
+
+    using begin_serialize_member_functor = Cdr& (Cdr::*)(
+        const MemberId&,
+        bool,
+        Cdr::state&,
+        XCdrHeaderSelection);
+    begin_serialize_member_functor begin_serialize_member_ { nullptr };
+
+    using end_serialize_member_functor = Cdr& (Cdr::*)(
+        const Cdr::state&);
+    end_serialize_member_functor end_serialize_member_ { nullptr };
+
+    using begin_serialize_opt_member_functor = Cdr& (Cdr::*)(
+        const MemberId&,
+        bool,
+        Cdr::state&,
+        XCdrHeaderSelection);
+    begin_serialize_opt_member_functor begin_serialize_opt_member_ { nullptr };
+
+    using end_serialize_memberopt__functor = Cdr& (Cdr::*)(
+        const Cdr::state&);
+    end_serialize_member_functor end_serialize_opt_member_ { nullptr };
+
+    using begin_serialize_type_functor = Cdr& (Cdr::*)(
+        Cdr::state&,
+        EncodingAlgorithmFlag);
+    begin_serialize_type_functor begin_serialize_type_ { nullptr };
+
+    using end_serialize_type_functor = Cdr& (Cdr::*)(
+        const Cdr::state&);
+    end_serialize_type_functor end_serialize_type_ { nullptr };
+
+    using deserialize_type_functor = Cdr& (Cdr::*)(
+        EncodingAlgorithmFlag,
+        std::function<bool (Cdr&, const MemberId&)>);
+    deserialize_type_functor deserialize_type_ { nullptr };
+
+    //! @brief Reference to the buffer that will be serialized/deserialized.
+    FastBuffer& cdr_buffer_;
+
+    //! @brief The type of CDR that will be use in serialization/deserialization.
+    CdrVersion cdr_version_ {CdrVersion::XCDRv2};
+
+    //! @brief Stores the main encoding algorithm.
+    EncodingAlgorithmFlag encoding_flag_ {EncodingAlgorithmFlag::PLAIN_CDR2};
+
+    //! @brief Stores the current encoding algorithm.
+    EncodingAlgorithmFlag current_encoding_ {EncodingAlgorithmFlag::PLAIN_CDR2};
+
+    //! @brief This attribute stores the option flags when the CDR type is DDS_CDR;
+    std::array<uint8_t, 2> options_{{0}};
+
+    //! @brief The endianness that will be applied over the buffer.
+    uint8_t endianness_ {Endianness::LITTLE_ENDIANNESS};
+
+    //! @brief This attribute specifies if it is needed to swap the bytes.
+    bool swap_bytes_ {false};
+
+    //! @brief Stores the last datasize serialized/deserialized. It's used to optimize.
+    size_t last_data_size_ {0};
+
+    //! @brief The current position in the serialization/deserialization process.
+    FastBuffer::iterator offset_;
+
+    //! @brief The position from where the alignment is calculated.
+    FastBuffer::iterator origin_;
+
+    //! @brief The last position in the buffer;
+    FastBuffer::iterator end_;
+
+    //! Next member identifier to be processed.
+    MemberId next_member_id_;
+
+    //! Align for types equal or greater than 64bits.
+    size_t align64_ {4};
+
+
+    enum SerializedMemberSizeForNextInt
+    {
+        NO_SERIALIZED_MEMBER_SIZE,
+        SERIALIZED_MEMBER_SIZE,
+        SERIALIZED_MEMBER_SIZE_4,
+        SERIALIZED_MEMBER_SIZE_8
+    }
+    //! Specifies if a DHEADER was serialized. Used to optimize XCDRv2 member headers.
+    serialized_member_size_ {NO_SERIALIZED_MEMBER_SIZE};
+
+
+    uint32_t get_long_lc(
+            SerializedMemberSizeForNextInt serialized_member_size);
+
+    uint32_t get_short_lc(
+            size_t member_serialized_size);
+
+    template<class _T, typename std::enable_if<std::is_enum<_T>::value ||
+            std::is_arithmetic<_T>::value>::type* = nullptr>
+    constexpr SerializedMemberSizeForNextInt get_serialized_member_size() const
+    {
+        return (1 == sizeof(_T) ? SERIALIZED_MEMBER_SIZE :
+               (4 == sizeof(_T) ? SERIALIZED_MEMBER_SIZE_4 :
+               (8 == sizeof(_T) ? SERIALIZED_MEMBER_SIZE_8 :  NO_SERIALIZED_MEMBER_SIZE)));
+    }
+
 };
-}  // namespace fastcdr
-}  // namespace eprosima
 
-#endif  // _CDR_CDR_H_
+}            //namespace fastcdr
+}        //namespace eprosima
+
+#endif // _CDR_CDR_H_

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/CdrEncoding.hpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/CdrEncoding.hpp
@@ -1,0 +1,54 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _FASTCDR_CDRENCODING_HPP_
+#define _FASTCDR_CDRENCODING_HPP_
+
+#include <cstdint>
+
+namespace eprosima {
+namespace fastcdr {
+
+//! @brief This enumeration represents the kinds of CDR serialization supported by eprosima::fastcdr::CDR.
+typedef enum
+{
+    //! @brief Common CORBA CDR serialization.
+    CORBA_CDR = 0,
+    //! @brief DDS CDR serialization.
+    DDS_CDR = 1,
+    //! @brief XCDRv1 encoding defined by standard DDS X-Types 1.3
+    XCDRv1 = 2,
+    //! @brief XCDRv2 encoding defined by standard DDS X-Types 1.3
+    XCDRv2 = 3
+} CdrVersion;
+
+//! @brief This enumeration represents the supported XCDR encoding algorithms.
+typedef enum : uint8_t
+{
+    //! @brief Specifies that the content is PLAIN_CDR.
+    PLAIN_CDR = 0x0,
+    //! @brief Specifies that the content is PL_CDR,
+    PL_CDR = 0x2,
+    //! @brief Specifies that the content is PLAIN_CDR2.
+    PLAIN_CDR2 = 0x6,
+    //! @brief Specifies that the content is DELIMIT_CDR2.
+    DELIMIT_CDR2 = 0x8,
+    //! @brief Specifies that the content is PL_CDR2.
+    PL_CDR2 = 0xa
+} EncodingAlgorithmFlag;
+
+} // namespace fastcdr
+} // namespace eprosima
+
+#endif // _FASTCDR_CDRENCODING_HPP_

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/CdrSizeCalculator.hpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/CdrSizeCalculator.hpp
@@ -1,0 +1,1270 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _FASTCDR_CDRSIZECALCULATOR_HPP_
+#define _FASTCDR_CDRSIZECALCULATOR_HPP_
+
+#include <array>
+#include <bitset>
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <vector>
+
+#include "fastcdr_dll.h"
+
+#include "CdrEncoding.hpp"
+#include "cdr/fixed_size_string.hpp"
+#include "detail/container_recursive_inspector.hpp"
+#include "exceptions/BadParamException.h"
+#include "xcdr/external.hpp"
+#include "xcdr/MemberId.hpp"
+#include "xcdr/optional.hpp"
+
+namespace eprosima {
+namespace fastcdr {
+
+class CdrSizeCalculator;
+
+template<class _T>
+extern size_t calculate_serialized_size(
+        CdrSizeCalculator&,
+        const _T&,
+        size_t&);
+
+/*!
+ * @brief This class offers an interface to calculate the encoded size of a type serialized using a support encoding
+ * algorithm.
+ * @ingroup FASTCDRAPIREFERENCE
+ */
+class CdrSizeCalculator
+{
+public:
+
+    /*!
+     * @brief Constructor.
+     * @param[in] cdr_version Represents the version of the encoding algorithm that will be used for the encoding.
+     * The default value is CdrVersion::XCDRv2.
+     */
+    Cdr_DllAPI CdrSizeCalculator(
+            CdrVersion cdr_version);
+
+    /*!
+     * @brief Retrieves the version of the encoding algorithm used by the instance.
+     * @return Configured CdrVersion.
+     */
+    Cdr_DllAPI CdrVersion get_cdr_version() const;
+
+    /*!
+     * @brief Retrieves the current encoding algorithm used by the instance.
+     * @return Configured EncodingAlgorithmFlag.
+     */
+    Cdr_DllAPI EncodingAlgorithmFlag get_encoding() const;
+
+    /*!
+     * @brief Generic template which calculates the encoded size of an instance of an unknown type.
+     * @tparam _T Instance's type.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<class _T, typename std::enable_if<!std::is_enum<_T>::value>::type* = nullptr, typename = void>
+    size_t calculate_serialized_size(
+            const _T& data,
+            size_t& current_alignment)
+    {
+        return eprosima::fastcdr::calculate_serialized_size(*this, data, current_alignment);
+    }
+
+    /*!
+     * @brief Template which calculates the encoded size of an instance of an enumeration of 32bits.
+     * @tparam _T Instance's type.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            int32_t>::value>::type* = nullptr>
+    size_t calculate_serialized_size(
+            const _T& data,
+            size_t& current_alignment)
+    {
+        return calculate_serialized_size(static_cast<int32_t>(data), current_alignment);
+    }
+
+    /*!
+     * @brief Template which calculates the encoded size of an instance of an enumeration of unsigned 32bits.
+     * @tparam _T Instance's type.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            uint32_t>::value>::type* = nullptr>
+    size_t calculate_serialized_size(
+            const _T& data,
+            size_t& current_alignment)
+    {
+        return calculate_serialized_size(static_cast<uint32_t>(data), current_alignment);
+    }
+
+    /*!
+     * @brief Template which calculates the encoded size of an instance of an enumeration of 16bits.
+     * @tparam _T Instance's type.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            int16_t>::value>::type* = nullptr>
+    size_t calculate_serialized_size(
+            const _T& data,
+            size_t& current_alignment)
+    {
+        return calculate_serialized_size(static_cast<int16_t>(data), current_alignment);
+    }
+
+    /*!
+     * @brief Template which calculates the encoded size of an instance of an enumeration of unsigned 16bits.
+     * @tparam _T Instance's type.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            uint16_t>::value>::type* = nullptr>
+    size_t calculate_serialized_size(
+            const _T& data,
+            size_t& current_alignment)
+    {
+        return calculate_serialized_size(static_cast<uint16_t>(data), current_alignment);
+    }
+
+    /*!
+     * @brief Template which calculates the encoded size of an instance of an enumeration of 8bits.
+     * @tparam _T Instance's type.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            int8_t>::value>::type* = nullptr>
+    size_t calculate_serialized_size(
+            const _T& data,
+            size_t& current_alignment)
+    {
+        return calculate_serialized_size(static_cast<int8_t>(data), current_alignment);
+    }
+
+    /*!
+     * @brief Template which calculates the encoded size of an instance of an enumeration of unsigned 8bits.
+     * @tparam _T Instance's type.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<class _T,
+            typename std::enable_if<std::is_enum<_T>::value>::type* = nullptr,
+            typename std::enable_if<std::is_same<typename std::underlying_type<_T>::type,
+            uint8_t>::value>::type* = nullptr>
+    size_t calculate_serialized_size(
+            const _T& data,
+            size_t& current_alignment)
+    {
+        return calculate_serialized_size(static_cast<uint8_t>(data), current_alignment);
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an int8_t.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const int8_t& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        ++current_alignment;
+        return 1;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an uint8_t.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const uint8_t& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        ++current_alignment;
+        return 1;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a char.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const char& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        ++current_alignment;
+        return 1;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a bool.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const bool& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        ++current_alignment;
+        return 1;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a wchar.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const wchar_t& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {2 + alignment(current_alignment, 2)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a int16_t.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const int16_t& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {2 + alignment(current_alignment, 2)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a uint16_t.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const uint16_t& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {2 + alignment(current_alignment, 2)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a int32_t.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const int32_t& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {4 + alignment(current_alignment, 4)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a uint32_t.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const uint32_t& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {4 + alignment(current_alignment, 4)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a int64_t.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const int64_t& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {8 + alignment(current_alignment, align64_)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a uint64_t.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const uint64_t& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {8 + alignment(current_alignment, align64_)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a float.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const float& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {4 + alignment(current_alignment, 4)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a double.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const double& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {8 + alignment(current_alignment, align64_)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a long double.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const long double& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {16 + alignment(current_alignment, align64_)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a std::string.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const std::string& data,
+            size_t& current_alignment)
+    {
+        size_t calculated_size {4 + alignment(current_alignment, 4) + data.size() + 1};
+        current_alignment += calculated_size;
+        serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
+
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a std::wstring.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const std::wstring& data,
+            size_t& current_alignment)
+    {
+        size_t calculated_size {4 + alignment(current_alignment, 4) + data.size() * 2};
+        current_alignment += calculated_size;
+
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a fixed_string.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template <size_t MAX_CHARS>
+    size_t calculate_serialized_size(
+            const fixed_string<MAX_CHARS>& data,
+            size_t& current_alignment)
+    {
+        size_t calculated_size {4 + alignment(current_alignment, 4) + data.size() + 1};
+        current_alignment += calculated_size;
+
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a sequence of non-primitives.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<class _T, typename std::enable_if<!std::is_enum<_T>::value &&
+            !std::is_arithmetic<_T>::value>::type* = nullptr>
+    size_t calculate_serialized_size(
+            const std::vector<_T>& data,
+            size_t& current_alignment)
+    {
+        size_t initial_alignment {current_alignment};
+
+        if (CdrVersion::XCDRv2 == cdr_version_)
+        {
+            // DHEADER
+            current_alignment += 4 + alignment(current_alignment, 4);
+        }
+
+        current_alignment += 4 + alignment(current_alignment, 4);
+
+        size_t calculated_size {current_alignment - initial_alignment};
+        calculated_size += calculate_array_serialized_size(data.data(), data.size(), current_alignment);
+
+        if (CdrVersion::XCDRv2 == cdr_version_)
+        {
+            // Inform DHEADER can be joined with NEXTINT
+            serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
+        }
+
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a sequence of primitives.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<class _T, typename std::enable_if<std::is_enum<_T>::value ||
+            std::is_arithmetic<_T>::value>::type* = nullptr>
+    size_t calculate_serialized_size(
+            const std::vector<_T>& data,
+            size_t& current_alignment)
+    {
+        size_t initial_alignment {current_alignment};
+
+        current_alignment += 4 + alignment(current_alignment, 4);
+
+        size_t calculated_size {current_alignment - initial_alignment};
+        calculated_size += calculate_array_serialized_size(data.data(), data.size(), current_alignment);
+
+        if (CdrVersion::XCDRv2 == cdr_version_)
+        {
+            serialized_member_size_ = get_serialized_member_size<_T>();
+        }
+
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a sequence of bool.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_serialized_size(
+            const std::vector<bool>& data,
+            size_t& current_alignment)
+    {
+        size_t calculated_size {data.size() + 4 + alignment(current_alignment, 4)};
+        current_alignment += calculated_size;
+
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an array.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<class _T, size_t _Size>
+    size_t calculate_serialized_size(
+            const std::array<_T, _Size>& data,
+            size_t& current_alignment)
+    {
+        size_t initial_alignment {current_alignment};
+
+        if (CdrVersion::XCDRv2 == cdr_version_ &&
+                !is_multi_array_primitive(&data))
+        {
+            // DHEADER
+            current_alignment += 4 + alignment(current_alignment, 4);
+        }
+
+        size_t calculated_size {current_alignment - initial_alignment};
+        calculated_size += calculate_array_serialized_size(data.data(), data.size(), current_alignment);
+
+        if (CdrVersion::XCDRv2 == cdr_version_ &&
+                !is_multi_array_primitive(&data))
+        {
+            // Inform DHEADER can be joined with NEXTINT
+            serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
+        }
+
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a map of non-primitives.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<class _K, class _V, typename std::enable_if<!std::is_enum<_V>::value &&
+            !std::is_arithmetic<_V>::value>::type* = nullptr>
+    size_t calculate_serialized_size(
+            const std::map<_K, _V>& data,
+            size_t& current_alignment)
+    {
+        size_t initial_alignment {current_alignment};
+
+        if (CdrVersion::XCDRv2 == cdr_version_)
+        {
+            // DHEADER
+            current_alignment += 4 + alignment(current_alignment, 4);
+        }
+
+        current_alignment += 4 + alignment(current_alignment, 4);
+
+        size_t calculated_size {current_alignment - initial_alignment};
+        for (auto it = data.begin(); it != data.end(); ++it)
+        {
+            calculated_size += calculate_serialized_size(it->first, current_alignment);
+            calculated_size += calculate_serialized_size(it->second, current_alignment);
+        }
+
+        if (CdrVersion::XCDRv2 == cdr_version_)
+        {
+            // Inform DHEADER can be joined with NEXTINT
+            serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
+        }
+
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a map of primitives.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<class _K, class _V, typename std::enable_if<std::is_enum<_V>::value ||
+            std::is_arithmetic<_V>::value>::type* = nullptr>
+    size_t calculate_serialized_size(
+            const std::map<_K, _V>& data,
+            size_t& current_alignment)
+    {
+        size_t initial_alignment {current_alignment};
+
+        current_alignment += 4 + alignment(current_alignment, 4);
+
+        size_t calculated_size {current_alignment - initial_alignment};
+        for (auto it = data.begin(); it != data.end(); ++it)
+        {
+            calculated_size += calculate_serialized_size(it->first, current_alignment);
+            calculated_size += calculate_serialized_size(it->second, current_alignment);
+        }
+
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a bitset of 8bits.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<size_t N, typename std::enable_if < (N < 9) > ::type* = nullptr>
+    size_t calculate_serialized_size(
+            const std::bitset<N>& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        ++current_alignment;
+        return 1;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a bitset of 16bits.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<size_t N, typename std::enable_if < (8 < N && N < 17) > ::type* = nullptr>
+    size_t calculate_serialized_size(
+            const std::bitset<N>& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {2 + alignment(current_alignment, 2)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a bitset of 32bits.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<size_t N, typename std::enable_if < (16 < N && N < 33) > ::type* = nullptr>
+    size_t calculate_serialized_size(
+            const std::bitset<N>& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {4 + alignment(current_alignment, 4)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a bitset of 64bits.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<size_t N, typename std::enable_if < (32 < N && N < 65) > ::type* = nullptr>
+    size_t calculate_serialized_size(
+            const std::bitset<N>& data,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {8 + alignment(current_alignment, align64_)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an optional type.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<class _T>
+    size_t calculate_serialized_size(
+            const optional<_T>& data,
+            size_t& current_alignment)
+    {
+        size_t initial_alignment = current_alignment;
+
+        if (CdrVersion::XCDRv2 == cdr_version_ &&
+                EncodingAlgorithmFlag::PL_CDR2 != current_encoding_)
+        {
+            // Take into account the boolean is_present;
+            ++current_alignment;
+        }
+
+        size_t calculated_size {current_alignment - initial_alignment};
+
+        if (data.has_value())
+        {
+            calculated_size += calculate_serialized_size(data.value(), current_alignment);
+        }
+
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an external type.
+     * @param[in] data Reference to the instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @exception exception::BadParamException This exception is thrown when the external is null.
+     * @return Encoded size of the instance.
+     */
+    template<class _T>
+    size_t calculate_serialized_size(
+            const external<_T>& data,
+            size_t& current_alignment)
+    {
+        if (!data)
+        {
+            throw exception::BadParamException("External member is null");
+        }
+
+        return calculate_serialized_size(*data, current_alignment);
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an array of unknown type.
+     * @tparam _T Array's type.
+     * @param[in] data Reference to the array's instance.
+     * @param[in] num_elements Number of elements in the array.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<class _T>
+    size_t calculate_array_serialized_size(
+            const _T* data,
+            size_t num_elements,
+            size_t& current_alignment)
+    {
+        size_t calculated_size {0};
+
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            calculated_size += calculate_serialized_size(data[count], current_alignment);
+        }
+
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an array of int8_t.
+     * @param[in] data Reference to the array's instance.
+     * @param[in] num_elements Number of elements in the array.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_array_serialized_size(
+            const int8_t* data,
+            size_t num_elements,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        current_alignment += num_elements;
+        return num_elements;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an array of uint8_t.
+     * @param[in] data Reference to the array's instance.
+     * @param[in] num_elements Number of elements in the array.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_array_serialized_size(
+            const uint8_t* data,
+            size_t num_elements,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        current_alignment += num_elements;
+        return num_elements;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an array of char.
+     * @param[in] data Reference to the array's instance.
+     * @param[in] num_elements Number of elements in the array.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_array_serialized_size(
+            const char* data,
+            size_t num_elements,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        current_alignment += num_elements;
+        return num_elements;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an array of wchar.
+     * @param[in] data Reference to the array's instance.
+     * @param[in] num_elements Number of elements in the array.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_array_serialized_size(
+            const wchar_t* data,
+            size_t num_elements,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {num_elements* 2 + alignment(current_alignment, 2)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an array of int16_t.
+     * @param[in] data Reference to the array's instance.
+     * @param[in] num_elements Number of elements in the array.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_array_serialized_size(
+            const int16_t* data,
+            size_t num_elements,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {num_elements* 2 + alignment(current_alignment, 2)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an array of uint16_t.
+     * @param[in] data Reference to the array's instance.
+     * @param[in] num_elements Number of elements in the array.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_array_serialized_size(
+            const uint16_t* data,
+            size_t num_elements,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {num_elements* 2 + alignment(current_alignment, 2)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an array of int32_t.
+     * @param[in] data Reference to the array's instance.
+     * @param[in] num_elements Number of elements in the array.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_array_serialized_size(
+            const int32_t* data,
+            size_t num_elements,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {num_elements* 4 + alignment(current_alignment, 4)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an array of uint32_t.
+     * @param[in] data Reference to the array's instance.
+     * @param[in] num_elements Number of elements in the array.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_array_serialized_size(
+            const uint32_t* data,
+            size_t num_elements,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {num_elements* 4 + alignment(current_alignment, 4)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an array of int64_t.
+     * @param[in] data Reference to the array's instance.
+     * @param[in] num_elements Number of elements in the array.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_array_serialized_size(
+            const int64_t* data,
+            size_t num_elements,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {num_elements* 8 + alignment(current_alignment, align64_)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an array of uint64_t.
+     * @param[in] data Reference to the array's instance.
+     * @param[in] num_elements Number of elements in the array.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_array_serialized_size(
+            const uint64_t* data,
+            size_t num_elements,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {num_elements* 8 + alignment(current_alignment, align64_)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an array of float.
+     * @param[in] data Reference to the array's instance.
+     * @param[in] num_elements Number of elements in the array.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_array_serialized_size(
+            const float* data,
+            size_t num_elements,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {num_elements* 4 + alignment(current_alignment, 4)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an array of double.
+     * @param[in] data Reference to the array's instance.
+     * @param[in] num_elements Number of elements in the array.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_array_serialized_size(
+            const double* data,
+            size_t num_elements,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {num_elements* 8 + alignment(current_alignment, align64_)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of an array of long double.
+     * @param[in] data Reference to the array's instance.
+     * @param[in] num_elements Number of elements in the array.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    TEMPLATE_SPEC
+    size_t calculate_array_serialized_size(
+            const long double* data,
+            size_t num_elements,
+            size_t& current_alignment)
+    {
+        static_cast<void>(data);
+        size_t calculated_size {num_elements* 16 + alignment(current_alignment, align64_)};
+        current_alignment += calculated_size;
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Specific template which calculates the encoded size of an instance of a multi-dimensional array.
+     * @param[in] data Reference to the array's instance.
+     * @param[in] num_elements Number of elements in the array.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the instance.
+     */
+    template<class _T, size_t _N>
+    size_t calculate_array_serialized_size(
+            const std::array<_T, _N>* data,
+            size_t num_elements,
+            size_t& current_alignment)
+    {
+        return calculate_array_serialized_size(data->data(), num_elements * data->size(), current_alignment);
+    }
+
+    /*!
+     * @brief Generic template which calculates the encoded size of the constructed type's member of a unknown type.
+     * @tparam _T Member's type.
+     * @param[in] id Member's identifier.
+     * @param[in] data Reference to the member's instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the member's instance.
+     */
+    template<class _T>
+    size_t calculate_member_serialized_size(
+            const MemberId& id,
+            const _T& data,
+            size_t& current_alignment)
+    {
+        size_t initial_alignment {current_alignment};
+
+        if (EncodingAlgorithmFlag::PL_CDR == current_encoding_ ||
+                EncodingAlgorithmFlag::PL_CDR2 == current_encoding_)
+        {
+            // Align to 4 for the XCDR header before calculating the data serialized size.
+            current_alignment += alignment(current_alignment, 4);
+        }
+
+        size_t prev_size {current_alignment - initial_alignment};
+        size_t extra_size {0};
+
+        if (EncodingAlgorithmFlag::PL_CDR == current_encoding_)
+        {
+            current_alignment = 0;
+        }
+
+        size_t calculated_size {calculate_serialized_size(data, current_alignment)};
+
+        if (CdrVersion::XCDRv2 == cdr_version_ && EncodingAlgorithmFlag::PL_CDR2 == current_encoding_ &&
+                0 < calculated_size)
+        {
+
+            if (8 < calculated_size)
+            {
+                extra_size = 8; // Long EMHEADER.
+                if (NO_SERIALIZED_MEMBER_SIZE != serialized_member_size_)
+                {
+                    calculated_size -= 4; // Join NEXTINT and DHEADER.
+                }
+            }
+            else
+            {
+                extra_size = 4; // EMHEADER;
+            }
+        }
+        else if (CdrVersion::XCDRv1 == cdr_version_ && EncodingAlgorithmFlag::PL_CDR == current_encoding_ &&
+                0 < calculated_size)
+        {
+            extra_size = 4; // ShortMemberHeader
+
+            if (0x3F00 < id.id || calculated_size > std::numeric_limits<uint16_t>::max())
+            {
+                extra_size += 8; // LongMemberHeader
+            }
+
+        }
+
+        calculated_size += prev_size + extra_size;
+        if (EncodingAlgorithmFlag::PL_CDR != current_encoding_)
+        {
+            current_alignment += extra_size;
+        }
+
+        serialized_member_size_ = NO_SERIALIZED_MEMBER_SIZE;
+
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Generic template which calculates the encoded size of the constructed type's member of type optional.
+     * @tparam _T Member's optional type.
+     * @param[in] id Member's identifier.
+     * @param[in] data Reference to the member's instance.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return Encoded size of the member's instance.
+     */
+    template<class _T>
+    size_t calculate_member_serialized_size(
+            const MemberId& id,
+            const optional<_T>& data,
+            size_t& current_alignment)
+    {
+        size_t initial_alignment = current_alignment;
+
+        if (CdrVersion::XCDRv2 != cdr_version_ ||
+                EncodingAlgorithmFlag::PL_CDR2 == current_encoding_)
+        {
+            if (data.has_value() || EncodingAlgorithmFlag::PLAIN_CDR == current_encoding_)
+            {
+                // Align to 4 for the XCDR header before calculating the data serialized size.
+                current_alignment += alignment(current_alignment, 4);
+            }
+        }
+
+        size_t prev_size = {current_alignment - initial_alignment};
+        size_t extra_size {0};
+
+        if (CdrVersion::XCDRv1 == cdr_version_ &&
+                (data.has_value() || EncodingAlgorithmFlag::PLAIN_CDR == current_encoding_))
+        {
+            current_alignment = 0;
+        }
+
+        size_t calculated_size {calculate_serialized_size(data, current_alignment)};
+
+        if (CdrVersion::XCDRv2 == cdr_version_ && EncodingAlgorithmFlag::PL_CDR2 == current_encoding_ &&
+                0 < calculated_size)
+        {
+            if (8 < calculated_size)
+            {
+                extra_size = 8; // Long EMHEADER.
+                if (NO_SERIALIZED_MEMBER_SIZE != serialized_member_size_)
+                {
+                    extra_size -= 4; // Join NEXTINT and DHEADER.
+                }
+            }
+            else
+            {
+                extra_size = 4; // EMHEADER;
+            }
+        }
+        else if (CdrVersion::XCDRv1 == cdr_version_ &&
+                (0 < calculated_size || EncodingAlgorithmFlag::PLAIN_CDR == current_encoding_))
+        {
+            extra_size = 4; // ShortMemberHeader
+
+            if (0x3F00 < id.id || calculated_size > std::numeric_limits<uint16_t>::max())
+            {
+                extra_size += 8; // LongMemberHeader
+            }
+
+        }
+
+        calculated_size += prev_size + extra_size;
+        if (CdrVersion::XCDRv1 != cdr_version_)
+        {
+            current_alignment += extra_size;
+        }
+
+
+        return calculated_size;
+    }
+
+    /*!
+     * @brief Indicates a new constructed type will be calculated.
+     * @param[in] new_encoding New encoding algorithm used for the constructed type.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return If new encoding algorithm encodes a header, return the encoded size of it.
+     */
+    Cdr_DllAPI size_t begin_calculate_type_serialized_size(
+            EncodingAlgorithmFlag new_encoding,
+            size_t& current_alignment);
+
+    /*!
+     * @brief Indicates the ending of a constructed type.
+     * @param[in] new_encoding New encoding algorithm used after the constructed type.
+     * @param[inout] current_alignment Current alignment in the encoding.
+     * @return If current encoding algorithm encodes a final mark, return the encoded size of it.
+     */
+    Cdr_DllAPI size_t end_calculate_type_serialized_size(
+            EncodingAlgorithmFlag new_encoding,
+            size_t& current_alignment);
+
+private:
+
+    CdrSizeCalculator() = delete;
+
+    CdrVersion cdr_version_ {CdrVersion::XCDRv2};
+
+    EncodingAlgorithmFlag current_encoding_ {EncodingAlgorithmFlag::PLAIN_CDR2};
+
+    enum SerializedMemberSizeForNextInt
+    {
+        NO_SERIALIZED_MEMBER_SIZE,
+        SERIALIZED_MEMBER_SIZE,
+        SERIALIZED_MEMBER_SIZE_4,
+        SERIALIZED_MEMBER_SIZE_8
+    }
+    //! Specifies if a DHEADER was serialized. Used to calculate XCDRv2 member headers.
+    serialized_member_size_ {NO_SERIALIZED_MEMBER_SIZE};
+
+    //! Align for types equal or greater than 64bits.
+    size_t align64_ {4};
+
+    inline size_t alignment(
+            size_t current_alignment,
+            size_t data_size) const
+    {
+        return (data_size - (current_alignment % data_size)) & (data_size - 1);
+    }
+
+    template<class _T, typename std::enable_if<std::is_enum<_T>::value ||
+            std::is_arithmetic<_T>::value>::type* = nullptr>
+    constexpr SerializedMemberSizeForNextInt get_serialized_member_size() const
+    {
+        return (1 == sizeof(_T) ? SERIALIZED_MEMBER_SIZE :
+               (4 == sizeof(_T) ? SERIALIZED_MEMBER_SIZE_4 :
+               (8 == sizeof(_T) ? SERIALIZED_MEMBER_SIZE_8 :  NO_SERIALIZED_MEMBER_SIZE)));
+    }
+
+};
+
+}        // namespace fastcdr
+}        // namespace eprosima
+
+#endif // _FASTCDR_CDRSIZECALCULATOR_HPP_

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/FastBuffer.h
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/FastBuffer.h
@@ -22,180 +22,216 @@
 #include <cstddef>
 #include <utility>
 
-inline uint32_t size_to_uint32(size_t val)
+inline uint32_t size_to_uint32(
+        size_t val)
 {
-#if defined(_WIN32) || !defined(FASTCDR_ARM32)
-  // On 64 bit platforms and all Windows architectures (because of C4267), explicitly
-  // cast.
-  return static_cast<uint32_t>(val);
-#else
-  // Skip useless cast on 32-bit builds.
-  return val;
-#endif  // if defined(_WIN32) || !defined(FASTCDR_ARM32)
+  #if defined(_WIN32) || !defined(FASTCDR_ARM32)
+    // On 64 bit platforms and all Windows architectures (because of C4267), explicitly cast.
+    return static_cast<uint32_t>(val);
+  #else
+    // Skip useless cast on 32-bit builds.
+    return val;
+  #endif // if defined(_WIN32) || !defined(FASTCDR_ARM32)
 }
 
-namespace eprosima
-{
-namespace fastcdr
-{
+namespace eprosima {
+namespace fastcdr {
 /*!
  * @brief This class implements the iterator used to go through a FastBuffer.
  */
 class Cdr_DllAPI _FastBuffer_iterator
 {
 public:
-  /*!
-   * @brief Default constructor.
-   * The iterator points any position.
-   */
-  _FastBuffer_iterator() : m_buffer(NULL), m_currentPosition(NULL)
-  {
-  }
 
-  /*!
-   * @brief Constructor.
-   * The iterator points to the indicated position.
-   * @param buffer Pointer to the raw buffer.
-   * @param index Position of the raw buffer where the iterator will point.
-   */
-  explicit _FastBuffer_iterator(char* buffer, size_t index)
-    : m_buffer(buffer), m_currentPosition(&m_buffer[index])
-  {
-  }
+    /*!
+     * @brief Default constructor.
+     * The iterator points any position.
+     */
+    _FastBuffer_iterator() = default;
 
-  /*!
-   * @brief This operator changes the iterator's raw buffer.
-   * This operator makes the iterator point to the same position but in another raw
-   * buffer. The new raw buffer is the same than the source iterator's.
-   * @param iterator The source iterator. The iterator will use the source iterator's raw
-   * buffer after this operation.
-   */
-  inline void operator<<(const _FastBuffer_iterator& iterator)
-  {
-    ptrdiff_t diff = m_currentPosition - m_buffer;
-    m_buffer = iterator.m_buffer;
-    m_currentPosition = m_buffer + diff;
-  }
-
-  /*!
-   * @brief This operator changes the position where the iterator points.
-   * This operator takes the index of the source iterator, but the iterator continues
-   * using its raw buffer.
-   * @param iterator The source iterator. The iterator will use the source's iterator
-   * index to point to its own raw buffer.
-   */
-  inline void operator>>(const _FastBuffer_iterator& iterator)
-  {
-    ptrdiff_t diff = iterator.m_currentPosition - iterator.m_buffer;
-    m_currentPosition = m_buffer + diff;
-  }
-
-  /*!
-   * @brief This operator copies a data in the raw buffer.
-   * The copy uses the size of the data type.
-   * @param data Data to be copied. Cannot be NULL.
-   */
-  template <typename _T>
-  inline void operator<<(const _T& data)
-  {
-    memcpy(m_currentPosition, &data, sizeof(_T));
-  }
-
-  /*!
-   * @brief This operator copies data from the raw buffer to a variable.
-   * The copy uses the size of the data type.
-   * @param data Data to be filled.
-   */
-  template <typename _T>
-  inline void operator>>(_T& data)
-  {
-    memcpy(&data, m_currentPosition, sizeof(_T));
-  }
-
-  /*!
-   * @brief This function copies a buffer into the raw buffer.
-   * @param src The source buffer.
-   * @param size The number of bytes to be copied.
-   */
-  inline void memcopy(const void* src, const size_t size)
-  {
-    if (size > 0)
+    /*!
+     * @brief Constructor.
+     * The iterator points to the indicated position.
+     * @param buffer Pointer to the raw buffer.
+     * @param index Position of the raw buffer where the iterator will point.
+     */
+    explicit _FastBuffer_iterator(
+            char* buffer,
+            size_t index)
+        : buffer_(buffer)
+        , current_position_(&buffer_[index])
     {
-      memcpy(m_currentPosition, src, size);
     }
-  }
 
-  /*!
-   * @brief This function copies from the raw buffer to a external buffer.
-   * @param dst The destination buffer.
-   * @param size The size of bytes to be copied.
-   */
-  inline void rmemcopy(void* dst, const size_t size)
-  {
-    if (size > 0)
+    /*!
+     * @brief This operator changes the iterator's raw buffer.
+     * This operator makes the iterator point to the same position but in another raw buffer.
+     * The new raw buffer is the same than the source iterator's.
+     * @param iterator The source iterator. The iterator will use the source iterator's raw buffer after this operation.
+     */
+    inline
+    void operator <<(
+            const _FastBuffer_iterator& iterator)
     {
-      memcpy(dst, m_currentPosition, size);
+        ptrdiff_t diff = current_position_ - buffer_;
+        buffer_ = iterator.buffer_;
+        current_position_ = buffer_ + diff;
     }
-  }
 
-  /*!
-   * @brief This function increments the position where the iterator points.
-   * @param numBytes Number of bytes the iterator moves the position.
-   */
-  inline void operator+=(size_t numBytes)
-  {
-    m_currentPosition += numBytes;
-  }
+    /*!
+     * @brief This operator changes the position where the iterator points.
+     * This operator takes the index of the source iterator, but the iterator continues using its raw buffer.
+     * @param iterator The source iterator. The iterator will use the source's iterator index to point to its own raw buffer.
+     */
+    inline
+    void operator >>(
+            const _FastBuffer_iterator& iterator)
+    {
+        ptrdiff_t diff = iterator.current_position_ - iterator.buffer_;
+        current_position_ = buffer_ + diff;
+    }
 
-  /*!
-   * @brief This operator returns the subtraction of the current interator's position and
-   * the source iterator's position.
-   * @param it Source iterator whose position is subtracted to the current iterator's
-   * position.
-   * @return The result of subtract the current iterator's position and the source
-   * iterator's position.
-   */
-  inline size_t operator-(const _FastBuffer_iterator& it) const
-  {
-    return static_cast<size_t>(m_currentPosition - it.m_currentPosition);
-  }
+    /*!
+     * @brief This operator copies a data in the raw buffer.
+     * The copy uses the size of the data type.
+     * @param data Data to be copied. Cannot be NULL.
+     */
+    template<typename _T>
+    inline
+    void operator <<(
+            const _T& data)
+    {
+        memcpy(current_position_, &data, sizeof(_T));
+    }
 
-  /*!
-   * @brief This function increments the iterator in one the position.
-   * @return The current iterator.
-   */
-  inline _FastBuffer_iterator operator++()
-  {
-    ++m_currentPosition;
-    return *this;
-  }
+    /*!
+     * @brief This operator copies data from the raw buffer to a variable.
+     * The copy uses the size of the data type.
+     * @param data Data to be filled.
+     */
+    template<typename _T>
+    inline
+    void operator >>(
+            _T& data)
+    {
+        memcpy(&data, current_position_, sizeof(_T));
+    }
 
-  /*!
-   * @brief This function increments the iterator in one the position.
-   * @return The current iterator.
-   */
-  inline _FastBuffer_iterator operator++(int)
-  {
-    _FastBuffer_iterator tmp = *this;
-    ++*this;
-    return tmp;
-  }
+    /*!
+     * @brief This function copies a buffer into the raw buffer.
+     * @param src The source buffer.
+     * @param size The number of bytes to be copied.
+     */
+    inline
+    void memcopy(
+            const void* src,
+            const size_t size)
+    {
+        if (size > 0)
+        {
+            memcpy(current_position_, src, size);
+        }
+    }
 
-  /*!
-   * @brief This function returns the current position in the raw buffer.
-   * @return The current position in the raw buffer.
-   */
-  inline char* operator&()
-  {
-    return m_currentPosition;
-  }
+    /*!
+     * @brief This function copies from the raw buffer to a external buffer.
+     * @param dst The destination buffer.
+     * @param size The size of bytes to be copied.
+     */
+    inline
+    void rmemcopy(
+            void* dst,
+            const size_t size)
+    {
+        if (size > 0)
+        {
+            memcpy(dst, current_position_, size);
+        }
+    }
+
+    /*!
+     * @brief This function increments the position where the iterator points.
+     * @param num_bytes Number of bytes the iterator moves the position.
+     */
+    inline
+    void operator +=(
+            size_t num_bytes)
+    {
+        current_position_ += num_bytes;
+    }
+
+    inline
+    void operator -=(
+            size_t num_bytes)
+    {
+        current_position_ -= num_bytes;
+    }
+
+    /*!
+     * @brief This operator returns the subtraction of the current interator's position and the source iterator's position.
+     * @param it Source iterator whose position is subtracted to the current iterator's position.
+     * @return The result of subtract the current iterator's position and the source iterator's position.
+     */
+    inline
+    size_t operator -(
+            const _FastBuffer_iterator& it) const
+    {
+        return static_cast<size_t>(current_position_ - it.current_position_);
+    }
+
+    /*!
+     * @brief This function increments the iterator in one the position.
+     * @return The current iterator.
+     */
+    inline
+    _FastBuffer_iterator operator ++()
+    {
+        ++current_position_;
+        return *this;
+    }
+
+    /*!
+     * @brief This function increments the iterator in one the position.
+     * @return The current iterator.
+     */
+    inline
+    _FastBuffer_iterator operator ++(
+            int)
+    {
+        _FastBuffer_iterator tmp = *this;
+        ++*this;
+        return tmp;
+    }
+
+    /*!
+     * @brief This function returns the current position in the raw buffer.
+     * @return The current position in the raw buffer.
+     */
+    inline
+    char* operator &()
+    {
+        return current_position_;
+    }
+
+    bool operator ==(
+            const _FastBuffer_iterator& other_iterator) const
+    {
+        return other_iterator.current_position_ == current_position_;
+    }
+
+    bool operator !=(
+            const _FastBuffer_iterator& other_iterator) const
+    {
+        return !(other_iterator == *this);
+    }
 
 private:
-  //! Pointer to the raw buffer.
-  char* m_buffer;
 
-  //! Current position in the raw buffer.
-  char* m_currentPosition;
+    //! Pointer to the raw buffer.
+    char* buffer_ {nullptr};
+
+    //! Current position in the raw buffer.
+    char* current_position_ {nullptr};
 };
 
 /*!
@@ -207,122 +243,126 @@ private:
 class Cdr_DllAPI FastBuffer
 {
 public:
-  typedef _FastBuffer_iterator iterator;
 
-  /*!
-   * @brief This constructor creates an internal stream and assigns it to the
-   * eprosima::fastcdr::FastBuffers object. The user can obtain this internal stream using
-   * the function eprosima::fastcdr::FastBuffers::getBuffer(). Be careful because this
-   * internal stream is deleted in the destruction of the eprosima::fastcdr::FastBuffers
-   * object.
-   */
-  FastBuffer();
+    typedef _FastBuffer_iterator iterator;
 
-  /*!
-   * @brief This constructor assigns the user's stream of bytes to the
-   * eprosima::fastcdr::FastBuffers object. The user's stream will be used to serialize.
-   *
-   * @param buffer The user's buffer that will be used. This buffer is not deallocated in
-   * the object's destruction. Cannot be NULL.
-   * @param bufferSize The length of user's buffer.
-   */
-  FastBuffer(char* const buffer, const size_t bufferSize);
+    /*!
+     * @brief This constructor creates an internal stream and assigns it to the eprosima::fastcdr::FastBuffers object.
+     * The user can obtain this internal stream using the function eprosima::fastcdr::FastBuffers::getBuffer(). Be careful because this internal stream
+     * is deleted in the destruction of the eprosima::fastcdr::FastBuffers object.
+     */
+    FastBuffer() = default;
 
-  //! Move constructor
-  FastBuffer(FastBuffer&& fbuffer)
-    : m_buffer(nullptr), m_bufferSize(0), m_internalBuffer(true)
-  {
-    std::swap(m_buffer, fbuffer.m_buffer);
-    std::swap(m_bufferSize, fbuffer.m_bufferSize);
-    std::swap(m_internalBuffer, fbuffer.m_internalBuffer);
-  }
+    /*!
+     * @brief This constructor assigns the user's stream of bytes to the eprosima::fastcdr::FastBuffers object.
+     * The user's stream will be used to serialize.
+     *
+     * @param buffer The user's buffer that will be used. This buffer is not deallocated in the object's destruction. Cannot be NULL.
+     * @param bufferSize The length of user's buffer.
+     */
+    FastBuffer(
+            char* const buffer,
+            const size_t bufferSize);
 
-  //! Move assignment
-  FastBuffer& operator=(FastBuffer&& fbuffer)
-  {
-    std::swap(m_buffer, fbuffer.m_buffer);
-    std::swap(m_bufferSize, fbuffer.m_bufferSize);
-    std::swap(m_internalBuffer, fbuffer.m_internalBuffer);
-    return *this;
-  }
+    //! Move constructor
+    FastBuffer(
+            FastBuffer&& fbuffer)
+        : buffer_(nullptr)
+        , size_(0)
+        , m_internalBuffer(true)
+    {
+        std::swap(buffer_, fbuffer.buffer_);
+        std::swap(size_, fbuffer.size_);
+        std::swap(m_internalBuffer, fbuffer.m_internalBuffer);
+    }
 
-  /*!
-   * @brief Default destructor.
-   */
-  virtual ~FastBuffer();
+    //! Move assignment
+    FastBuffer& operator =(
+            FastBuffer&& fbuffer)
+    {
+        std::swap(buffer_, fbuffer.buffer_);
+        std::swap(size_, fbuffer.size_);
+        std::swap(m_internalBuffer, fbuffer.m_internalBuffer);
+        return *this;
+    }
 
-  /*!
-   * @brief This function returns the stream that the eprosima::fastcdr::FastBuffers uses
-   * to serialize data.
-   * @return The stream used by eprosima::fastcdr::FastBuffers to serialize data.
-   */
-  inline char* getBuffer() const
-  {
-    return m_buffer;
-  }
+    /*!
+     * @brief Default destructor.
+     */
+    virtual ~FastBuffer();
 
-  /*!
-   * @brief This function returns the size of the allocated memory of the stream that the
-   * eprosima::fastcdr::FastBuffers uses to serialize data.
-   * @return The size of the allocated memory of the stream used by the
-   * eprosima::fastcdr::FastBuffers to serialize data.
-   */
-  inline size_t getBufferSize() const
-  {
-    return m_bufferSize;
-  }
+    /*!
+     * @brief This function returns the stream that the eprosima::fastcdr::FastBuffers uses to serialize data.
+     * @return The stream used by eprosima::fastcdr::FastBuffers to serialize data.
+     */
+    inline char* getBuffer() const
+    {
+        return buffer_;
+    }
 
-  /*!
-   * @brief This function returns a iterator that points to the begining of the stream.
-   * @return The new iterator.
-   */
-  inline iterator begin()
-  {
-    return (iterator(m_buffer, 0));
-  }
+    /*!
+     * @brief This function returns the size of the allocated memory of the stream that the eprosima::fastcdr::FastBuffers uses to serialize data.
+     * @return The size of the allocated memory of the stream used by the eprosima::fastcdr::FastBuffers to serialize data.
+     */
+    inline size_t getBufferSize() const
+    {
+        return size_;
+    }
 
-  /*!
-   * @brief This function returns a iterator that points to the end of the stream.
-   * @return The new iterator.
-   */
-  inline iterator end()
-  {
-    return (iterator(m_buffer, m_bufferSize));
-  }
+    /*!
+     * @brief This function returns a iterator that points to the begining of the stream.
+     * @return The new iterator.
+     */
+    inline
+    iterator begin()
+    {
+        return (iterator(buffer_, 0));
+    }
 
-  /*!
-   * @brief This function reserves memory for the internal raw buffer. It will only do so
-   * if the buffer is not yet allocated and is not externally set.
-   * @param size The size of the memory to be allocated.
-   * @return True if the allocation suceeded. False if the raw buffer was set externally
-   * or is already allocated.
-   */
-  bool reserve(size_t size);
+    /*!
+     * @brief This function returns a iterator that points to the end of the stream.
+     * @return The new iterator.
+     */
+    inline
+    iterator end()
+    {
+        return (iterator(buffer_, size_));
+    }
 
-  /*!
-   * @brief This function resizes the raw buffer. It will call the user's defined function
-   * for this purpose.
-   * @param minSizeInc The minimun growth expected of the current raw buffer.
-   * @return True if the operation works. False if it does not.
-   */
-  bool resize(size_t minSizeInc);
+    /*!
+     * @brief This function reserves memory for the internal raw buffer. It will only do so if the buffer is not yet allocated and is not externally set.
+     * @param size The size of the memory to be allocated.
+     * @return True if the allocation suceeded. False if the raw buffer was set externally or is already allocated.
+     */
+    bool reserve(
+            size_t size);
+
+    /*!
+     * @brief This function resizes the raw buffer. It will call the user's defined function for this purpose.
+     * @param min_size_inc The minimun growth expected of the current raw buffer.
+     * @return True if the operation works. False if it does not.
+     */
+    bool resize(
+            size_t min_size_inc);
 
 private:
-  FastBuffer(const FastBuffer&) = delete;
 
-  FastBuffer& operator=(const FastBuffer&) = delete;
+    FastBuffer(
+            const FastBuffer&) = delete;
 
-  //! @brief Pointer to the stream of bytes that contains the serialized data.
-  char* m_buffer;
+    FastBuffer& operator =(
+            const FastBuffer&) = delete;
 
-  //! @brief The total size of the user's buffer.
-  size_t m_bufferSize;
+    //! @brief Pointer to the stream of bytes that contains the serialized data.
+    char* buffer_ { nullptr };
 
-  //! @brief This variable indicates if the managed buffer is internal or is from the
-  //! user.
-  bool m_internalBuffer;
+    //! @brief The total size of the user's buffer.
+    size_t size_ { 0 };
+
+    //! @brief This variable indicates if the managed buffer is internal or is from the user.
+    bool m_internalBuffer { true };
 };
-}  // namespace fastcdr
-}  // namespace eprosima
+}     //namespace fastcdr
+} //namespace eprosima
 
-#endif  // _FASTCDR_FASTCDRBUFFER_H_
+#endif // _FASTCDR_FASTCDRBUFFER_H_

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/FastCdr.h
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/FastCdr.h
@@ -26,2029 +26,2053 @@
 #include <malloc.h>
 #else
 #include <stdlib.h>
-#endif  // if !__APPLE__ && !__FreeBSD__ && !__VXWORKS__
+#endif // if !__APPLE__ && !__FreeBSD__ && !__VXWORKS__
 
-#if HAVE_CXX0X
 #include <array>
-#endif  // if HAVE_CXX0X
 
-namespace eprosima
-{
-namespace fastcdr
-{
+namespace eprosima {
+namespace fastcdr {
 /*!
- * @brief This class offers an interface to serialize/deserialize some basic types using a
- * modified CDR protocol inside a eprosima::FastBuffer. This modified CDR protocol
- * provides a serialization mechanism much faster than common CDR protocol, because it
- * doesn't use alignment.
+ * @brief This class offers an interface to serialize/deserialize some basic types using a modified CDR protocol inside a eprosima::FastBuffer.
+ * This modified CDR protocol provides a serialization mechanism much faster than common CDR protocol, because it doesn't use alignment.
  * @ingroup FASTCDRAPIREFERENCE
  */
 class Cdr_DllAPI FastCdr
 {
 public:
-  /*!
-   * @brief This class stores the current state of a CDR serialization.
-   */
-  class Cdr_DllAPI state
-  {
-    friend class FastCdr;
-
-  public:
-    /*!
-     * @brief Default constructor.
-     */
-    state(const FastCdr& fastcdr);
 
     /*!
-     * @brief Copy constructor.
+     * @brief This class stores the current state of a CDR serialization.
      */
-    state(const state&);
-
-  private:
-    state& operator=(const state&) = delete;
-
-    //! @brief The position in the buffer when the state was created.
-    const FastBuffer::iterator m_currentPosition;
-  };
-  /*!
-   * @brief This constructor creates a eprosima::fastcdr::FastCdr object that can
-   * serialize/deserialize the assigned buffer.
-   *
-   * @param cdrBuffer A reference to the buffer that contains (or will contain) the CDR
-   * representation.
-   */
-  FastCdr(FastBuffer& cdrBuffer);
-
-  /*!
-   * @brief This function skips a number of bytes in the CDR stream buffer.
-   * @param numBytes The number of bytes that will be jumped.
-   * @return True is returned when the jump operation works successfully. Otherwise, false
-   * is returned.
-   */
-  bool jump(size_t numBytes);
-
-  /*!
-   * @brief This function resets the current position in the buffer to the begining.
-   */
-  void reset();
-
-  /*!
-   * @brief This function returns the current position in the CDR stream.
-   * @return Pointer to the current position in the buffer.
-   */
-  char* getCurrentPosition();
-
-  /*!
-   * @brief This function returns the length of the serialized data inside the stream.
-   * @return The length of the serialized data.
-   */
-  inline size_t getSerializedDataLength() const
-  {
-    return m_currentPosition - m_cdrBuffer.begin();
-  }
-
-  /*!
-   * @brief This function returns the current state of the CDR stream.
-   * @return The current state of the buffer.
-   */
-  FastCdr::state getState();
-
-  /*!
-   * @brief This function sets a previous state of the CDR stream;
-   * @param state Previous state that will be set again.
-   */
-  void setState(FastCdr::state& state);
-
-  /*!
-   * @brief This operator serializes an octet.
-   * @param octet_t The value of the octet that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const uint8_t octet_t)
-  {
-    return serialize(octet_t);
-  }
-
-  /*!
-   * @brief This operator serializes a character.
-   * @param char_t The value of the character that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const char char_t)
-  {
-    return serialize(char_t);
-  }
-
-  /*!
-   * @brief This operator serializes a int8_t.
-   * @param int8 The value of the int8_t that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const int8_t int8)
-  {
-    return serialize(int8);
-  }
-
-  /*!
-   * @brief This operator serializes an unsigned short.
-   * @param ushort_t The value of the unsigned short that will be serialized in the
-   * buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const uint16_t ushort_t)
-  {
-    return serialize(ushort_t);
-  }
-
-  /*!
-   * @brief This operator serializes a short.
-   * @param short_t The value of the short that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const int16_t short_t)
-  {
-    return serialize(short_t);
-  }
-
-  /*!
-   * @brief This operator serializes an unsigned long.
-   * @param ulong_t The value of the unsigned long that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const uint32_t ulong_t)
-  {
-    return serialize(ulong_t);
-  }
-
-  /*!
-   * @brief This operator serializes a long.
-   * @param long_t The value of the long that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const int32_t long_t)
-  {
-    return serialize(long_t);
-  }
-
-  /*!
-   * @brief This operator serializes a wide-char.
-   * @param wchar The value of the wide-char that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const wchar_t wchar)
-  {
-    return serialize(wchar);
-  }
-
-  /*!
-   * @brief This operator serializes an unsigned long long.
-   * @param ulonglong_t The value of the unsigned long long that will be serialized in the
-   * buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const uint64_t ulonglong_t)
-  {
-    return serialize(ulonglong_t);
-  }
-
-  /*!
-   * @brief This operator serializes a long long.
-   * @param longlong_t The value of the long long that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const int64_t longlong_t)
-  {
-    return serialize(longlong_t);
-  }
-
-  /*!
-   * @brief This operator serializes a float.
-   * @param float_t The value of the float that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const float float_t)
-  {
-    return serialize(float_t);
-  }
-
-  /*!
-   * @brief This operator serializes a ldouble.
-   * @param double_t The value of the double that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const double double_t)
-  {
-    return serialize(double_t);
-  }
-
-  /*!
-   * @brief This operator serializes a long double.
-   * @param ldouble_t The value of the long double that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const long double ldouble_t)
-  {
-    return serialize(ldouble_t);
-  }
-
-  /*!
-   * @brief This operator serializes a boolean.
-   * @param bool_t The value of the boolean that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const bool bool_t)
-  {
-    return serialize(bool_t);
-  }
-
-  /*!
-   * @brief This operator serializes a null-terminated string.
-   * @param string_t The value of the string that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const char* string_t)
-  {
-    return serialize(string_t);
-  }
-
-  /*!
-   * @brief This operator serializes a null-terminated wide-string.
-   * @param string_t The value of the wide-string that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const wchar_t* string_t)
-  {
-    return serialize(string_t);
-  }
-
-  /*!
-   * @brief This operator serializes a string.
-   * @param string_t The string that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const std::string& string_t)
-  {
-    return serialize(string_t);
-  }
-
-  /*!
-   * @brief This operator serializes a wstring.
-   * @param string_t The wstring that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator<<(const std::wstring& string_t)
-  {
-    return serialize(string_t);
-  }
-
-#if HAVE_CXX0X
-  /*!
-   * @brief This operator template is used to serialize arrays.
-   * @param array_t The array that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  template <class _T, size_t _Size>
-  inline FastCdr& operator<<(const std::array<_T, _Size>& array_t)
-  {
-    return serialize<_T, _Size>(array_t);
-  }
-
-#endif  // if HAVE_CXX0X
-
-  /*!
-   * @brief This operator template is used to serialize sequences.
-   * @param vector_t The sequence that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  inline FastCdr& operator<<(const std::vector<_T>& vector_t)
-  {
-    return serialize<_T>(vector_t);
-  }
-
-  /*!
-   * @brief This operator template is used to serialize non-basic types.
-   * @param type_t The object that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  inline FastCdr& operator<<(const _T& type_t)
-  {
-    type_t.serialize(*this);
-    return *this;
-  }
-
-  /*!
-   * @brief This operator deserializes an octet.
-   * @param octet_t The variable that will store the octet read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator>>(uint8_t& octet_t)
-  {
-    return deserialize(octet_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a character.
-   * @param char_t The variable that will store the character read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator>>(char& char_t)
-  {
-    return deserialize(char_t);
-  }
-
-  /*!
-   * @brief This operator deserializes an int8_t.
-   * @param int8 The variable that will store the int8_t read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator>>(int8_t& int8)
-  {
-    return deserialize(int8);
-  }
-
-  /*!
-   * @brief This operator deserializes an unsigned short.
-   * @param ushort_t The variable that will store the unsigned short read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator>>(uint16_t& ushort_t)
-  {
-    return deserialize(ushort_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a short.
-   * @param short_t The variable that will store the short read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator>>(int16_t& short_t)
-  {
-    return deserialize(short_t);
-  }
-
-  /*!
-   * @brief This operator deserializes an unsigned long.
-   * @param ulong_t The variable that will store the unsigned long read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator>>(uint32_t& ulong_t)
-  {
-    return deserialize(ulong_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a long.
-   * @param long_t The variable that will store the long read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator>>(int32_t& long_t)
-  {
-    return deserialize(long_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a wide-char.
-   * @param wchar The variable that will store the wide-char read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator>>(wchar_t& wchar)
-  {
-    return deserialize(wchar);
-  }
-
-  /*!
-   * @brief This operator deserializes an unsigned long long.
-   * @param ulonglong_t The variable that will store the unsigned long long read from the
-   * buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator>>(uint64_t& ulonglong_t)
-  {
-    return deserialize(ulonglong_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a long long.
-   * @param longlong_t The variable that will store the long long read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator>>(int64_t& longlong_t)
-  {
-    return deserialize(longlong_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a float.
-   * @param float_t The variable that will store the float read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator>>(float& float_t)
-  {
-    return deserialize(float_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a double.
-   * @param double_t The variable that will store the double read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator>>(double& double_t)
-  {
-    return deserialize(double_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a long double.
-   * @param ldouble_t The variable that will store the long double read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator>>(long double& ldouble_t)
-  {
-    return deserialize(ldouble_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a boolean.
-   * @param bool_t The variable that will store the boolean read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   * @exception exception::BadParamException This exception is thrown when trying to
-   * deserialize in an invalid value.
-   */
-  inline FastCdr& operator>>(bool& bool_t)
-  {
-    return deserialize(bool_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a null-terminated c-string.
-   * @param string_t The variable that will store the c-string read from the buffer.
-   *                 Please note that a newly allocated string will be returned.
-   *                 The caller should free the returned pointer when appropiate.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize a position that exceeds the internal memory size.
-   * @exception exception::BadParamException This exception is thrown when trying to
-   * deserialize an invalid value.
-   */
-  inline FastCdr& operator>>(char*& string_t)
-  {
-    return deserialize(string_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a string.
-   * @param string_t The variable that will store the string read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator>>(std::string& string_t)
-  {
-    return deserialize(string_t);
-  }
-
-  /*!
-   * @brief This operator deserializes a wstring.
-   * @param string_t The variable that will store the wstring read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& operator>>(std::wstring& string_t)
-  {
-    return deserialize(string_t);
-  }
-
-#if HAVE_CXX0X
-  /*!
-   * @brief This operator template is used to deserialize arrays.
-   * @param array_t The variable that will store the array read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  template <class _T, size_t _Size>
-  inline FastCdr& operator>>(std::array<_T, _Size>& array_t)
-  {
-    return deserialize<_T, _Size>(array_t);
-  }
-
-#endif  // if HAVE_CXX0X
-
-  /*!
-   * @brief This operator template is used to deserialize sequences.
-   * @param vector_t The variable that will store the sequence read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  inline FastCdr& operator>>(std::vector<_T>& vector_t)
-  {
-    return deserialize<_T>(vector_t);
-  }
-
-  /*!
-   * @brief This operator template is used to deserialize non-basic types.
-   * @param type_t The variable that will store the object read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  inline FastCdr& operator>>(_T& type_t)
-  {
-    type_t.deserialize(*this);
-    return *this;
-  }
-
-  /*!
-   * @brief This function serializes an octet.
-   * @param octet_t The value of the octet that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serialize(const uint8_t octet_t)
-  {
-    return serialize(static_cast<char>(octet_t));
-  }
-
-  /*!
-   * @brief This function serializes a character.
-   * @param char_t The value of the character that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serialize(const char char_t)
-  {
-    if (((m_lastPosition - m_currentPosition) >= sizeof(char_t)) ||
-        resize(sizeof(char_t)))
+    class Cdr_DllAPI state
     {
-      m_currentPosition++ << char_t;
-      return *this;
+        friend class FastCdr;
+
+    public:
+
+        /*!
+         * @brief Default constructor.
+         */
+        state(
+                const FastCdr& fastcdr);
+
+        /*!
+         * @brief Copy constructor.
+         */
+        state(
+                const state&);
+
+    private:
+
+        state& operator =(
+                const state&) = delete;
+
+        //! @brief The position in the buffer when the state was created.
+        const FastBuffer::iterator current_position_;
+    };
+    /*!
+     * @brief This constructor creates a eprosima::fastcdr::FastCdr object that can serialize/deserialize
+     * the assigned buffer.
+     *
+     * @param cdr_buffer A reference to the buffer that contains (or will contain) the CDR representation.
+     */
+    FastCdr(
+            FastBuffer& cdr_buffer);
+
+    /*!
+     * @brief This function skips a number of bytes in the CDR stream buffer.
+     * @param num_bytes The number of bytes that will be jumped.
+     * @return True is returned when the jump operation works successfully. Otherwise, false is returned.
+     */
+    bool jump(
+            size_t num_bytes);
+
+    /*!
+     * @brief This function resets the current position in the buffer to the begining.
+     */
+    void reset();
+
+    /*!
+     * @brief This function returns the current position in the CDR stream.
+     * @return Pointer to the current position in the buffer.
+     */
+    char* get_current_position();
+
+    /*!
+     * @brief This function returns the length of the serialized data inside the stream.
+     * @return The length of the serialized data.
+     */
+    inline size_t get_serialized_data_length() const
+    {
+        return current_position_ - cdr_buffer_.begin();
     }
 
-    throw exception::NotEnoughMemoryException(
-        exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
+    /*!
+     * @brief This function returns the current state of the CDR stream.
+     * @return The current state of the buffer.
+     */
+    FastCdr::state get_state();
 
-  /*!
-   * @brief This function serializes an int8_t.
-   * @param int8 The value of the int8_t that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serialize(const int8_t int8)
-  {
-    return serialize(static_cast<char>(int8));
-  }
+    /*!
+     * @brief This function sets a previous state of the CDR stream;
+     * @param state Previous state that will be set again.
+     */
+    void set_state(
+            FastCdr::state& state);
 
-  /*!
-   * @brief This function serializes an unsigned short.
-   * @param ushort_t The value of the unsigned short that will be serialized in the
-   * buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serialize(const uint16_t ushort_t)
-  {
-    return serialize(static_cast<int16_t>(ushort_t));
-  }
-
-  /*!
-   * @brief This function serializes a short.
-   * @param short_t The value of the short that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serialize(const int16_t short_t)
-  {
-    if (((m_lastPosition - m_currentPosition) >= sizeof(short_t)) ||
-        resize(sizeof(short_t)))
+    /*!
+     * @brief This operator serializes an octet.
+     * @param octet_t The value of the octet that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const uint8_t octet_t)
     {
-      m_currentPosition << short_t;
-      m_currentPosition += sizeof(short_t);
-
-      return *this;
+        return serialize(octet_t);
     }
 
-    throw exception::NotEnoughMemoryException(
-        exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
-
-  /*!
-   * @brief This function serializes an unsigned long.
-   * @param ulong_t The value of the unsigned long that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serialize(const uint32_t ulong_t)
-  {
-    return serialize(static_cast<int32_t>(ulong_t));
-  }
-
-  /*!
-   * @brief This function serializes a long.
-   * @param long_t The value of the long that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serialize(const int32_t long_t)
-  {
-    if (((m_lastPosition - m_currentPosition) >= sizeof(long_t)) ||
-        resize(sizeof(long_t)))
+    /*!
+     * @brief This operator serializes a character.
+     * @param char_t The value of the character that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const char char_t)
     {
-      m_currentPosition << long_t;
-      m_currentPosition += sizeof(long_t);
-
-      return *this;
+        return serialize(char_t);
     }
 
-    throw exception::NotEnoughMemoryException(
-        exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
-
-  /*!
-   * @brief This function serializes a wide-char.
-   * @param wchar The value of the wide-char that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serialize(const wchar_t wchar)
-  {
-    return serialize(static_cast<uint32_t>(wchar));
-  }
-
-  /*!
-   * @brief This function serializes an unsigned long long.
-   * @param ulonglong_t The value of the unsigned long long that will be serialized in the
-   * buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serialize(const uint64_t ulonglong_t)
-  {
-    return serialize(static_cast<int64_t>(ulonglong_t));
-  }
-
-  /*!
-   * @brief This function serializes a long long.
-   * @param longlong_t The value of the long long that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serialize(const int64_t longlong_t)
-  {
-    if (((m_lastPosition - m_currentPosition) >= sizeof(longlong_t)) ||
-        resize(sizeof(longlong_t)))
+    /*!
+     * @brief This operator serializes a int8_t.
+     * @param int8 The value of the int8_t that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const int8_t int8)
     {
-      m_currentPosition << longlong_t;
-      m_currentPosition += sizeof(longlong_t);
-
-      return *this;
+        return serialize(int8);
     }
 
-    throw exception::NotEnoughMemoryException(
-        exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
-
-  /*!
-   * @brief This function serializes a float.
-   * @param float_t The value of the float that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serialize(const float float_t)
-  {
-    if (((m_lastPosition - m_currentPosition) >= sizeof(float_t)) ||
-        resize(sizeof(float_t)))
+    /*!
+     * @brief This operator serializes an unsigned short.
+     * @param ushort_t The value of the unsigned short that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const uint16_t ushort_t)
     {
-      m_currentPosition << float_t;
-      m_currentPosition += sizeof(float_t);
-
-      return *this;
+        return serialize(ushort_t);
     }
 
-    throw exception::NotEnoughMemoryException(
-        exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
-
-  /*!
-   * @brief This function serializes a double.
-   * @param double_t The value of the double that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serialize(const double double_t)
-  {
-    if (((m_lastPosition - m_currentPosition) >= sizeof(double_t)) ||
-        resize(sizeof(double_t)))
+    /*!
+     * @brief This operator serializes a short.
+     * @param short_t The value of the short that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const int16_t short_t)
     {
-      m_currentPosition << double_t;
-      m_currentPosition += sizeof(double_t);
-
-      return *this;
+        return serialize(short_t);
     }
 
-    throw exception::NotEnoughMemoryException(
-        exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
-
-  /*!
-   * @brief This function serializes a long double.
-   * @param ldouble_t The value of the long double that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serialize(const long double ldouble_t)
-  {
-    if (((m_lastPosition - m_currentPosition) >= sizeof(ldouble_t)) ||
-        resize(sizeof(ldouble_t)))
+    /*!
+     * @brief This operator serializes an unsigned long.
+     * @param ulong_t The value of the unsigned long that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const uint32_t ulong_t)
     {
-      m_currentPosition << ldouble_t;
+        return serialize(ulong_t);
+    }
+
+    /*!
+     * @brief This operator serializes a long.
+     * @param long_t The value of the long that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const int32_t long_t)
+    {
+        return serialize(long_t);
+    }
+
+    /*!
+     * @brief This operator serializes a wide-char.
+     * @param wchar The value of the wide-char that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const wchar_t wchar)
+    {
+        return serialize(wchar);
+    }
+
+    /*!
+     * @brief This operator serializes an unsigned long long.
+     * @param ulonglong_t The value of the unsigned long long that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const uint64_t ulonglong_t)
+    {
+        return serialize(ulonglong_t);
+    }
+
+    /*!
+     * @brief This operator serializes a long long.
+     * @param longlong_t The value of the long long that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const int64_t longlong_t)
+    {
+        return serialize(longlong_t);
+    }
+
+    /*!
+     * @brief This operator serializes a float.
+     * @param float_t The value of the float that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const float float_t)
+    {
+        return serialize(float_t);
+    }
+
+    /*!
+     * @brief This operator serializes a ldouble.
+     * @param double_t The value of the double that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const double double_t)
+    {
+        return serialize(double_t);
+    }
+
+    /*!
+     * @brief This operator serializes a long double.
+     * @param ldouble_t The value of the long double that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const long double ldouble_t)
+    {
+        return serialize(ldouble_t);
+    }
+
+    /*!
+     * @brief This operator serializes a boolean.
+     * @param bool_t The value of the boolean that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const bool bool_t)
+    {
+        return serialize(bool_t);
+    }
+
+    /*!
+     * @brief This operator serializes a null-terminated string.
+     * @param string_t The value of the string that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const char* string_t)
+    {
+        return serialize(string_t);
+    }
+
+    /*!
+     * @brief This operator serializes a null-terminated wide-string.
+     * @param string_t The value of the wide-string that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const wchar_t* string_t)
+    {
+        return serialize(string_t);
+    }
+
+    /*!
+     * @brief This operator serializes a string.
+     * @param string_t The string that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const std::string& string_t)
+    {
+        return serialize(string_t);
+    }
+
+    /*!
+     * @brief This operator serializes a wstring.
+     * @param string_t The wstring that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator <<(
+            const std::wstring& string_t)
+    {
+        return serialize(string_t);
+    }
+
+    /*!
+     * @brief This operator template is used to serialize arrays.
+     * @param array_t The array that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    template<class _T, size_t _Size>
+    inline FastCdr& operator <<(
+            const std::array<_T, _Size>& array_t)
+    {
+        return serialize<_T, _Size>(array_t);
+    }
+
+    /*!
+     * @brief This operator template is used to serialize sequences.
+     * @param vector_t The sequence that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    inline FastCdr& operator <<(
+            const std::vector<_T>& vector_t)
+    {
+        return serialize<_T>(vector_t);
+    }
+
+    /*!
+     * @brief This operator template is used to serialize non-basic types.
+     * @param type_t The object that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    inline FastCdr& operator <<(
+            const _T& type_t)
+    {
+        type_t.serialize(*this);
+        return *this;
+    }
+
+    /*!
+     * @brief This operator deserializes an octet.
+     * @param octet_t The variable that will store the octet read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator >>(
+            uint8_t& octet_t)
+    {
+        return deserialize(octet_t);
+    }
+
+    /*!
+     * @brief This operator deserializes a character.
+     * @param char_t The variable that will store the character read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator >>(
+            char& char_t)
+    {
+        return deserialize(char_t);
+    }
+
+    /*!
+     * @brief This operator deserializes an int8_t.
+     * @param int8 The variable that will store the int8_t read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator >>(
+            int8_t& int8)
+    {
+        return deserialize(int8);
+    }
+
+    /*!
+     * @brief This operator deserializes an unsigned short.
+     * @param ushort_t The variable that will store the unsigned short read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator >>(
+            uint16_t& ushort_t)
+    {
+        return deserialize(ushort_t);
+    }
+
+    /*!
+     * @brief This operator deserializes a short.
+     * @param short_t The variable that will store the short read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator >>(
+            int16_t& short_t)
+    {
+        return deserialize(short_t);
+    }
+
+    /*!
+     * @brief This operator deserializes an unsigned long.
+     * @param ulong_t The variable that will store the unsigned long read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator >>(
+            uint32_t& ulong_t)
+    {
+        return deserialize(ulong_t);
+    }
+
+    /*!
+     * @brief This operator deserializes a long.
+     * @param long_t The variable that will store the long read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator >>(
+            int32_t& long_t)
+    {
+        return deserialize(long_t);
+    }
+
+    /*!
+     * @brief This operator deserializes a wide-char.
+     * @param wchar The variable that will store the wide-char read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator >>(
+            wchar_t& wchar)
+    {
+        return deserialize(wchar);
+    }
+
+    /*!
+     * @brief This operator deserializes an unsigned long long.
+     * @param ulonglong_t The variable that will store the unsigned long long read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator >>(
+            uint64_t& ulonglong_t)
+    {
+        return deserialize(ulonglong_t);
+    }
+
+    /*!
+     * @brief This operator deserializes a long long.
+     * @param longlong_t The variable that will store the long long read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator >>(
+            int64_t& longlong_t)
+    {
+        return deserialize(longlong_t);
+    }
+
+    /*!
+     * @brief This operator deserializes a float.
+     * @param float_t The variable that will store the float read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator >>(
+            float& float_t)
+    {
+        return deserialize(float_t);
+    }
+
+    /*!
+     * @brief This operator deserializes a double.
+     * @param double_t The variable that will store the double read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator >>(
+            double& double_t)
+    {
+        return deserialize(double_t);
+    }
+
+    /*!
+     * @brief This operator deserializes a long double.
+     * @param ldouble_t The variable that will store the long double read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator >>(
+            long double& ldouble_t)
+    {
+        return deserialize(ldouble_t);
+    }
+
+    /*!
+     * @brief This operator deserializes a boolean.
+     * @param bool_t The variable that will store the boolean read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     * @exception exception::BadParamException This exception is thrown when trying to deserialize in an invalid value.
+     */
+    inline FastCdr& operator >>(
+            bool& bool_t)
+    {
+        return deserialize(bool_t);
+    }
+
+    /*!
+     * @brief This operator deserializes a null-terminated c-string.
+     * @param string_t The variable that will store the c-string read from the buffer.
+     *                 Please note that a newly allocated string will be returned.
+     *                 The caller should free the returned pointer when appropiate.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize a position that exceeds the internal memory size.
+     * @exception exception::BadParamException This exception is thrown when trying to deserialize an invalid value.
+     */
+    inline FastCdr& operator >>(
+            char*& string_t)
+    {
+        return deserialize(string_t);
+    }
+
+    /*!
+     * @brief This operator deserializes a string.
+     * @param string_t The variable that will store the string read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator >>(
+            std::string& string_t)
+    {
+        return deserialize(string_t);
+    }
+
+    /*!
+     * @brief This operator deserializes a wstring.
+     * @param string_t The variable that will store the wstring read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline FastCdr& operator >>(
+            std::wstring& string_t)
+    {
+        return deserialize(string_t);
+    }
+
+    /*!
+     * @brief This operator template is used to deserialize arrays.
+     * @param array_t The variable that will store the array read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    template<class _T, size_t _Size>
+    inline FastCdr& operator >>(
+            std::array<_T, _Size>& array_t)
+    {
+        return deserialize<_T, _Size>(array_t);
+    }
+
+    /*!
+     * @brief This operator template is used to deserialize sequences.
+     * @param vector_t The variable that will store the sequence read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    inline FastCdr& operator >>(
+            std::vector<_T>& vector_t)
+    {
+        return deserialize<_T>(vector_t);
+    }
+
+    /*!
+     * @brief This operator template is used to deserialize non-basic types.
+     * @param type_t The variable that will store the object read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    inline FastCdr& operator >>(
+            _T& type_t)
+    {
+        type_t.deserialize(*this);
+        return *this;
+    }
+
+    /*!
+     * @brief This function serializes an octet.
+     * @param octet_t The value of the octet that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize(
+            const uint8_t octet_t)
+    {
+        return serialize(static_cast<char>(octet_t));
+    }
+
+    /*!
+     * @brief This function serializes a character.
+     * @param char_t The value of the character that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize(
+            const char char_t)
+    {
+        if (((last_position_ - current_position_) >= sizeof(char_t)) || resize(sizeof(char_t)))
+        {
+            current_position_++ << char_t;
+            return *this;
+        }
+
+        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    }
+
+    /*!
+     * @brief This function serializes an int8_t.
+     * @param int8 The value of the int8_t that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize(
+            const int8_t int8)
+    {
+        return serialize(static_cast<char>(int8));
+    }
+
+    /*!
+     * @brief This function serializes an unsigned short.
+     * @param ushort_t The value of the unsigned short that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize(
+            const uint16_t ushort_t)
+    {
+        return serialize(static_cast<int16_t>(ushort_t));
+    }
+
+    /*!
+     * @brief This function serializes a short.
+     * @param short_t The value of the short that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize(
+            const int16_t short_t)
+    {
+        if (((last_position_ - current_position_) >= sizeof(short_t)) || resize(sizeof(short_t)))
+        {
+            current_position_ << short_t;
+            current_position_ += sizeof(short_t);
+
+            return *this;
+        }
+
+        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    }
+
+    /*!
+     * @brief This function serializes an unsigned long.
+     * @param ulong_t The value of the unsigned long that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize(
+            const uint32_t ulong_t)
+    {
+        return serialize(static_cast<int32_t>(ulong_t));
+    }
+
+    /*!
+     * @brief This function serializes a long.
+     * @param long_t The value of the long that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize(
+            const int32_t long_t)
+    {
+        if (((last_position_ - current_position_) >= sizeof(long_t)) || resize(sizeof(long_t)))
+        {
+            current_position_ << long_t;
+            current_position_ += sizeof(long_t);
+
+            return *this;
+        }
+
+        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    }
+
+    /*!
+     * @brief This function serializes a wide-char.
+     * @param wchar The value of the wide-char that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize(
+            const wchar_t wchar)
+    {
+        return serialize(static_cast<uint32_t>(wchar));
+    }
+
+    /*!
+     * @brief This function serializes an unsigned long long.
+     * @param ulonglong_t The value of the unsigned long long that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize(
+            const uint64_t ulonglong_t)
+    {
+        return serialize(static_cast<int64_t>(ulonglong_t));
+    }
+
+    /*!
+     * @brief This function serializes a long long.
+     * @param longlong_t The value of the long long that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize(
+            const int64_t longlong_t)
+    {
+        if (((last_position_ - current_position_) >= sizeof(longlong_t)) || resize(sizeof(longlong_t)))
+        {
+            current_position_ << longlong_t;
+            current_position_ += sizeof(longlong_t);
+
+            return *this;
+        }
+
+        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    }
+
+    /*!
+     * @brief This function serializes a float.
+     * @param float_t The value of the float that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize(
+            const float float_t)
+    {
+        if (((last_position_ - current_position_) >= sizeof(float_t)) || resize(sizeof(float_t)))
+        {
+            current_position_ << float_t;
+            current_position_ += sizeof(float_t);
+
+            return *this;
+        }
+
+        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    }
+
+    /*!
+     * @brief This function serializes a double.
+     * @param double_t The value of the double that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize(
+            const double double_t)
+    {
+        if (((last_position_ - current_position_) >= sizeof(double_t)) || resize(sizeof(double_t)))
+        {
+            current_position_ << double_t;
+            current_position_ += sizeof(double_t);
+
+            return *this;
+        }
+
+        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    }
+
+    /*!
+     * @brief This function serializes a long double.
+     * @param ldouble_t The value of the long double that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize(
+            const long double ldouble_t)
+    {
+        if (((last_position_ - current_position_) >= sizeof(ldouble_t)) || resize(sizeof(ldouble_t)))
+        {
+            current_position_ << ldouble_t;
 #if defined(_WIN32)
-      m_currentPosition += sizeof(ldouble_t);
-      m_currentPosition << static_cast<long double>(0);
-#endif  // if defined(_WIN32)
-      m_currentPosition += sizeof(ldouble_t);
+            current_position_ += sizeof(ldouble_t);
+            current_position_ << static_cast<long double>(0);
+#endif // if defined(_WIN32)
+            current_position_ += sizeof(ldouble_t);
 
-      return *this;
+            return *this;
+        }
+
+        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
-    throw exception::NotEnoughMemoryException(
-        exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
+    /*!
+     * @brief This function serializes a boolean.
+     * @param bool_t The value of the boolean that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& serialize(
+            const bool bool_t);
 
-  /*!
-   * @brief This function serializes a boolean.
-   * @param bool_t The value of the boolean that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& serialize(const bool bool_t);
+    /*!
+     * @brief This function serializes a string.
+     * @param string_t The pointer to the string that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& serialize(
+            const char* string_t);
 
-  /*!
-   * @brief This function serializes a string.
-   * @param string_t The pointer to the string that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& serialize(const char* string_t);
+    /*!
+     * @brief This function serializes a wstring.
+     * @param string_t The pointer to the wstring that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& serialize(
+            const wchar_t* string_t);
 
-  /*!
-   * @brief This function serializes a wstring.
-   * @param string_t The pointer to the wstring that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& serialize(const wchar_t* string_t);
-
-  /*!
-   * @brief This function serializes a std::string.
-   * @param string_t The string that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serialize(const std::string& string_t)
-  {
-    return serialize(string_t.c_str());
-  }
-
-  /*!
-   * @brief This function serializes a std::wstring.
-   * @param string_t The wstring that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serialize(const std::wstring& string_t)
-  {
-    return serialize(string_t.c_str());
-  }
-
-#if HAVE_CXX0X
-  /*!
-   * @brief This function template serializes an array.
-   * @param array_t The array that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  template <class _T, size_t _Size>
-  inline FastCdr& serialize(const std::array<_T, _Size>& array_t)
-  {
-    return serializeArray(array_t.data(), array_t.size());
-  }
-
-#endif  // if HAVE_CXX0X
-
-#if !defined(_MSC_VER) && HAVE_CXX0X
-  /*!
-   * @brief This function template serializes a sequence of booleans.
-   * @param vector_t The sequence that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  template <class _T = bool>
-  FastCdr& serialize(const std::vector<bool>& vector_t)
-  {
-    return serializeBoolSequence(vector_t);
-  }
-
-#endif  // if !defined(_MSC_VER) && HAVE_CXX0X
-
-  /*!
-   * @brief This function template serializes a sequence.
-   * @param vector_t The sequence that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  FastCdr& serialize(const std::vector<_T>& vector_t)
-  {
-    state state_before_error(*this);
-
-    *this << static_cast<int32_t>(vector_t.size());
-
-    try
+    /*!
+     * @brief This function serializes a std::string.
+     * @param string_t The string that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize(
+            const std::string& string_t)
     {
-      return serializeArray(vector_t.data(), vector_t.size());
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      setState(state_before_error);
-      ex.raise();
+        return serialize(string_t.c_str());
     }
 
-    return *this;
-  }
+    /*!
+     * @brief This function serializes a std::wstring.
+     * @param string_t The wstring that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize(
+            const std::wstring& string_t)
+    {
+        return serialize(string_t.c_str());
+    }
+
+    /*!
+     * @brief This function template serializes an array.
+     * @param array_t The array that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    template<class _T, size_t _Size>
+    inline FastCdr& serialize(
+            const std::array<_T, _Size>& array_t)
+    {
+        return serialize_array(array_t.data(), array_t.size());
+    }
+
+    /*!
+     * @brief This function template serializes a sequence of booleans.
+     * @param vector_t The sequence that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    template<class _T = bool>
+    FastCdr& serialize(
+            const std::vector<bool>& vector_t)
+    {
+        return serialize_bool_sequence(vector_t);
+    }
+
+    /*!
+     * @brief This function template serializes a sequence.
+     * @param vector_t The sequence that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    FastCdr& serialize(
+            const std::vector<_T>& vector_t)
+    {
+        state state_before_error(*this);
+
+        *this << static_cast<int32_t>(vector_t.size());
+
+        try
+        {
+            return serialize_array(vector_t.data(), vector_t.size());
+        }
+        catch (eprosima::fastcdr::exception::Exception& ex)
+        {
+            set_state(state_before_error);
+            ex.raise();
+        }
+
+        return *this;
+    }
 
 #ifdef _MSC_VER
-  /*!
-   * @brief This function template serializes a sequence of booleans.
-   * @param vector_t The sequence that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  template <>
-  FastCdr& serialize<bool>(const std::vector<bool>& vector_t)
-  {
-    return serializeBoolSequence(vector_t);
-  }
-
-#endif  // ifdef _MSC_VER
-
-  /*!
-   * @brief This function template serializes a non-basic type.
-   * @param type_t The object that will be serialized in the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  inline FastCdr& serialize(const _T& type_t)
-  {
-    type_t.serialize(*this);
-    return *this;
-  }
-
-  /*!
-   * @brief This function serializes an array of octets.
-   * @param octet_t The sequence of octets that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serializeArray(const uint8_t* octet_t, size_t numElements)
-  {
-    return serializeArray(reinterpret_cast<const char*>(octet_t), numElements);
-  }
-
-  /*!
-   * @brief This function serializes an array of characters.
-   * @param char_t The array of characters that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& serializeArray(const char* char_t, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of int8_t.
-   * @param int8 The sequence of int8_t that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serializeArray(const int8_t* int8, size_t numElements)
-  {
-    return serializeArray(reinterpret_cast<const char*>(int8), numElements);
-  }
-
-  /*!
-   * @brief This function serializes an array of unsigned shorts.
-   * @param ushort_t The array of unsigned shorts that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serializeArray(const uint16_t* ushort_t, size_t numElements)
-  {
-    return serializeArray(reinterpret_cast<const int16_t*>(ushort_t), numElements);
-  }
-
-  /*!
-   * @brief This function serializes an array of shorts.
-   * @param short_t The array of shorts that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& serializeArray(const int16_t* short_t, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of unsigned longs.
-   * @param ulong_t The array of unsigned longs that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serializeArray(const uint32_t* ulong_t, size_t numElements)
-  {
-    return serializeArray(reinterpret_cast<const int32_t*>(ulong_t), numElements);
-  }
-
-  /*!
-   * @brief This function serializes an array of longs.
-   * @param long_t The array of longs that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& serializeArray(const int32_t* long_t, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of wide-chars.
-   * @param wchar The array of wide-chars that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& serializeArray(const wchar_t* wchar, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of unsigned long longs.
-   * @param ulonglong_t The array of unsigned long longs that will be serialized in the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serializeArray(const uint64_t* ulonglong_t, size_t numElements)
-  {
-    return serializeArray(reinterpret_cast<const int64_t*>(ulonglong_t), numElements);
-  }
-
-  /*!
-   * @brief This function serializes an array of long longs.
-   * @param longlong_t The array of  long longs that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& serializeArray(const int64_t* longlong_t, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of floats.
-   * @param float_t The array of floats that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& serializeArray(const float* float_t, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of doubles.
-   * @param double_t The array of doubles that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& serializeArray(const double* double_t, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of long doubles.
-   * @param ldouble_t The array of long doubles that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& serializeArray(const long double* ldouble_t, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of booleans.
-   * @param bool_t The array of booleans that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& serializeArray(const bool* bool_t, size_t numElements);
-
-  /*!
-   * @brief This function serializes an array of strings.
-   * @param string_t The array of strings that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serializeArray(const std::string* string_t, size_t numElements)
-  {
-    for (size_t count = 0; count < numElements; ++count)
+    /*!
+     * @brief This function template serializes a sequence of booleans.
+     * @param vector_t The sequence that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    template<>
+    FastCdr& serialize<bool>(
+            const std::vector<bool>& vector_t)
     {
-      serialize(string_t[count].c_str());
-    }
-    return *this;
-  }
-
-  /*!
-   * @brief This function serializes an array of wstrings.
-   * @param string_t The array of wstrings that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& serializeArray(const std::wstring* string_t, size_t numElements)
-  {
-    for (size_t count = 0; count < numElements; ++count)
-    {
-      serialize(string_t[count].c_str());
-    }
-    return *this;
-  }
-
-  /*!
-   * @brief This function template serializes an array of sequences.
-   * @param vector_t The array of sequences that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  FastCdr& serializeArray(const std::vector<_T>* vector_t, size_t numElements)
-  {
-    for (size_t count = 0; count < numElements; ++count)
-    {
-      serialize(vector_t[count]);
-    }
-    return *this;
-  }
-
-  /*!
-   * @brief This function template serializes an array of non-basic type objects.
-   * @param type_t The array of objects that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  FastCdr& serializeArray(const _T* type_t, size_t numElements)
-  {
-    for (size_t count = 0; count < numElements; ++count)
-    {
-      type_t[count].serialize(*this);
-    }
-    return *this;
-  }
-
-  /*!
-   * @brief This function template serializes a raw sequence.
-   * @param sequence_t Pointer to the sequence that will be serialized in the buffer.
-   * @param numElements The number of elements contained in the sequence.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  FastCdr& serializeSequence(const _T* sequence_t, size_t numElements)
-  {
-    state state_before_error(*this);
-
-    serialize(static_cast<int32_t>(numElements));
-
-    try
-    {
-      return serializeArray(sequence_t, numElements);
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      setState(state_before_error);
-      ex.raise();
+        return serialize_bool_sequence(vector_t);
     }
 
-    return *this;
-  }
+#endif // ifdef _MSC_VER
 
-  /*!
-   * @brief This function deserializes an octet.
-   * @param octet_t The variable that will store the octet read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserialize(uint8_t& octet_t)
-  {
-    return deserialize(reinterpret_cast<char&>(octet_t));
-  }
-
-  /*!
-   * @brief This function deserializes a character.
-   * @param char_t The variable that will store the character read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserialize(char& char_t)
-  {
-    if ((m_lastPosition - m_currentPosition) >= sizeof(char_t))
+    /*!
+     * @brief This function template serializes a non-basic type.
+     * @param type_t The object that will be serialized in the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    inline FastCdr& serialize(
+            const _T& type_t)
     {
-      m_currentPosition++ >> char_t;
-      return *this;
+        type_t.serialize(*this);
+        return *this;
     }
 
-    throw exception::NotEnoughMemoryException(
-        exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
-
-  /*!
-   * @brief This function deserializes an int8_t.
-   * @param int8 The variable that will store the int8_t read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserialize(int8_t& int8)
-  {
-    return deserialize(reinterpret_cast<char&>(int8));
-  }
-
-  /*!
-   * @brief This function deserializes an unsigned short.
-   * @param ushort_t The variable that will store the unsigned short read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserialize(uint16_t& ushort_t)
-  {
-    return deserialize(reinterpret_cast<int16_t&>(ushort_t));
-  }
-
-  /*!
-   * @brief This function deserializes a short.
-   * @param short_t The variable that will store the short read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserialize(int16_t& short_t)
-  {
-    if ((m_lastPosition - m_currentPosition) >= sizeof(short_t))
+    /*!
+     * @brief This function serializes an array of octets.
+     * @param octet_t The sequence of octets that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize_array(
+            const uint8_t* octet_t,
+            size_t num_elements)
     {
-      m_currentPosition >> short_t;
-      m_currentPosition += sizeof(short_t);
-
-      return *this;
+        return serialize_array(reinterpret_cast<const char*>(octet_t), num_elements);
     }
 
-    throw exception::NotEnoughMemoryException(
-        exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
+    /*!
+     * @brief This function serializes an array of characters.
+     * @param char_t The array of characters that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& serialize_array(
+            const char* char_t,
+            size_t num_elements);
 
-  /*!
-   * @brief This function deserializes an unsigned long.
-   * @param ulong_t The variable that will store the unsigned long read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserialize(uint32_t& ulong_t)
-  {
-    return deserialize(reinterpret_cast<int32_t&>(ulong_t));
-  }
-
-  /*!
-   * @brief This function deserializes a long.
-   * @param long_t The variable that will store the long read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserialize(int32_t& long_t)
-  {
-    if ((m_lastPosition - m_currentPosition) >= sizeof(long_t))
+    /*!
+     * @brief This function serializes an array of int8_t.
+     * @param int8 The sequence of int8_t that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize_array(
+            const int8_t* int8,
+            size_t num_elements)
     {
-      m_currentPosition >> long_t;
-      m_currentPosition += sizeof(long_t);
-
-      return *this;
+        return serialize_array(reinterpret_cast<const char*>(int8), num_elements);
     }
 
-    throw exception::NotEnoughMemoryException(
-        exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
-
-  /*!
-   * @brief This function deserializes a wide-char.
-   * @param wchar The variable that will store the wide-char read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserialize(wchar_t& wchar)
-  {
-    uint32_t ret;
-    deserialize(ret);
-    wchar = static_cast<wchar_t>(ret);
-    return *this;
-  }
-
-  /*!
-   * @brief This function deserializes an unsigned long long.
-   * @param ulonglong_t The variable that will store the unsigned long long read from the
-   * buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserialize(uint64_t& ulonglong_t)
-  {
-    return deserialize(reinterpret_cast<int64_t&>(ulonglong_t));
-  }
-
-  /*!
-   * @brief This function deserializes a long long.
-   * @param longlong_t The variable that will store the long long read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserialize(int64_t& longlong_t)
-  {
-    if ((m_lastPosition - m_currentPosition) >= sizeof(longlong_t))
+    /*!
+     * @brief This function serializes an array of unsigned shorts.
+     * @param ushort_t The array of unsigned shorts that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize_array(
+            const uint16_t* ushort_t,
+            size_t num_elements)
     {
-      m_currentPosition >> longlong_t;
-      m_currentPosition += sizeof(longlong_t);
-
-      return *this;
+        return serialize_array(reinterpret_cast<const int16_t*>(ushort_t), num_elements);
     }
 
-    throw exception::NotEnoughMemoryException(
-        exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
+    /*!
+     * @brief This function serializes an array of shorts.
+     * @param short_t The array of shorts that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& serialize_array(
+            const int16_t* short_t,
+            size_t num_elements);
 
-  /*!
-   * @brief This function deserializes a float.
-   * @param float_t The variable that will store the float read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserialize(float& float_t)
-  {
-    if ((m_lastPosition - m_currentPosition) >= sizeof(float_t))
+    /*!
+     * @brief This function serializes an array of unsigned longs.
+     * @param ulong_t The array of unsigned longs that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize_array(
+            const uint32_t* ulong_t,
+            size_t num_elements)
     {
-      m_currentPosition >> float_t;
-      m_currentPosition += sizeof(float_t);
-
-      return *this;
+        return serialize_array(reinterpret_cast<const int32_t*>(ulong_t), num_elements);
     }
 
-    throw exception::NotEnoughMemoryException(
-        exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
+    /*!
+     * @brief This function serializes an array of longs.
+     * @param long_t The array of longs that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& serialize_array(
+            const int32_t* long_t,
+            size_t num_elements);
 
-  /*!
-   * @brief This function deserializes a double.
-   * @param double_t The variable that will store the double read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserialize(double& double_t)
-  {
-    if ((m_lastPosition - m_currentPosition) >= sizeof(double_t))
+    /*!
+     * @brief This function serializes an array of wide-chars.
+     * @param wchar The array of wide-chars that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& serialize_array(
+            const wchar_t* wchar,
+            size_t num_elements);
+
+    /*!
+     * @brief This function serializes an array of unsigned long longs.
+     * @param ulonglong_t The array of unsigned long longs that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize_array(
+            const uint64_t* ulonglong_t,
+            size_t num_elements)
     {
-      m_currentPosition >> double_t;
-      m_currentPosition += sizeof(double_t);
-
-      return *this;
+        return serialize_array(reinterpret_cast<const int64_t*>(ulonglong_t), num_elements);
     }
 
-    throw exception::NotEnoughMemoryException(
-        exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
+    /*!
+     * @brief This function serializes an array of long longs.
+     * @param longlong_t The array of  long longs that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& serialize_array(
+            const int64_t* longlong_t,
+            size_t num_elements);
 
-  /*!
-   * @brief This function deserializes a long double.
-   * @param ldouble_t The variable that will store the long double read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserialize(long double& ldouble_t)
-  {
-    if ((m_lastPosition - m_currentPosition) >= sizeof(ldouble_t))
+    /*!
+     * @brief This function serializes an array of floats.
+     * @param float_t The array of floats that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& serialize_array(
+            const float* float_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function serializes an array of doubles.
+     * @param double_t The array of doubles that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& serialize_array(
+            const double* double_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function serializes an array of long doubles.
+     * @param ldouble_t The array of long doubles that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& serialize_array(
+            const long double* ldouble_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function serializes an array of booleans.
+     * @param bool_t The array of booleans that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& serialize_array(
+            const bool* bool_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function serializes an array of strings.
+     * @param string_t The array of strings that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize_array(
+            const std::string* string_t,
+            size_t num_elements)
     {
-      m_currentPosition >> ldouble_t;
-      m_currentPosition += sizeof(ldouble_t);
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            serialize(string_t[count].c_str());
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief This function serializes an array of wstrings.
+     * @param string_t The array of wstrings that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& serialize_array(
+            const std::wstring* string_t,
+            size_t num_elements)
+    {
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            serialize(string_t[count].c_str());
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief This function template serializes an array of sequences.
+     * @param vector_t The array of sequences that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    FastCdr& serialize_array(
+            const std::vector<_T>* vector_t,
+            size_t num_elements)
+    {
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            serialize(vector_t[count]);
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief This function template serializes an array of non-basic type objects.
+     * @param type_t The array of objects that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    FastCdr& serialize_array(
+            const _T* type_t,
+            size_t num_elements)
+    {
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            type_t[count].serialize(*this);
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief This function template serializes a raw sequence.
+     * @param sequence_t Pointer to the sequence that will be serialized in the buffer.
+     * @param num_elements The number of elements contained in the sequence.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    FastCdr& serialize_sequence(
+            const _T* sequence_t,
+            size_t num_elements)
+    {
+        state state_before_error(*this);
+
+        serialize(static_cast<int32_t>(num_elements));
+
+        try
+        {
+            return serialize_array(sequence_t, num_elements);
+        }
+        catch (eprosima::fastcdr::exception::Exception& ex)
+        {
+            set_state(state_before_error);
+            ex.raise();
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief This function deserializes an octet.
+     * @param octet_t The variable that will store the octet read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize(
+            uint8_t& octet_t)
+    {
+        return deserialize(reinterpret_cast<char&>(octet_t));
+    }
+
+    /*!
+     * @brief This function deserializes a character.
+     * @param char_t The variable that will store the character read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize(
+            char& char_t)
+    {
+        if ((last_position_ - current_position_) >= sizeof(char_t))
+        {
+            current_position_++ >> char_t;
+            return *this;
+        }
+
+        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    }
+
+    /*!
+     * @brief This function deserializes an int8_t.
+     * @param int8 The variable that will store the int8_t read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize(
+            int8_t& int8)
+    {
+        return deserialize(reinterpret_cast<char&>(int8));
+    }
+
+    /*!
+     * @brief This function deserializes an unsigned short.
+     * @param ushort_t The variable that will store the unsigned short read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize(
+            uint16_t& ushort_t)
+    {
+        return deserialize(reinterpret_cast<int16_t&>(ushort_t));
+    }
+
+    /*!
+     * @brief This function deserializes a short.
+     * @param short_t The variable that will store the short read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize(
+            int16_t& short_t)
+    {
+        if ((last_position_ - current_position_) >= sizeof(short_t))
+        {
+            current_position_ >> short_t;
+            current_position_ += sizeof(short_t);
+
+            return *this;
+        }
+
+        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    }
+
+    /*!
+     * @brief This function deserializes an unsigned long.
+     * @param ulong_t The variable that will store the unsigned long read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize(
+            uint32_t& ulong_t)
+    {
+        return deserialize(reinterpret_cast<int32_t&>(ulong_t));
+    }
+
+    /*!
+     * @brief This function deserializes a long.
+     * @param long_t The variable that will store the long read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize(
+            int32_t& long_t)
+    {
+        if ((last_position_ - current_position_) >= sizeof(long_t))
+        {
+            current_position_ >> long_t;
+            current_position_ += sizeof(long_t);
+
+            return *this;
+        }
+
+        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    }
+
+    /*!
+     * @brief This function deserializes a wide-char.
+     * @param wchar The variable that will store the wide-char read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize(
+            wchar_t& wchar)
+    {
+        uint32_t ret;
+        deserialize(ret);
+        wchar = static_cast<wchar_t>(ret);
+        return *this;
+    }
+
+    /*!
+     * @brief This function deserializes an unsigned long long.
+     * @param ulonglong_t The variable that will store the unsigned long long read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize(
+            uint64_t& ulonglong_t)
+    {
+        return deserialize(reinterpret_cast<int64_t&>(ulonglong_t));
+    }
+
+    /*!
+     * @brief This function deserializes a long long.
+     * @param longlong_t The variable that will store the long long read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize(
+            int64_t& longlong_t)
+    {
+        if ((last_position_ - current_position_) >= sizeof(longlong_t))
+        {
+            current_position_ >> longlong_t;
+            current_position_ += sizeof(longlong_t);
+
+            return *this;
+        }
+
+        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    }
+
+    /*!
+     * @brief This function deserializes a float.
+     * @param float_t The variable that will store the float read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize(
+            float& float_t)
+    {
+        if ((last_position_ - current_position_) >= sizeof(float_t))
+        {
+            current_position_ >> float_t;
+            current_position_ += sizeof(float_t);
+
+            return *this;
+        }
+
+        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    }
+
+    /*!
+     * @brief This function deserializes a double.
+     * @param double_t The variable that will store the double read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize(
+            double& double_t)
+    {
+        if ((last_position_ - current_position_) >= sizeof(double_t))
+        {
+            current_position_ >> double_t;
+            current_position_ += sizeof(double_t);
+
+            return *this;
+        }
+
+        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    }
+
+    /*!
+     * @brief This function deserializes a long double.
+     * @param ldouble_t The variable that will store the long double read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize(
+            long double& ldouble_t)
+    {
+        if ((last_position_ - current_position_) >= sizeof(ldouble_t))
+        {
+            current_position_ >> ldouble_t;
+            current_position_ += sizeof(ldouble_t);
 #if defined(_WIN32)
-      m_currentPosition += sizeof(ldouble_t);
-#endif  // if defined(_WIN32)
+            current_position_ += sizeof(ldouble_t);
+#endif // if defined(_WIN32)
 
-      return *this;
+            return *this;
+        }
+
+        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
-    throw exception::NotEnoughMemoryException(
-        exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
+    /*!
+     * @brief This function deserializes a boolean.
+     * @param bool_t The variable that will store the boolean read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     * @exception exception::BadParamException This exception is thrown when trying to deserialize in an invalid value.
+     */
+    FastCdr& deserialize(
+            bool& bool_t);
 
-  /*!
-   * @brief This function deserializes a boolean.
-   * @param bool_t The variable that will store the boolean read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   * @exception exception::BadParamException This exception is thrown when trying to
-   * deserialize in an invalid value.
-   */
-  FastCdr& deserialize(bool& bool_t);
+    /*!
+     * @brief This function deserializes a string.
+     * This function allocates memory to store the string. The user pointer will be set to point this allocated memory.
+     * The user will have to free this allocated memory using free()
+     * @param string_t The pointer that will point to the string read from the buffer.
+     * The user will have to free the allocated memory using free()
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& deserialize(
+            char*& string_t);
 
-  /*!
-   * @brief This function deserializes a string.
-   * This function allocates memory to store the string. The user pointer will be set to
-   * point this allocated memory. The user will have to free this allocated memory using
-   * free()
-   * @param string_t The pointer that will point to the string read from the buffer.
-   * The user will have to free the allocated memory using free()
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& deserialize(char*& string_t);
+    /*!
+     * @brief This function deserializes a wide string.
+     * This function allocates memory to store the wide string. The user pointer will be set to point this allocated memory.
+     * The user will have to free this allocated memory using free()
+     * @param string_t The pointer that will point to the wide string read from the buffer.
+     * The user will have to free the allocated memory using free()
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& deserialize(
+            wchar_t*& string_t);
 
-  /*!
-   * @brief This function deserializes a wide string.
-   * This function allocates memory to store the wide string. The user pointer will be set
-   * to point this allocated memory. The user will have to free this allocated memory
-   * using free()
-   * @param string_t The pointer that will point to the wide string read from the buffer.
-   * The user will have to free the allocated memory using free()
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& deserialize(wchar_t*& string_t);
-
-  /*!
-   * @brief This function deserializes a std::string.
-   * @param string_t The variable that will store the string read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserialize(std::string& string_t)
-  {
-    uint32_t length = 0;
-    const char* str = readString(length);
-    string_t = std::string(str, length);
-    return *this;
-  }
-
-  /*!
-   * @brief This function deserializes a std::wstring.
-   * @param string_t The variable that will store the wstring read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserialize(std::wstring& string_t)
-  {
-    uint32_t length = 0;
-    string_t = readWString(length);
-    return *this;
-  }
-
-#if HAVE_CXX0X
-  /*!
-   * @brief This function template deserializes an array.
-   * @param array_t The variable that will store the array read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  template <class _T, size_t _Size>
-  inline FastCdr& deserialize(std::array<_T, _Size>& array_t)
-  {
-    return deserializeArray(array_t.data(), array_t.size());
-  }
-
-#endif  // if HAVE_CXX0X
-
-#if !defined(_MSC_VER) && HAVE_CXX0X
-  /*!
-   * @brief This function template deserializes a sequence of booleans.
-   * @param vector_t The variable that will store the sequence read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  template <class _T = bool>
-  FastCdr& deserialize(std::vector<bool>& vector_t)
-  {
-    return deserializeBoolSequence(vector_t);
-  }
-
-#endif  // if !defined(_MSC_VER) && HAVE_CXX0X
-
-  /*!
-   * @brief This function template deserializes a sequence.
-   * @param vector_t The variable that will store the sequence read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  FastCdr& deserialize(std::vector<_T>& vector_t)
-  {
-    uint32_t seqLength = 0;
-    state state_before_error(*this);
-
-    *this >> seqLength;
-
-    try
+    /*!
+     * @brief This function deserializes a std::string.
+     * @param string_t The variable that will store the string read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize(
+            std::string& string_t)
     {
-      vector_t.resize(seqLength);
-      return deserializeArray(vector_t.data(), vector_t.size());
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      setState(state_before_error);
-      ex.raise();
+        uint32_t length = 0;
+        const char* str = read_string(length);
+        string_t = std::string(str, length);
+        return *this;
     }
 
-    return *this;
-  }
+    /*!
+     * @brief This function deserializes a std::wstring.
+     * @param string_t The variable that will store the wstring read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize(
+            std::wstring& string_t)
+    {
+        uint32_t length = 0;
+        string_t = read_wstring(length);
+        return *this;
+    }
+
+    /*!
+     * @brief This function template deserializes an array.
+     * @param array_t The variable that will store the array read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    template<class _T, size_t _Size>
+    inline FastCdr& deserialize(
+            std::array<_T, _Size>& array_t)
+    {
+        return deserialize_array(array_t.data(), array_t.size());
+    }
+
+    /*!
+     * @brief This function template deserializes a sequence of booleans.
+     * @param vector_t The variable that will store the sequence read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    template<class _T = bool>
+    FastCdr& deserialize(
+            std::vector<bool>& vector_t)
+    {
+        return deserialize_bool_sequence(vector_t);
+    }
+
+    /*!
+     * @brief This function template deserializes a sequence.
+     * @param vector_t The variable that will store the sequence read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    FastCdr& deserialize(
+            std::vector<_T>& vector_t)
+    {
+        uint32_t sequence_length = 0;
+        state state_before_error(*this);
+
+        *this >> sequence_length;
+
+        try
+        {
+            vector_t.resize(sequence_length);
+            return deserialize_array(vector_t.data(), vector_t.size());
+        }
+        catch (eprosima::fastcdr::exception::Exception& ex)
+        {
+            set_state(state_before_error);
+            ex.raise();
+        }
+
+        return *this;
+    }
 
 #ifdef _MSC_VER
-  /*!
-   * @brief This function template deserializes a sequence of booleans.
-   * @param vector_t The variable that will store the sequence read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  template <>
-  FastCdr& deserialize<bool>(std::vector<bool>& vector_t)
-  {
-    return deserializeBoolSequence(vector_t);
-  }
-
-#endif  // ifdef _MSC_VER
-
-  /*!
-   * @brief This function template deserializes a non-basic type object.
-   * @param type_t The variable that will store the object read from the buffer.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  inline FastCdr& deserialize(_T& type_t)
-  {
-    type_t.deserialize(*this);
-    return *this;
-  }
-
-  /*!
-   * @brief This function deserializes an array of octets.
-   * @param octet_t The variable that will store the array of octets read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserializeArray(uint8_t* octet_t, size_t numElements)
-  {
-    return deserializeArray(reinterpret_cast<char*>(octet_t), numElements);
-  }
-
-  /*!
-   * @brief This function deserializes an array of characters.
-   * @param char_t The variable that will store the array of characters read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& deserializeArray(char* char_t, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of int8_t.
-   * @param int8 The variable that will store the array of int8_t read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserializeArray(int8_t* int8, size_t numElements)
-  {
-    return deserializeArray(reinterpret_cast<char*>(int8), numElements);
-  }
-
-  /*!
-   * @brief This function deserializes an array of unsigned shorts.
-   * @param ushort_t The variable that will store the array of unsigned shorts read from
-   * the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserializeArray(uint16_t* ushort_t, size_t numElements)
-  {
-    return deserializeArray(reinterpret_cast<int16_t*>(ushort_t), numElements);
-  }
-
-  /*!
-   * @brief This function deserializes an array of shorts.
-   * @param short_t The variable that will store the array of shorts read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& deserializeArray(int16_t* short_t, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of unsigned longs.
-   * @param ulong_t The variable that will store the array of unsigned longs read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserializeArray(uint32_t* ulong_t, size_t numElements)
-  {
-    return deserializeArray(reinterpret_cast<int32_t*>(ulong_t), numElements);
-  }
-
-  /*!
-   * @brief This function deserializes an array of longs.
-   * @param long_t The variable that will store the array of longs read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& deserializeArray(int32_t* long_t, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of wide-chars.
-   * @param wchar The variable that will store the array of wide-chars read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& deserializeArray(wchar_t* wchar, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of unsigned long longs.
-   * @param ulonglong_t The variable that will store the array of unsigned long longs read
-   * from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserializeArray(uint64_t* ulonglong_t, size_t numElements)
-  {
-    return deserializeArray(reinterpret_cast<int64_t*>(ulonglong_t), numElements);
-  }
-
-  /*!
-   * @brief This function deserializes an array of long longs.
-   * @param longlong_t The variable that will store the array of long longs read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& deserializeArray(int64_t* longlong_t, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of floats.
-   * @param float_t The variable that will store the array of floats read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& deserializeArray(float* float_t, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of doubles.
-   * @param double_t The variable that will store the array of doubles read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& deserializeArray(double* double_t, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of long doubles.
-   * @param ldouble_t The variable that will store the array of long doubles read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& deserializeArray(long double* ldouble_t, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of booleans.
-   * @param bool_t The variable that will store the array of booleans read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  FastCdr& deserializeArray(bool* bool_t, size_t numElements);
-
-  /*!
-   * @brief This function deserializes an array of strings.
-   * @param string_t The variable that will store the array of strings read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserializeArray(std::string* string_t, size_t numElements)
-  {
-    for (size_t count = 0; count < numElements; ++count)
+    /*!
+     * @brief This function template deserializes a sequence of booleans.
+     * @param vector_t The variable that will store the sequence read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    template<>
+    FastCdr& deserialize<bool>(
+            std::vector<bool>& vector_t)
     {
-      deserialize(string_t[count]);
-    }
-    return *this;
-  }
-
-  /*!
-   * @brief This function deserializes an array of wide-strings.
-   * @param string_t The variable that will store the array of strings read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  inline FastCdr& deserializeArray(std::wstring* string_t, size_t numElements)
-  {
-    for (size_t count = 0; count < numElements; ++count)
-    {
-      deserialize(string_t[count]);
-    }
-    return *this;
-  }
-
-  /*!
-   * @brief This function template deserializes an array of sequences.
-   * @param vector_t The variable that will store the array of sequences read from the
-   * buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  FastCdr& deserializeArray(std::vector<_T>* vector_t, size_t numElements)
-  {
-    for (size_t count = 0; count < numElements; ++count)
-    {
-      deserialize(vector_t[count]);
-    }
-    return *this;
-  }
-
-  /*!
-   * @brief This function template deserializes an array of non-basic type objects.
-   * @param type_t The variable that will store the array of objects read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  FastCdr& deserializeArray(_T* type_t, size_t numElements)
-  {
-    for (size_t count = 0; count < numElements; ++count)
-    {
-      type_t[count].deserialize(*this);
-    }
-    return *this;
-  }
-
-#if !defined(_MSC_VER) && HAVE_CXX0X
-  /*!
-   * @brief This function template deserializes a string sequence.
-   * This function allocates memory to store the sequence. The user pointer will be set to
-   * point this allocated memory. The user will have to free this allocated memory using
-   * free()
-   * @param sequence_t The pointer that will store the sequence read from the buffer.
-   * @param numElements This variable return the number of elements of the sequence.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  template <class _T = std::string>
-  FastCdr& deserializeSequence(std::string*& sequence_t, size_t& numElements)
-  {
-    return deserializeStringSequence(sequence_t, numElements);
-  }
-
-  /*!
-   * @brief This function template deserializes a wide-string sequence.
-   * This function allocates memory to store the sequence. The user pointer will be set to
-   * point this allocated memory. The user will have to free this allocated memory using
-   * free()
-   * @param sequence_t The pointer that will store the sequence read from the buffer.
-   * @param numElements This variable return the number of elements of the sequence.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  template <class _T = std::wstring>
-  FastCdr& deserializeSequence(std::wstring*& sequence_t, size_t& numElements)
-  {
-    return deserializeWStringSequence(sequence_t, numElements);
-  }
-
-#endif  // if !defined(_MSC_VER) && HAVE_CXX0X
-
-  /*!
-   * @brief This function template deserializes a raw sequence.
-   * This function allocates memory to store the sequence. The user pointer will be set to
-   * point this allocated memory. The user will have to free this allocated memory using
-   * free()
-   * @param sequence_t The pointer that will store the sequence read from the buffer.
-   * @param numElements This variable return the number of elements of the sequence.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  template <class _T>
-  FastCdr& deserializeSequence(_T*& sequence_t, size_t& numElements)
-  {
-    uint32_t seqLength = 0;
-    state state_before_error(*this);
-
-    deserialize(seqLength);
-
-    try
-    {
-      sequence_t = reinterpret_cast<_T*>(calloc(seqLength, sizeof(_T)));
-      deserializeArray(sequence_t, seqLength);
-    }
-    catch (eprosima::fastcdr::exception::Exception& ex)
-    {
-      free(sequence_t);
-      sequence_t = NULL;
-      setState(state_before_error);
-      ex.raise();
+        return deserialize_bool_sequence(vector_t);
     }
 
-    numElements = seqLength;
-    return *this;
-  }
+#endif // ifdef _MSC_VER
+
+    /*!
+     * @brief This function template deserializes a non-basic type object.
+     * @param type_t The variable that will store the object read from the buffer.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    inline FastCdr& deserialize(
+            _T& type_t)
+    {
+        type_t.deserialize(*this);
+        return *this;
+    }
+
+    /*!
+     * @brief This function deserializes an array of octets.
+     * @param octet_t The variable that will store the array of octets read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize_array(
+            uint8_t* octet_t,
+            size_t num_elements)
+    {
+        return deserialize_array(reinterpret_cast<char*>(octet_t), num_elements);
+    }
+
+    /*!
+     * @brief This function deserializes an array of characters.
+     * @param char_t The variable that will store the array of characters read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& deserialize_array(
+            char* char_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of int8_t.
+     * @param int8 The variable that will store the array of int8_t read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize_array(
+            int8_t* int8,
+            size_t num_elements)
+    {
+        return deserialize_array(reinterpret_cast<char*>(int8), num_elements);
+    }
+
+    /*!
+     * @brief This function deserializes an array of unsigned shorts.
+     * @param ushort_t The variable that will store the array of unsigned shorts read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize_array(
+            uint16_t* ushort_t,
+            size_t num_elements)
+    {
+        return deserialize_array(reinterpret_cast<int16_t*>(ushort_t), num_elements);
+    }
+
+    /*!
+     * @brief This function deserializes an array of shorts.
+     * @param short_t The variable that will store the array of shorts read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& deserialize_array(
+            int16_t* short_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of unsigned longs.
+     * @param ulong_t The variable that will store the array of unsigned longs read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize_array(
+            uint32_t* ulong_t,
+            size_t num_elements)
+    {
+        return deserialize_array(reinterpret_cast<int32_t*>(ulong_t), num_elements);
+    }
+
+    /*!
+     * @brief This function deserializes an array of longs.
+     * @param long_t The variable that will store the array of longs read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& deserialize_array(
+            int32_t* long_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of wide-chars.
+     * @param wchar The variable that will store the array of wide-chars read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& deserialize_array(
+            wchar_t* wchar,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of unsigned long longs.
+     * @param ulonglong_t The variable that will store the array of unsigned long longs read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize_array(
+            uint64_t* ulonglong_t,
+            size_t num_elements)
+    {
+        return deserialize_array(reinterpret_cast<int64_t*>(ulonglong_t), num_elements);
+    }
+
+    /*!
+     * @brief This function deserializes an array of long longs.
+     * @param longlong_t The variable that will store the array of long longs read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& deserialize_array(
+            int64_t* longlong_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of floats.
+     * @param float_t The variable that will store the array of floats read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& deserialize_array(
+            float* float_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of doubles.
+     * @param double_t The variable that will store the array of doubles read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& deserialize_array(
+            double* double_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of long doubles.
+     * @param ldouble_t The variable that will store the array of long doubles read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& deserialize_array(
+            long double* ldouble_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of booleans.
+     * @param bool_t The variable that will store the array of booleans read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    FastCdr& deserialize_array(
+            bool* bool_t,
+            size_t num_elements);
+
+    /*!
+     * @brief This function deserializes an array of strings.
+     * @param string_t The variable that will store the array of strings read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize_array(
+            std::string* string_t,
+            size_t num_elements)
+    {
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            deserialize(string_t[count]);
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief This function deserializes an array of wide-strings.
+     * @param string_t The variable that will store the array of strings read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    inline
+    FastCdr& deserialize_array(
+            std::wstring* string_t,
+            size_t num_elements)
+    {
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            deserialize(string_t[count]);
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief This function template deserializes an array of sequences.
+     * @param vector_t The variable that will store the array of sequences read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    FastCdr& deserialize_array(
+            std::vector<_T>* vector_t,
+            size_t num_elements)
+    {
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            deserialize(vector_t[count]);
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief This function template deserializes an array of non-basic type objects.
+     * @param type_t The variable that will store the array of objects read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    FastCdr& deserialize_array(
+            _T* type_t,
+            size_t num_elements)
+    {
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            type_t[count].deserialize(*this);
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief This function template deserializes a string sequence.
+     * This function allocates memory to store the sequence. The user pointer will be set to point this allocated memory.
+     * The user will have to free this allocated memory using free()
+     * @param sequence_t The pointer that will store the sequence read from the buffer.
+     * @param num_elements This variable return the number of elements of the sequence.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    template<class _T = std::string>
+    FastCdr& deserialize_sequence(
+            std::string*& sequence_t,
+            size_t& num_elements)
+    {
+        return deserialize_string_sequence(sequence_t, num_elements);
+    }
+
+    /*!
+     * @brief This function template deserializes a wide-string sequence.
+     * This function allocates memory to store the sequence. The user pointer will be set to point this allocated memory.
+     * The user will have to free this allocated memory using free()
+     * @param sequence_t The pointer that will store the sequence read from the buffer.
+     * @param num_elements This variable return the number of elements of the sequence.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    template<class _T = std::wstring>
+    FastCdr& deserialize_sequence(
+            std::wstring*& sequence_t,
+            size_t& num_elements)
+    {
+        return deserialize_wstring_sequence(sequence_t, num_elements);
+    }
+
+    /*!
+     * @brief This function template deserializes a raw sequence.
+     * This function allocates memory to store the sequence. The user pointer will be set to point this allocated memory.
+     * The user will have to free this allocated memory using free()
+     * @param sequence_t The pointer that will store the sequence read from the buffer.
+     * @param num_elements This variable return the number of elements of the sequence.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    template<class _T>
+    FastCdr& deserialize_sequence(
+            _T*& sequence_t,
+            size_t& num_elements)
+    {
+        uint32_t sequence_length = 0;
+        state state_before_error(*this);
+
+        deserialize(sequence_length);
+
+        try
+        {
+            sequence_t = reinterpret_cast<_T*>(calloc(sequence_length, sizeof(_T)));
+            deserialize_array(sequence_t, sequence_length);
+        }
+        catch (eprosima::fastcdr::exception::Exception& ex)
+        {
+            free(sequence_t);
+            sequence_t = NULL;
+            set_state(state_before_error);
+            ex.raise();
+        }
+
+        num_elements = sequence_length;
+        return *this;
+    }
 
 #ifdef _MSC_VER
-  /*!
-   * @brief This function template deserializes a string sequence.
-   * This function allocates memory to store the sequence. The user pointer will be set to
-   * point this allocated memory. The user will have to free this allocated memory using
-   * free()
-   * @param sequence_t The pointer that will store the sequence read from the buffer.
-   * @param numElements This variable return the number of elements of the sequence.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  template <>
-  FastCdr& deserializeSequence<std::string>(std::string*& sequence_t, size_t& numElements)
-  {
-    return deserializeStringSequence(sequence_t, numElements);
-  }
+    /*!
+     * @brief This function template deserializes a string sequence.
+     * This function allocates memory to store the sequence. The user pointer will be set to point this allocated memory.
+     * The user will have to free this allocated memory using free()
+     * @param sequence_t The pointer that will store the sequence read from the buffer.
+     * @param num_elements This variable return the number of elements of the sequence.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    template<>
+    FastCdr& deserialize_sequence<std::string>(
+            std::string*& sequence_t,
+            size_t& num_elements)
+    {
+        return deserialize_string_sequence(sequence_t, num_elements);
+    }
 
-  /*!
-   * @brief This function template deserializes a wide-string sequence.
-   * This function allocates memory to store the sequence. The user pointer will be set to
-   * point this allocated memory. The user will have to free this allocated memory using
-   * free()
-   * @param sequence_t The pointer that will store the sequence read from the buffer.
-   * @param numElements This variable return the number of elements of the sequence.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  template <>
-  FastCdr& deserializeSequence<std::wstring>(std::wstring*& sequence_t,
-                                             size_t& numElements)
-  {
-    return deserializeWStringSequence(sequence_t, numElements);
-  }
+    /*!
+     * @brief This function template deserializes a wide-string sequence.
+     * This function allocates memory to store the sequence. The user pointer will be set to point this allocated memory.
+     * The user will have to free this allocated memory using free()
+     * @param sequence_t The pointer that will store the sequence read from the buffer.
+     * @param num_elements This variable return the number of elements of the sequence.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    template<>
+    FastCdr& deserialize_sequence<std::wstring>(
+            std::wstring*& sequence_t,
+            size_t& num_elements)
+    {
+        return deserialize_wstring_sequence(sequence_t, num_elements);
+    }
 
-#endif  // ifdef _MSC_VER
+#endif // ifdef _MSC_VER
 
 private:
-  FastCdr(const FastCdr&) = delete;
 
-  FastCdr& operator=(const FastCdr&) = delete;
+    FastCdr(
+            const FastCdr&) = delete;
 
-  FastCdr& serializeBoolSequence(const std::vector<bool>& vector_t);
+    FastCdr& operator =(
+            const FastCdr&) = delete;
 
-  FastCdr& deserializeBoolSequence(std::vector<bool>& vector_t);
+    FastCdr& serialize_bool_sequence(
+            const std::vector<bool>& vector_t);
 
-  FastCdr& deserializeStringSequence(std::string*& sequence_t, size_t& numElements);
+    FastCdr& deserialize_bool_sequence(
+            std::vector<bool>& vector_t);
 
-  FastCdr& deserializeWStringSequence(std::wstring*& sequence_t, size_t& numElements);
+    FastCdr& deserialize_string_sequence(
+            std::string*& sequence_t,
+            size_t& num_elements);
 
-#if HAVE_CXX0X
-  /*!
-   * @brief This function template detects the content type of the STD container array and
-   * serializes the array.
-   * @param array_t The array that will be serialized in the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to serialize in a position that exceeds the internal memory size.
-   */
-  template <class _T, size_t _Size>
-  FastCdr& serializeArray(const std::array<_T, _Size>* array_t, size_t numElements)
-  {
-    return serializeArray(array_t->data(), numElements * array_t->size());
-  }
+    FastCdr& deserialize_wstring_sequence(
+            std::wstring*& sequence_t,
+            size_t& num_elements);
 
-  /*!
-   * @brief This function template detects the content type of the STD container array and
-   * deserializes the array.
-   * @param array_t The variable that will store the array read from the buffer.
-   * @param numElements Number of the elements in the array.
-   * @return Reference to the eprosima::fastcdr::FastCdr object.
-   * @exception exception::NotEnoughMemoryException This exception is thrown when trying
-   * to deserialize in a position that exceeds the internal memory size.
-   */
-  template <class _T, size_t _Size>
-  FastCdr& deserializeArray(std::array<_T, _Size>* array_t, size_t numElements)
-  {
-    return deserializeArray(array_t->data(), numElements * array_t->size());
-  }
+    /*!
+     * @brief This function template detects the content type of the STD container array and serializes the array.
+     * @param array_t The array that will be serialized in the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize in a position that exceeds the internal memory size.
+     */
+    template<class _T, size_t _Size>
+    FastCdr& serialize_array(
+            const std::array<_T, _Size>* array_t,
+            size_t num_elements)
+    {
+        return serialize_array(array_t->data(), num_elements * array_t->size());
+    }
 
-#endif  // if HAVE_CXX0X
+    /*!
+     * @brief This function template detects the content type of the STD container array and deserializes the array.
+     * @param array_t The variable that will store the array read from the buffer.
+     * @param num_elements Number of the elements in the array.
+     * @return Reference to the eprosima::fastcdr::FastCdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to deserialize in a position that exceeds the internal memory size.
+     */
+    template<class _T, size_t _Size>
+    FastCdr& deserialize_array(
+            std::array<_T, _Size>* array_t,
+            size_t num_elements)
+    {
+        return deserialize_array(array_t->data(), num_elements * array_t->size());
+    }
 
-  bool resize(size_t minSizeInc);
+    bool resize(
+            size_t min_size_inc);
 
-  const char* readString(uint32_t& length);
+    const char* read_string(
+            uint32_t& length);
 
-  std::wstring readWString(uint32_t& length);
+    std::wstring read_wstring(
+            uint32_t& length);
 
-  //! @brief Reference to the buffer that will be serialized/deserialized.
-  FastBuffer& m_cdrBuffer;
+    //! @brief Reference to the buffer that will be serialized/deserialized.
+    FastBuffer& cdr_buffer_;
 
-  //! @brief The current position in the serialization/deserialization process.
-  FastBuffer::iterator m_currentPosition;
+    //! @brief The current position in the serialization/deserialization process.
+    FastBuffer::iterator current_position_;
 
-  //! @brief The last position in the buffer;
-  FastBuffer::iterator m_lastPosition;
+    //! @brief The last position in the buffer;
+    FastBuffer::iterator last_position_;
 };
-}  // namespace fastcdr
-}  // namespace eprosima
+}     //namespace fastcdr
+} //namespace eprosima
 
-#endif  //_FASTCDR_FASTCDR_H_
+#endif //_FASTCDR_FASTCDR_H_

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/cdr/fixed_size_string.hpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/cdr/fixed_size_string.hpp
@@ -1,0 +1,344 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*!
+ * @file fixed_size_string.hpp
+ *
+ */
+
+#ifndef FASTCDR_UTILS_FIXED_SIZE_STRING_HPP_
+#define FASTCDR_UTILS_FIXED_SIZE_STRING_HPP_
+
+#include <string>
+#include <cstring>
+
+#ifdef _WIN32
+#define MEMCCPY _memccpy
+#else
+#define MEMCCPY memccpy
+#endif // ifdef _WIN32
+
+namespace eprosima {
+namespace fastcdr {
+
+/**
+ * @brief Template class for non-alloc strings.
+ *
+ * Will be truncated when assigned from a longer string.
+ *
+ * @tparam MAX_CHARS Maximum number of characters is specified as the template parameter.
+ *                   Space for an additional null terminator will be reserved.
+ */
+template <size_t MAX_CHARS>
+struct fixed_string
+{
+public:
+
+    //! @brief Maximum number of characters.
+    static constexpr size_t max_size = MAX_CHARS;
+
+    //! @brief Default constructor.
+    fixed_string() noexcept
+    {
+        memset(string_data, 0, sizeof(string_data));
+        string_len = 0;
+    }
+
+    // We don't need to define copy/move constructors/assignment operators as the default ones would be enough
+
+    /*!
+     * @brief Constructs from a char array
+     * @param[in] c_array Char array to be constructed from.
+     * @param[in] n_chars Number of characters of the Char array
+     */
+    fixed_string(
+            const char* c_array,
+            size_t n_chars) noexcept
+    {
+        assign(c_array, n_chars);
+    }
+
+    /*!
+     * @brief Assigns from a char array
+     * @param[in] c_array Char array to be assigned from.
+     * @param[in] n_chars Number of characters of the Char array.
+     * @return Reference of this instance.
+     */
+    fixed_string& assign(
+            const char* c_array,
+            size_t n_chars) noexcept
+    {
+        string_len = (nullptr == c_array) ? 0 :
+                (MAX_CHARS < n_chars) ? MAX_CHARS : n_chars;
+        if (0 < string_len)
+        {
+            memcpy(string_data, c_array, string_len);
+        }
+        return *this;
+    }
+
+    /*!
+     * @brief Constructs from a C string.
+     * @param[in] c_string Pointer to the C string.
+     */
+    fixed_string (
+            const char* c_string) noexcept
+        : fixed_string()
+    {
+        set(c_string != nullptr ? c_string : "");
+    }
+
+    /*!
+     * @brief Assigns from a C string.
+     * @param[in] c_string Pointer to the C string.
+     * @return Reference of this instance.
+     */
+    fixed_string& operator = (
+            const char* c_string) noexcept
+    {
+        set(c_string != nullptr ? c_string : "");
+        return *this;
+    }
+
+    /*!
+     * @brief Constructs from a std::string.
+     * @param[in] str Reference to the std::string.
+     */
+    fixed_string (
+            const std::string& str) noexcept
+        : fixed_string()
+    {
+        set(str.c_str());
+    }
+
+    /*!
+     * @brief Assigns from a std::string.
+     * @param[in] str Reference to the std::string.
+     * return Reference of this instance.
+     */
+    fixed_string& operator = (
+            const std::string& str) noexcept
+    {
+        set(str.c_str());
+        return *this;
+    }
+
+    /*!
+     * @brief Assigns from a fixed_string of any size.
+     * @param[in] rhs Reference to the fixed_string.
+     * return Reference of this instance.
+     */
+    template<size_t N> fixed_string& operator = (
+            const fixed_string<N>& rhs) noexcept
+    {
+        set(rhs.c_str());
+        return *this;
+    }
+
+    /*!
+     * @brief Converts to C string.
+     * @return Pointer to the C string.
+     */
+    const char* c_str() const noexcept
+    {
+        return string_data;
+    }
+
+    /*!
+     * @brief Converts to std::string.
+     * @return Reference to the std::string.
+     */
+    std::string to_string() const
+    {
+        return std::string(string_data);
+    }
+
+    /*!
+     * @brief Compares equality with a C string.
+     * @param[in] rhs C string to be compared with.
+     * @return `true` if strings are equal. `false` otherwise.
+     */
+    bool operator == (
+            const char* rhs) const noexcept
+    {
+        return strncmp(string_data, rhs, MAX_CHARS) == 0;
+    }
+
+    /*!
+     * @brief Compares equality with a std::string.
+     * @param[in] rhs std::string to be compared with.
+     * @return `true` if strings are equal. `false` otherwise.
+     */
+    bool operator == (
+            const std::string& rhs) const noexcept
+    {
+        return strncmp(string_data, rhs.c_str(), MAX_CHARS) == 0;
+    }
+
+    /*!
+     * @brief Compares equality with a fixed_string of any size.
+     * @param[in] rhs fixed_string to be compared with.
+     * @return `true` if strings are equal. `false` otherwise.
+     */
+    template<size_t N>  bool operator == (
+            const fixed_string<N>& rhs) const noexcept
+    {
+        return strncmp(string_data, rhs.c_str(), MAX_CHARS) == 0;
+    }
+
+    /*!
+     * @brief Compares inequality with a C string.
+     * @param[in] rhs C string to be compared with.
+     * @return `true` if strings are not equal. `false` otherwise.
+     */
+    bool operator != (
+            const char* rhs) const noexcept
+    {
+        return !(*this == rhs);
+    }
+
+    /*!
+     * @brief Compares inequality with a std::string.
+     * @param[in] rhs std::string to be compared with.
+     * @return `true` if strings are not equal. `false` otherwise.
+     */
+    bool operator != (
+            const std::string& rhs) const noexcept
+    {
+        return !(*this == rhs);
+    }
+
+    /*!
+     * @brief Compares inequality with a fixed_string of any size.
+     * @param[in] rhs fixed_string to be compared with.
+     * @return `true` if strings are not equal. `false` otherwise.
+     */
+    template<size_t N>  bool operator != (
+            const fixed_string<N>& rhs) const noexcept
+    {
+        return !(*this == rhs);
+    }
+
+    /*!
+     * @brief Compares relational less than with a fixed_string of any size.
+     * @param[in] rhs fixed_string to be compared with.
+     * @return `true` if this string is less than the provided one. `false` otherwise.
+     */
+    template<size_t N>  bool operator < (
+            const fixed_string<N>& rhs) const noexcept
+    {
+        return 0 > compare(rhs);
+    }
+
+    /*!
+     * @brief Compares relational greater than with a fixed_string of any size.
+     * @param[in] rhs fixed_string to be compared with.
+     * @return `true` if this string is greater than the provided one. `false` otherwise.
+     */
+    template<size_t N>  bool operator > (
+            const fixed_string<N>& rhs) const noexcept
+    {
+        return 0 < compare(rhs);
+    }
+
+    /*!
+     * @brief Compares relational less than with a std::string of any size.
+     * @param[in] rhs std::string to be compared with.
+     * @return `true` if this string is less than the provided one. `false` otherwise.
+     */
+    bool operator < (
+            const std::string& rhs) const noexcept
+    {
+        return 0 > compare(rhs);
+    }
+
+    /*!
+     * @brief Compares relational greater than with a std::string of any size.
+     * @param[in] rhs std::string to be compared with.
+     * @return `true` if this string is greater than the provided one. `false` otherwise.
+     */
+    bool operator > (
+            const std::string& rhs) const noexcept
+    {
+        return 0 < compare(rhs);
+    }
+
+    /*!
+     * @brief Casts to a C string.
+     */
+    operator const char* () const noexcept {
+        return c_str();
+    }
+
+    /*!
+     * @brief Returns the size of the string.
+     * @return Length of the string.
+     */
+    size_t size() const noexcept
+    {
+        return string_len;
+    }
+
+    /*!
+     * @brief Compares with a C string.
+     * @param[in] str C string to be compared with.
+     * @return Integer value with the result of the comparison as described in `std::string::compare()`.
+     */
+    int compare(
+            const char* str) const noexcept
+    {
+        return strncmp(string_data, str, MAX_CHARS);
+    }
+
+    /*!
+     * @brief Compares with a std::string.
+     * @param[in] str std::string to be compared with.
+     * @return Integer value with the result of the comparison as described in `std::string::compare()`.
+     */
+    int compare(
+            const std::string& str) const noexcept
+    {
+        return strncmp(string_data, str.c_str(), MAX_CHARS);
+    }
+
+    /*!
+     * @brief Compares with a fixed_string
+     * @param[in] str fixed_string to be compared with.
+     * @return Integer value with the result of the comparison as described in `std::string::compare()`.
+     */
+    template<size_t N>  int compare(
+            const fixed_string<N>& str) const noexcept
+    {
+        return strncmp(string_data, str.c_str(), MAX_CHARS);
+    }
+
+private:
+
+    void set(
+            const char* c_string) noexcept
+    {
+        char* result = static_cast<char*>(MEMCCPY(string_data, c_string, '\0', MAX_CHARS));
+        string_len = (result == nullptr) ? MAX_CHARS : static_cast<size_t>(result - string_data) - 1u;
+    }
+
+    char string_data[MAX_CHARS + 1];      ///< Holds string data, including ending null character.
+    size_t string_len;                    ///< Holds current string length.
+};
+
+using string_255 = fixed_string<255>;
+
+} /* namespace fastcdr */
+} /* namespace eprosima */
+
+#endif /* FASTCDR_UTILS_FIXED_SIZE_STRING_HPP_ */

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/config.h.in
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/config.h.in
@@ -23,39 +23,29 @@
 // C++11 support defines
 #ifndef HAVE_CXX11
 #define HAVE_CXX11 @HAVE_CXX11@
-#endif
-
-// C++0x support defines
-#ifndef HAVE_CXX0X
-#define HAVE_CXX0X @HAVE_CXX0X@
-#endif
-
-// C++ constexpr support
-#ifndef HAVE_CXX_CONSTEXPR
-#define HAVE_CXX_CONSTEXPR @HAVE_CXX_CONSTEXPR@
-#endif
-
-#if HAVE_CXX_CONSTEXPR
-#define CONSTEXPR constexpr
-#else
-#define CONSTEXPR const
-#endif
+#endif // ifndef HAVE_CXX11
 
 // Endianness defines
 #ifndef FASTCDR_IS_BIG_ENDIAN_TARGET
 #define FASTCDR_IS_BIG_ENDIAN_TARGET @FASTCDR_IS_BIG_ENDIAN_TARGET@
-#endif
+#endif // ifndef FASTCDR_IS_BIG_ENDIAN_TARGET
 
 #ifndef FASTCDR_HAVE_FLOAT128
 #define FASTCDR_HAVE_FLOAT128 @FASTCDR_HAVE_FLOAT128@
-#endif
+#endif // ifndef FASTCDR_HAVE_FLOAT128
 
 #ifndef FASTCDR_SIZEOF_LONG_DOUBLE
 #define FASTCDR_SIZEOF_LONG_DOUBLE @FASTCDR_SIZEOF_LONG_DOUBLE@
-#endif
+#endif // ifndef FASTCDR_SIZEOF_LONG_DOUBLE
 
 #if defined(__ARM_ARCH) && __ARM_ARCH <= 7
 #define FASTCDR_ARM32
-#endif
+#endif // if defined(__ARM_ARCH) && __ARM_ARCH <= 7
+
+#if defined(__GNUC__) && !defined(__clang__)
+#define TEMPLATE_SPEC
+#else
+#define TEMPLATE_SPEC template<>
+#endif // if defined(__GNUC__) && !defined(__clang__)
 
 #endif // _FASTCDR_CONFIG_H_

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/detail/container_recursive_inspector.hpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/detail/container_recursive_inspector.hpp
@@ -1,0 +1,53 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _FASTCDR_DETAIL_CONTAINERRECURSIVEINSPECTOR_HPP_
+#define _FASTCDR_DETAIL_CONTAINERRECURSIVEINSPECTOR_HPP_
+
+#include <array>
+#include <cstddef>
+#include <type_traits>
+
+namespace eprosima {
+namespace fastcdr {
+
+// Helpers to deduce multi-array of primitives.
+/// Basis
+constexpr bool is_multi_array_primitive(
+        ...)
+{
+    return false;
+}
+
+/// Specializations
+template <typename _T,
+        typename std::enable_if<std::is_enum<_T>::value ||
+        std::is_arithmetic<_T>::value>::type* = nullptr>
+constexpr bool is_multi_array_primitive(
+        _T const*)
+{
+    return true;
+}
+
+template <typename _T, size_t _N>
+constexpr bool is_multi_array_primitive(
+        std::array<_T, _N> const*)
+{
+    return is_multi_array_primitive(static_cast<_T const*>(nullptr));
+}
+
+} // namespace fastcdr
+} // namespace eprosima
+
+#endif // _FASTCDR_DETAIL_CONTAINERRECURSIVEINSPECTOR_HPP_

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/eProsima_auto_link.h
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/eProsima_auto_link.h
@@ -21,49 +21,47 @@
  */
 
 #if defined(_MSC_VER)
-#define EPROSIMA_STRINGIZE(X) EPROSIMA_DO_STRINGIZE(X)
-#define EPROSIMA_DO_STRINGIZE(X) #X
+    #define EPROSIMA_STRINGIZE(X) EPROSIMA_DO_STRINGIZE(X)
+    #define EPROSIMA_DO_STRINGIZE(X) #X
 
-#if defined(_DEBUG)
-#define EPROSIMA_LIB_DEBUG_TAG "d"
-#else
-#define EPROSIMA_LIB_DEBUG_TAG
-#endif  // _DEBUG
+    #if defined(_DEBUG)
+        #define EPROSIMA_LIB_DEBUG_TAG "d"
+    #else
+        #define EPROSIMA_LIB_DEBUG_TAG
+    #endif // _DEBUG
 
 // Select linkage option.
-#if (defined(_DLL) || defined(_RTLDLL)) && defined(EPROSIMA_DYN_LINK)
-#define EPROSIMA_LIB_PREFIX
-#elif defined(EPROSIMA_DYN_LINK)
-#error "Mixing a dll eprosima library with a static runtime is a bad idea"
-#else
-#define EPROSIMA_LIB_PREFIX "lib"
-#endif  // if (defined(_DLL) || defined(_RTLDLL)) && defined(EPROSIMA_DYN_LINK)
+    #if (defined(_DLL) || defined(_RTLDLL)) && defined(EPROSIMA_DYN_LINK)
+        #define EPROSIMA_LIB_PREFIX
+    #elif defined(EPROSIMA_DYN_LINK)
+        #error "Mixing a dll eprosima library with a static runtime is a bad idea"
+    #else
+        #define EPROSIMA_LIB_PREFIX "lib"
+    #endif // if (defined(_DLL) || defined(_RTLDLL)) && defined(EPROSIMA_DYN_LINK)
 
 // Include library
-#if defined(EPROSIMA_LIB_NAME) && defined(EPROSIMA_LIB_PREFIX) &&                        \
-    defined(EPROSIMA_LIB_DEBUG_TAG) && defined(FASTCDR_VERSION_MAJOR) &&                 \
-    defined(FASTCDR_VERSION_MINOR)
-#pragma comment(lib, EPROSIMA_LIB_PREFIX EPROSIMA_STRINGIZE(EPROSIMA_LIB_NAME)           \
-                         EPROSIMA_LIB_DEBUG_TAG                                          \
-                "-" EPROSIMA_STRINGIZE(FASTCDR_VERSION_MAJOR) "." EPROSIMA_STRINGIZE(    \
-                    FASTCDR_VERSION_MINOR) ".lib")
-#else
-#error "Some required macros where not defined"
-#endif  // if defined(EPROSIMA_LIB_NAME) && defined(EPROSIMA_LIB_PREFIX) &&
-        // defined(EPROSIMA_LIB_DEBUG_TAG) && defined(FASTCDR_VERSION_MAJOR) &&
-        // defined(FASTCDR_VERSION_MINOR)
+    #if defined(EPROSIMA_LIB_NAME) \
+    && defined(EPROSIMA_LIB_PREFIX) \
+    && defined(EPROSIMA_LIB_DEBUG_TAG) \
+    && defined(FASTCDR_VERSION_MAJOR) \
+    && defined(FASTCDR_VERSION_MINOR)
+        #pragma \
+    comment(lib, EPROSIMA_LIB_PREFIX EPROSIMA_STRINGIZE(EPROSIMA_LIB_NAME) EPROSIMA_LIB_DEBUG_TAG "-" EPROSIMA_STRINGIZE(FASTCDR_VERSION_MAJOR) "." EPROSIMA_STRINGIZE(FASTCDR_VERSION_MINOR) ".lib")
+    #else
+    #error "Some required macros where not defined"
+    #endif // if defined(EPROSIMA_LIB_NAME) && defined(EPROSIMA_LIB_PREFIX) && defined(EPROSIMA_LIB_DEBUG_TAG) && defined(FASTCDR_VERSION_MAJOR) && defined(FASTCDR_VERSION_MINOR)
 
-#endif  // _MSC_VER
+#endif // _MSC_VER
 
 // Undef macros
 #ifdef EPROSIMA_LIB_PREFIX
 #undef EPROSIMA_LIB_PREFIX
-#endif  // ifdef EPROSIMA_LIB_PREFIX
+#endif // ifdef EPROSIMA_LIB_PREFIX
 
 #ifdef EPROSIMA_LIB_NAME
 #undef EPROSIMA_LIB_NAME
-#endif  // ifdef EPROSIMA_LIB_NAME
+#endif // ifdef EPROSIMA_LIB_NAME
 
 #ifdef EPROSIMA_LIB_DEBUG_TAG
 #undef EPROSIMA_LIB_DEBUG_TAG
-#endif  // ifdef EPROSIMA_LIB_DEBUG_TAG
+#endif // ifdef EPROSIMA_LIB_DEBUG_TAG

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/exceptions/BadOptionalAccessException.hpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/exceptions/BadOptionalAccessException.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _FASTCDR_EXCEPTIONS_NOTENOUGHMEMORYEXCEPTION_H_
-#define _FASTCDR_EXCEPTIONS_NOTENOUGHMEMORYEXCEPTION_H_
+#ifndef _FASTCDR_EXCEPTIONS_BADOPTIONALACCESSEXCEPTION_H_
+#define _FASTCDR_EXCEPTIONS_BADOPTIONALACCESSEXCEPTION_H_
 
 #include "Exception.h"
 
@@ -21,10 +21,10 @@ namespace eprosima {
 namespace fastcdr {
 namespace exception {
 /*!
- * @brief This class is thrown as an exception when the buffer's internal memory reachs its size limit.
+ * @brief This class is thrown as an exception when accessing the value of a null optional.
  * @ingroup EXCEPTIONMODULE
  */
-class NotEnoughMemoryException : public Exception
+class BadOptionalAccessException : public Exception
 {
 public:
 
@@ -33,51 +33,51 @@ public:
      *
      * @param message An error message. This message pointer is copied.
      */
-    Cdr_DllAPI NotEnoughMemoryException(
+    Cdr_DllAPI BadOptionalAccessException(
             const char* const& message) noexcept;
 
     /*!
      * @brief Default copy constructor.
      *
-     * @param ex NotEnoughMemoryException that will be copied.
+     * @param ex BadOptionalAccessException that will be copied.
      */
-    Cdr_DllAPI NotEnoughMemoryException(
-            const NotEnoughMemoryException& ex) noexcept;
+    Cdr_DllAPI BadOptionalAccessException(
+            const BadOptionalAccessException& ex) noexcept;
 
     /*!
      * @brief Default move constructor.
      *
-     * @param ex NotEnoughMemoryException that will be moved.
+     * @param ex BadOptionalAccessException that will be moved.
      */
-    Cdr_DllAPI NotEnoughMemoryException(
-            NotEnoughMemoryException&& ex) noexcept;
+    Cdr_DllAPI BadOptionalAccessException(
+            BadOptionalAccessException&& ex) noexcept;
 
     /*!
      * @brief Assigment operation.
      *
-     * @param ex NotEnoughMemoryException that will be copied.
+     * @param ex BadOptionalAccessException that will be copied.
      */
-    Cdr_DllAPI NotEnoughMemoryException& operator =(
-            const NotEnoughMemoryException& ex) noexcept;
+    Cdr_DllAPI BadOptionalAccessException& operator =(
+            const BadOptionalAccessException& ex) noexcept;
 
     /*!
      * @brief Assigment operation.
      *
-     * @param ex NotEnoughMemoryException that will be moved.
+     * @param ex BadOptionalAccessException that will be moved.
      */
-    Cdr_DllAPI NotEnoughMemoryException& operator =(
-            NotEnoughMemoryException&& ex) noexcept;
+    BadOptionalAccessException& operator =(
+            BadOptionalAccessException&& ex) noexcept;
 
     //! @brief Default destructor
-    virtual Cdr_DllAPI ~NotEnoughMemoryException() noexcept;
+    virtual Cdr_DllAPI ~BadOptionalAccessException() noexcept;
 
     //! @brief This function throws the object as exception.
     Cdr_DllAPI void raise() const override;
 
     //! @brief Default message used in the library.
-    static Cdr_DllAPI const char* const NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT;
+    static Cdr_DllAPI const char* const BAD_OPTIONAL_ACCESS_MESSAGE_DEFAULT;
 };
 }         //namespace exception
 }     //namespace fastcdr
 } //namespace eprosima
-#endif // _FASTCDR_EXCEPTIONS_NOTENOUGHMEMORYEXCEPTION_H_
+#endif // _FASTCDR_EXCEPTIONS_BADOPTIONALACCESSEXCEPTION_H_

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/exceptions/BadParamException.h
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/exceptions/BadParamException.h
@@ -17,69 +17,67 @@
 
 #include "Exception.h"
 
-namespace eprosima
-{
-namespace fastcdr
-{
-namespace exception
-{
+namespace eprosima {
+namespace fastcdr {
+namespace exception {
 /*!
- * @brief This class is thrown as an exception when a invalid parameter was being
- * serialized.
+ * @brief This class is thrown as an exception when an invalid parameter is being serialized.
  * @ingroup EXCEPTIONMODULE
  */
 class BadParamException : public Exception
 {
 public:
-  /*!
-   * @brief Default constructor.
-   *
-   * @param message A error message. This message pointer is copied.
-   */
-  Cdr_DllAPI BadParamException(const char* const& message) noexcept;
 
-  /*!
-   * @brief Default copy constructor.
-   *
-   * @param ex BadParamException that will be copied.
-   */
-  Cdr_DllAPI BadParamException(const BadParamException& ex) noexcept;
+    /*!
+     * @brief Default constructor.
+     *
+     * @param message An error message. This message pointer is copied.
+     */
+    Cdr_DllAPI BadParamException(
+            const char* const& message) noexcept;
 
-#if HAVE_CXX0X
-  /*!
-   * @brief Default move constructor.
-   *
-   * @param ex BadParamException that will be moved.
-   */
-  Cdr_DllAPI BadParamException(BadParamException&& ex) noexcept;
-#endif  // if HAVE_CXX0X
+    /*!
+     * @brief Default copy constructor.
+     *
+     * @param ex BadParamException that will be copied.
+     */
+    Cdr_DllAPI BadParamException(
+            const BadParamException& ex) noexcept;
 
-  /*!
-   * @brief Assigment operation.
-   *
-   * @param ex BadParamException that will be copied.
-   */
-  Cdr_DllAPI BadParamException& operator=(const BadParamException& ex) noexcept;
+    /*!
+     * @brief Default move constructor.
+     *
+     * @param ex BadParamException that will be moved.
+     */
+    Cdr_DllAPI BadParamException(
+            BadParamException&& ex) noexcept;
 
-#if HAVE_CXX0X
-  /*!
-   * @brief Assigment operation.
-   *
-   * @param ex BadParamException that will be moved.
-   */
-  BadParamException& operator=(BadParamException&& ex) noexcept;
-#endif  // if HAVE_CXX0X
+    /*!
+     * @brief Assigment operation.
+     *
+     * @param ex BadParamException that will be copied.
+     */
+    Cdr_DllAPI BadParamException& operator =(
+            const BadParamException& ex) noexcept;
 
-  //! @brief Default constructor
-  virtual Cdr_DllAPI ~BadParamException() noexcept;
+    /*!
+     * @brief Assigment operation.
+     *
+     * @param ex BadParamException that will be moved.
+     */
+    BadParamException& operator =(
+            BadParamException&& ex) noexcept;
 
-  //! @brief This function throws the object as exception.
-  virtual Cdr_DllAPI void raise() const;
+    //! @brief Default destructor
+    virtual Cdr_DllAPI ~BadParamException() noexcept;
 
-  //! @brief Default message used in the library.
-  static Cdr_DllAPI const char* const BAD_PARAM_MESSAGE_DEFAULT;
+    //! @brief This function throws the object as exception.
+    Cdr_DllAPI void raise() const override;
+
+    //! @brief Default message used in the library.
+    static Cdr_DllAPI const char* const BAD_PARAM_MESSAGE_DEFAULT;
 };
-}  // namespace exception
-}  // namespace fastcdr
-}  // namespace eprosima
-#endif  // _FASTCDR_EXCEPTIONS_BADPARAMEXCEPTION_H_
+}         //namespace exception
+}     //namespace fastcdr
+} //namespace eprosima
+#endif // _FASTCDR_EXCEPTIONS_BADPARAMEXCEPTION_H_

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/exceptions/Exception.h
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/exceptions/Exception.h
@@ -19,12 +19,9 @@
 #include <string>
 #include <exception>
 
-namespace eprosima
-{
-namespace fastcdr
-{
-namespace exception
-{
+namespace eprosima {
+namespace fastcdr {
+namespace exception {
 /*!
  * @brief This abstract class is used to create exceptions.
  * @ingroup EXCEPTIONMODULE
@@ -32,64 +29,68 @@ namespace exception
 class Exception : public std::exception
 {
 public:
-  //! \brief Default destructor.
-  virtual Cdr_DllAPI ~Exception() noexcept;
 
-  //! \brief This function throws the object as exception.
-  virtual Cdr_DllAPI void raise() const = 0;
+    //! \brief Default destructor.
+    virtual Cdr_DllAPI ~Exception() noexcept;
 
-  /*!
-   * @brief This function returns the error message.
-   *
-   * @return The error message.
-   */
-  virtual Cdr_DllAPI const char* what() const noexcept override;
+    //! \brief This function throws the object as exception.
+    virtual Cdr_DllAPI void raise() const = 0;
+
+    /*!
+     * @brief This function returns the error message.
+     *
+     * @return The error message.
+     */
+    virtual Cdr_DllAPI const char* what() const noexcept override;
 
 protected:
-  /*!
-   * @brief Default constructor.
-   *
-   * @param message A error message. This message pointer is copied.
-   */
-  Cdr_DllAPI Exception(const char* const& message) noexcept;
 
-  /*!
-   * @brief Default copy constructor.
-   *
-   * @param ex Exception that will be copied.
-   */
-  Cdr_DllAPI Exception(const Exception& ex) noexcept;
+    /*!
+     * @brief Default constructor.
+     *
+     * @param message A error message. This message pointer is copied.
+     */
+    Cdr_DllAPI Exception(
+            const char* const& message) noexcept;
 
-#if HAVE_CXX0X
-  /*!
-   * @brief Default move constructor.
-   *
-   * @param ex Exception that will be moved.
-   */
-  Cdr_DllAPI Exception(Exception&& ex) noexcept;
-#endif  // if HAVE_CXX0X
+    /*!
+     * @brief Default copy constructor.
+     *
+     * @param ex Exception that will be copied.
+     */
+    Cdr_DllAPI Exception(
+            const Exception& ex) noexcept;
 
-  /*!
-   * @brief Assigment operation.
-   *
-   * @param ex Exception that will be copied.
-   */
-  Cdr_DllAPI Exception& operator=(const Exception& ex) noexcept;
+    /*!
+     * @brief Default move constructor.
+     *
+     * @param ex Exception that will be moved.
+     */
+    Cdr_DllAPI Exception(
+            Exception&& ex) noexcept;
 
-#if HAVE_CXX0X
-  /*!
-   * @brief Assigment operation.
-   *
-   * @param ex Exception that will be moved.
-   */
-  Cdr_DllAPI Exception& operator=(Exception&&) noexcept;
-#endif  // if HAVE_CXX0X
+    /*!
+     * @brief Assigment operation.
+     *
+     * @param ex Exception that will be copied.
+     */
+    Cdr_DllAPI Exception& operator =(
+            const Exception& ex) noexcept;
+
+    /*!
+     * @brief Assigment operation.
+     *
+     * @param ex Exception that will be moved.
+     */
+    Cdr_DllAPI Exception& operator =(
+            Exception&& ex) noexcept;
 
 private:
-  const char* m_message;
-};
-}  // namespace exception
-}  // namespace fastcdr
-}  // namespace eprosima
 
-#endif  // _FASTCDR_EXCEPTIONS_EXCEPTION_H_
+    const char* m_message;
+};
+}         //namespace exception
+}     //namespace fastcdr
+} //namespace eprosima
+
+#endif // _FASTCDR_EXCEPTIONS_EXCEPTION_H_

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/exceptions/LockedExternalAccessException.hpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/exceptions/LockedExternalAccessException.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _FASTCDR_EXCEPTIONS_NOTENOUGHMEMORYEXCEPTION_H_
-#define _FASTCDR_EXCEPTIONS_NOTENOUGHMEMORYEXCEPTION_H_
+#ifndef _FASTCDR_EXCEPTIONS_LOCKEDEXTERNALACCESSEXCEPTION_H_
+#define _FASTCDR_EXCEPTIONS_LOCKEDEXTERNALACCESSEXCEPTION_H_
 
 #include "Exception.h"
 
@@ -21,10 +21,10 @@ namespace eprosima {
 namespace fastcdr {
 namespace exception {
 /*!
- * @brief This class is thrown as an exception when the buffer's internal memory reachs its size limit.
+ * @brief This class is thrown as an exception when accessing to set the value of a locked external.
  * @ingroup EXCEPTIONMODULE
  */
-class NotEnoughMemoryException : public Exception
+class LockedExternalAccessException : public Exception
 {
 public:
 
@@ -33,51 +33,51 @@ public:
      *
      * @param message An error message. This message pointer is copied.
      */
-    Cdr_DllAPI NotEnoughMemoryException(
+    Cdr_DllAPI LockedExternalAccessException(
             const char* const& message) noexcept;
 
     /*!
      * @brief Default copy constructor.
      *
-     * @param ex NotEnoughMemoryException that will be copied.
+     * @param ex LockedExternalAccessException that will be copied.
      */
-    Cdr_DllAPI NotEnoughMemoryException(
-            const NotEnoughMemoryException& ex) noexcept;
+    Cdr_DllAPI LockedExternalAccessException(
+            const LockedExternalAccessException& ex) noexcept;
 
     /*!
      * @brief Default move constructor.
      *
-     * @param ex NotEnoughMemoryException that will be moved.
+     * @param ex LockedExternalAccessException that will be moved.
      */
-    Cdr_DllAPI NotEnoughMemoryException(
-            NotEnoughMemoryException&& ex) noexcept;
+    Cdr_DllAPI LockedExternalAccessException(
+            LockedExternalAccessException&& ex) noexcept;
 
     /*!
      * @brief Assigment operation.
      *
-     * @param ex NotEnoughMemoryException that will be copied.
+     * @param ex LockedExternalAccessException that will be copied.
      */
-    Cdr_DllAPI NotEnoughMemoryException& operator =(
-            const NotEnoughMemoryException& ex) noexcept;
+    Cdr_DllAPI LockedExternalAccessException& operator =(
+            const LockedExternalAccessException& ex) noexcept;
 
     /*!
      * @brief Assigment operation.
      *
-     * @param ex NotEnoughMemoryException that will be moved.
+     * @param ex LockedExternalAccessException that will be moved.
      */
-    Cdr_DllAPI NotEnoughMemoryException& operator =(
-            NotEnoughMemoryException&& ex) noexcept;
+    LockedExternalAccessException& operator =(
+            LockedExternalAccessException&& ex) noexcept;
 
     //! @brief Default destructor
-    virtual Cdr_DllAPI ~NotEnoughMemoryException() noexcept;
+    virtual Cdr_DllAPI ~LockedExternalAccessException() noexcept;
 
     //! @brief This function throws the object as exception.
     Cdr_DllAPI void raise() const override;
 
     //! @brief Default message used in the library.
-    static Cdr_DllAPI const char* const NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT;
+    static Cdr_DllAPI const char* const LOCKED_EXTERNAL_ACCESS_MESSAGE_DEFAULT;
 };
 }         //namespace exception
 }     //namespace fastcdr
 } //namespace eprosima
-#endif // _FASTCDR_EXCEPTIONS_NOTENOUGHMEMORYEXCEPTION_H_
+#endif // _FASTCDR_EXCEPTIONS_LOCKEDEXTERNALACCESSEXCEPTION_H_

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/fastcdr_dll.h
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/fastcdr_dll.h
@@ -18,52 +18,52 @@
 #include <fastcdr/config.h>
 
 // normalize macros
-#if !defined(FASTCDR_DYN_LINK) && !defined(FASTCDR_STATIC_LINK) &&                       \
-    !defined(EPROSIMA_ALL_DYN_LINK) && !defined(EPROSIMA_ALL_STATIC_LINK)
+#if !defined(FASTCDR_DYN_LINK) && !defined(FASTCDR_STATIC_LINK) \
+    && !defined(EPROSIMA_ALL_DYN_LINK) && !defined(EPROSIMA_ALL_STATIC_LINK)
 #define FASTCDR_STATIC_LINK
-#endif  // if !defined(FASTCDR_DYN_LINK) && !defined(FASTCDR_STATIC_LINK) &&
-        // !defined(EPROSIMA_ALL_DYN_LINK) && !defined(EPROSIMA_ALL_STATIC_LINK)
+#endif // if !defined(FASTCDR_DYN_LINK) && !defined(FASTCDR_STATIC_LINK) && !defined(EPROSIMA_ALL_DYN_LINK) && !defined(EPROSIMA_ALL_STATIC_LINK)
 
 #if defined(EPROSIMA_ALL_DYN_LINK) && !defined(FASTCDR_DYN_LINK)
 #define FASTCDR_DYN_LINK
-#endif  // if defined(EPROSIMA_ALL_DYN_LINK) && !defined(FASTCDR_DYN_LINK)
+#endif // if defined(EPROSIMA_ALL_DYN_LINK) && !defined(FASTCDR_DYN_LINK)
 
 #if defined(FASTCDR_DYN_LINK) && defined(FASTCDR_STATIC_LINK)
 #error Must not define both FASTCDR_DYN_LINK and FASTCDR_STATIC_LINK
-#endif  // if defined(FASTCDR_DYN_LINK) && defined(FASTCDR_STATIC_LINK)
+#endif // if defined(FASTCDR_DYN_LINK) && defined(FASTCDR_STATIC_LINK)
 
 #if defined(EPROSIMA_ALL_NO_LIB) && !defined(FASTCDR_NO_LIB)
 #define FASTCDR_NO_LIB
-#endif  // if defined(EPROSIMA_ALL_NO_LIB) && !defined(FASTCDR_NO_LIB)
+#endif // if defined(EPROSIMA_ALL_NO_LIB) && !defined(FASTCDR_NO_LIB)
 
 // enable dynamic linking
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_ALL_DYN_LINK) || defined(FASTCDR_DYN_LINK)
 #if defined(fastcdr_EXPORTS)
-#define Cdr_DllAPI __declspec(dllexport)
+#define Cdr_DllAPI __declspec( dllexport )
 #else
-#define Cdr_DllAPI __declspec(dllimport)
-#endif  // FASTCDR_SOURCE
-#else
-#define Cdr_DllAPI
-#endif  // if defined(EPROSIMA_ALL_DYN_LINK) || defined(FASTCDR_DYN_LINK)
+#define Cdr_DllAPI __declspec( dllimport )
+#endif // FASTCDR_SOURCE
 #else
 #define Cdr_DllAPI
-#endif  // _WIN32
+#endif // if defined(EPROSIMA_ALL_DYN_LINK) || defined(FASTCDR_DYN_LINK)
+#else
+#define Cdr_DllAPI
+#endif // _WIN32
 
 // Auto linking.
 
-#if !defined(FASTCDR_SOURCE) && !defined(EPROSIMA_ALL_NO_LIB) && !defined(FASTCDR_NO_LIB)
+#if !defined(FASTCDR_SOURCE) && !defined(EPROSIMA_ALL_NO_LIB) \
+    && !defined(FASTCDR_NO_LIB)
 
 // Set properties.
 #define EPROSIMA_LIB_NAME fastcdr
 
 #if defined(EPROSIMA_ALL_DYN_LINK) || defined(FASTCDR_DYN_LINK)
 #define EPROSIMA_DYN_LINK
-#endif  // if defined(EPROSIMA_ALL_DYN_LINK) || defined(FASTCDR_DYN_LINK)
+#endif // if defined(EPROSIMA_ALL_DYN_LINK) || defined(FASTCDR_DYN_LINK)
 
 #include "eProsima_auto_link.h"
-#endif  // auto-linking disabled
+#endif // auto-linking disabled
 
-#endif  // _FASTCDR_FASTCDR_DLL_H_
+#endif // _FASTCDR_FASTCDR_DLL_H_

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/xcdr/MemberId.hpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/xcdr/MemberId.hpp
@@ -1,0 +1,72 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef _FASTCDR_XCDR_MEMBERID_HPP_
+#define _FASTCDR_XCDR_MEMBERID_HPP_
+
+#include <cstdint>
+
+#include "../fastcdr_dll.h"
+
+namespace eprosima {
+namespace fastcdr {
+
+class Cdr;
+
+class Cdr_DllAPI MemberId
+{
+public:
+
+    MemberId() = default;
+
+    MemberId(
+            uint32_t id_value)
+        : id(id_value)
+    {
+    }
+
+    bool operator ==(
+            uint32_t id_value) const
+    {
+        return id == id_value;
+    }
+
+    bool operator ==(
+            const MemberId member_id) const
+    {
+        return id == member_id.id;
+    }
+
+    bool operator !=(
+            const MemberId member_id) const
+    {
+        return !(member_id == *this);
+    }
+
+    uint32_t id { member_id_invalid_value_ };
+
+    bool must_understand { false };
+
+private:
+
+    static constexpr uint32_t member_id_invalid_value_ = 0xFFFFFFFF;
+
+};
+
+static const MemberId MEMBER_ID_INVALID {};
+
+} // namespace fastcdr
+} // namespace eprosima
+
+#endif //_FASTCDR_XCDR_MEMBERID_HPP_

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/xcdr/detail/optional.hpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/xcdr/detail/optional.hpp
@@ -1,0 +1,71 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef _FASTCDR_XCDR_DETAIL_OPTIONAL_HPP_
+#define _FASTCDR_XCDR_DETAIL_OPTIONAL_HPP_
+
+#include <type_traits>
+
+namespace eprosima {
+namespace fastcdr {
+namespace detail {
+template<class T, typename = void>
+struct optional_storage
+{
+    union
+    {
+        char dummy_;
+        T val_;
+    };
+
+    bool engaged_ { false };
+
+    optional_storage()
+    {
+    }
+
+    ~optional_storage()
+    {
+        if (engaged_)
+        {
+            val_.~T();
+        }
+    }
+
+};
+
+/* *INDENT-OFF* */
+template<class T>
+struct optional_storage<T, typename std::enable_if<std::is_trivially_destructible<T>{}>::type>
+{
+    union
+    {
+        char dummy_; T val_;
+    };
+
+    bool engaged_ { false };
+
+    optional_storage()
+    {
+    }
+
+    ~optional_storage() = default;
+};
+/* *INDENT-ON* */
+} // namespace detail
+} // namespace fastcdr
+} // namespace eprosima
+
+#endif //_FASTCDR_XCDR_DETAIL_OPTIONAL_HPP_
+

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/xcdr/external.hpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/xcdr/external.hpp
@@ -1,0 +1,190 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef _FASTCDR_XCDR_EXTERNAL_HPP_
+#define _FASTCDR_XCDR_EXTERNAL_HPP_
+
+#include <memory>
+
+#include "../exceptions/LockedExternalAccessException.hpp"
+
+namespace eprosima {
+namespace fastcdr {
+
+/*!
+ * @brief This class template manages an external member, a member declared to be external to the storage of a type.
+ */
+template<class T>
+class external
+{
+public:
+
+    using type = T;
+
+    //! Default constructor
+    external() = default;
+
+    //! Constructor from a pointer.
+    external(
+            T* pointer,
+            bool locked = false) noexcept
+        : pointer_ {pointer}
+        , locked_ {locked}
+    {
+    }
+
+    //! Constructor from a shared pointer.
+    external(
+            std::shared_ptr<T> pointer) noexcept
+        : pointer_ {pointer}
+    {
+    }
+
+    //! Copy constructor.
+    external(
+            const external<T>& other) noexcept
+        : locked_ {other.locked_}
+    {
+        if (locked_)
+        {
+            pointer_ = std::make_shared<T>(*other.pointer_);
+        }
+        else
+        {
+            pointer_ = other.pointer_;
+        }
+    }
+
+    //! Assignment
+    external<T>& operator =(
+            const external<T>& other)
+    {
+        if (locked_)
+        {
+            throw exception::LockedExternalAccessException(
+                      exception::LockedExternalAccessException::LOCKED_EXTERNAL_ACCESS_MESSAGE_DEFAULT);
+        }
+
+        if (!other.pointer_)
+        {
+            pointer_.reset();
+        }
+        else if (other.locked_)
+        {
+            if (!pointer_)
+            {
+                pointer_ = std::make_shared<T>(*other.pointer_);
+            }
+            else
+            {
+                *pointer_ = *other.pointer_;
+            }
+        }
+        else
+        {
+            pointer_ = other.pointer_;
+        }
+
+        return *this;
+    }
+
+    //! Destructor
+    ~external() = default;
+
+    //! Dereference object.
+    T& operator *() noexcept
+    {
+        return *pointer_;
+    }
+
+    //! Dereference object.
+    const T& operator *() const noexcept
+    {
+        return *pointer_;
+    }
+
+    //! Get pointer.
+    T* get() noexcept
+    {
+        return pointer_.get();
+    }
+
+    //! Get pointer.
+    const T* get() const noexcept
+    {
+        return pointer_.get();
+    }
+
+    //! Get shared pointer.
+    std::shared_ptr<T> get_shared_ptr() noexcept
+    {
+        return pointer_;
+    }
+
+    //! Dereference object member.
+    T* operator ->() noexcept
+    {
+        return pointer_.get();
+    }
+
+    //! Dereference object member.
+    const T* operator ->() const noexcept
+    {
+        return pointer_.get();
+    }
+
+    //! Compares they manage the same object or empty both.
+    bool operator ==(
+            const external<T>& other) const
+    {
+        return pointer_.get() == other.pointer_.get();
+    }
+
+    //! Compares they don't manages the same object
+    bool operator !=(
+            const external<T>& other) const
+    {
+        return !(*this == other);
+    }
+
+    //! Checks if not null
+    operator bool() const noexcept
+    {
+        return nullptr != pointer_.get();
+    }
+
+    //! Checks if locked
+    bool is_locked() const noexcept
+    {
+        return locked_;
+    }
+
+    //! Locks the managed object.
+    void lock() noexcept
+    {
+        locked_ = true;
+    }
+
+private:
+
+    std::shared_ptr<T> pointer_;
+
+    bool locked_ {false};
+
+};
+
+} // namespace fastcdr
+} // namespace eprosima
+
+#endif //_FASTCDR_XCDR_EXTERNAL_HPP_

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/xcdr/optional.hpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/include/fastcdr/xcdr/optional.hpp
@@ -1,0 +1,356 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef _FASTCDR_XCDR_OPTIONAL_HPP_
+#define _FASTCDR_XCDR_OPTIONAL_HPP_
+
+#include <new>
+#include <utility>
+
+#include "detail/optional.hpp"
+#include "../exceptions/BadOptionalAccessException.hpp"
+
+namespace eprosima {
+namespace fastcdr {
+
+//! An empty class type used to indicate optional type with uninitialized state.
+struct nullopt_t
+{
+    constexpr explicit nullopt_t(
+            int)
+    {
+    }
+
+};
+
+/*!
+ * @brief nullopt is a constant of type nullopt_t that is used to indicate optional type with uninitialized state.
+ */
+static constexpr nullopt_t nullopt {0};
+
+/*!
+ * @brief This class template manages an optional contained value, i.e. a value that may or may not be present.
+ */
+template<class T>
+class optional
+{
+public:
+
+    using type = T;
+
+    //! Default constructor
+    optional() = default;
+
+    //! Copy constructor from an instance of the templated class.
+    optional(
+            const T& val) noexcept
+    {
+        ::new(&storage_.val_)T(val);
+        storage_.engaged_ = true;
+    }
+
+    //! Move constructor from an instance of the templated class.
+    optional(
+            T&& val) noexcept
+    {
+        ::new(&storage_.val_)T(std::move(val));
+        storage_.engaged_ = true;
+    }
+
+    //! Copy constructor.
+    optional(
+            const optional<T>& val) noexcept
+    {
+        ::new(&storage_.val_)T(val.storage_.val_);
+        storage_.engaged_ = val.storage_.engaged_;
+    }
+
+    //! Move constructor.
+    optional(
+            optional<T>&& val) noexcept
+    {
+        ::new(&storage_.val_)T(std::move(val.storage_.val_));
+        storage_.engaged_ = val.storage_.engaged_;
+    }
+
+    //! Destructor
+    ~optional() = default;
+
+    /*!
+     * @brief Constructs the contained value in-place
+     *
+     * @param[in] _args The arguments to pass to the constructor.
+     */
+    template<class ... Args> void emplace(
+            Args&&... _args)
+    {
+        reset();
+        storage_.val_.T(std::forward<Args>(_args)...);
+        storage_.engaged_ = true;
+    }
+
+    /*!
+     * @brief Reset the state of the optional
+     *
+     * @param[in] initial_engaged True value initializes the state with a default instance of the templated class.
+     * False value leaves the optional in a uninitialized state.
+     */
+    void reset(
+            bool initial_engaged = false)
+    {
+        if (storage_.engaged_)
+        {
+            storage_.val_.~T();
+        }
+        storage_.engaged_ = initial_engaged;
+        if (storage_.engaged_)
+        {
+            ::new(&storage_.val_)T();
+        }
+    }
+
+    /*!
+     * @brief Returns the contained value.
+     *
+     * @return The contained value.
+     * @exception exception::BadOptionalAccessException This exception is thrown when the optional is uninitialized.
+     */
+    T& value()&
+    {
+        if (!storage_.engaged_)
+        {
+            throw exception::BadOptionalAccessException(
+                      exception::BadOptionalAccessException::BAD_OPTIONAL_ACCESS_MESSAGE_DEFAULT);
+        }
+
+        return storage_.val_;
+    }
+
+    /*!
+     * @brief Returns the contained value.
+     *
+     * @return The contained value.
+     * @exception exception::BadOptionalAccessException This exception is thrown when the optional is uninitialized.
+     */
+    const T& value() const&
+    {
+        if (!storage_.engaged_)
+        {
+            throw exception::BadOptionalAccessException(
+                      exception::BadOptionalAccessException::BAD_OPTIONAL_ACCESS_MESSAGE_DEFAULT);
+        }
+
+        return storage_.val_;
+    }
+
+    /*!
+     * @brief Returns the contained value.
+     *
+     * @return The contained value.
+     * @exception exception::BadOptionalAccessException This exception is thrown when the optional is uninitialized.
+     */
+    T&& value() &&
+    {
+        if (!storage_.engaged_)
+        {
+            throw exception::BadOptionalAccessException(
+                      exception::BadOptionalAccessException::BAD_OPTIONAL_ACCESS_MESSAGE_DEFAULT);
+        }
+
+        return std::move(storage_.val_);
+    }
+
+    /*!
+     * @brief Returns the contained value.
+     *
+     * @return The contained value.
+     * @exception exception::BadOptionalAccessException This exception is thrown when the optional is uninitialized.
+     */
+    const T&& value() const&&
+    {
+        if (!storage_.engaged_)
+        {
+            throw exception::BadOptionalAccessException(
+                      exception::BadOptionalAccessException::BAD_OPTIONAL_ACCESS_MESSAGE_DEFAULT);
+        }
+
+        return std::move(storage_.val_);
+    }
+
+    /*!
+     * @brief Checks whether the optional contains a value.
+     *
+     * @return Whether the optional contains a value.
+     */
+    bool has_value() const
+    {
+        return storage_.engaged_;
+    }
+
+    //! Assigns content from an optional.
+    optional& operator =(
+            const optional& opt)
+    {
+        reset();
+        storage_.engaged_ = opt.storage_.engaged_;
+        if (opt.storage_.engaged_)
+        {
+            ::new(&storage_.val_)T(opt.storage_.val_);
+        }
+        return *this;
+    }
+
+    //! Assigns content from an optional.
+    optional& operator =(
+            optional&& opt)
+    {
+        reset();
+        storage_.engaged_ = opt.storage_.engaged_;
+        if (opt.storage_.engaged_)
+        {
+            ::new(&storage_.val_)T(std::move(opt.storage_.val_));
+        }
+        return *this;
+    }
+
+    //! Assigns content from an instance of the templated class.
+    optional& operator =(
+            const T& val)
+    {
+        reset();
+        ::new(&storage_.val_)T(val);
+        storage_.engaged_ = true;
+        return *this;
+    }
+
+    //! Assigns content from an instance of the templated class.
+    optional& operator =(
+            T&& val)
+    {
+        reset();
+        ::new(&storage_.val_)T(std::move(val));
+        storage_.engaged_ = true;
+        return *this;
+    }
+
+    //! Uninitialized the optional.
+    optional& operator = (
+            nullopt_t) noexcept
+    {
+        reset();
+        return *this;
+    }
+
+    //! Compares optional values.
+    bool operator ==(
+            const optional& opt_val) const
+    {
+        return opt_val.storage_.engaged_ == storage_.engaged_ &&
+               (storage_.engaged_ ? opt_val.storage_.val_ == storage_.val_ : true);
+    }
+
+    //! Compares optional values.
+    bool operator !=(
+            const optional& opt_val) const
+    {
+        return !operator ==(opt_val);
+    }
+
+    /*!
+     * @brief Accesses the contained value.
+     *
+     * The behavior is undefined if *this does not contain a value.
+     *
+     * @return The contained value.
+     */
+    T& operator *() & noexcept
+    {
+        return storage_.val_;
+    }
+
+    /*!
+     * @brief Accesses the contained value.
+     *
+     * The behavior is undefined if *this does not contain a value.
+     *
+     * @return The contained value.
+     */
+    const T& operator *() const& noexcept
+    {
+        return storage_.val_;
+    }
+
+    /*!
+     * @brief Accesses the contained value.
+     *
+     * The behavior is undefined if *this does not contain a value.
+     *
+     * @return The contained value.
+     */
+    T&& operator *() && noexcept
+    {
+        return std::move(storage_.val_);
+    }
+
+    /*!
+     * @brief Accesses the contained value.
+     *
+     * The behavior is undefined if *this does not contain a value.
+     *
+     * @return The contained value.
+     */
+    const T&& operator *() const&& noexcept
+    {
+        return std::move(storage_.val_);
+    }
+
+    /*!
+     * @brief Accesses the contained value.
+     *
+     * The behavior is undefined if *this does not contain a value.
+     *
+     * @return The contained value.
+     */
+    T* operator ->() noexcept
+    {
+        return std::addressof(storage_.val_);
+    }
+
+    /*!
+     * @brief Accesses the contained value.
+     *
+     * The behavior is undefined if *this does not contain a value.
+     *
+     * @return The contained value.
+     */
+    const T* operator ->() const noexcept
+    {
+        return std::addressof(storage_.val_);
+    }
+
+    //! Checks whether the optional contains a value.
+    explicit operator bool() const noexcept
+    {
+        return storage_.engaged_;
+    }
+
+private:
+
+    detail::optional_storage<T> storage_;
+};
+
+} // namespace fastcdr
+} // namespace eprosima
+
+#endif //_FASTCDR_XCDR_OPTIONAL_HPP_

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/CMakeLists.txt
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/CMakeLists.txt
@@ -12,19 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(${PROJECT_SOURCE_DIR}/cmake/dev/set_sources.cmake)
-include(${PROJECT_SOURCE_DIR}/cmake/dev/generate_msvc_libraries.cmake)
+file(GLOB_RECURSE ALL_HEADERS
+    ${PROJECT_SOURCE_DIR}/include/**/*.h
+    ${PROJECT_SOURCE_DIR}/include/**/*.hpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/**/*.h
+    ${PROJECT_SOURCE_DIR}/src/cpp/**/*.hpp
+    )
 
 # Set source files
-set_sources(
+set(${PROJECT_NAME}_source_files
+    ${ALL_HEADERS}
+
     Cdr.cpp
+    CdrSizeCalculator.cpp
     FastCdr.cpp
     FastBuffer.cpp
-    exceptions/Exception.cpp
-    exceptions/NotEnoughMemoryException.cpp
+    exceptions/BadOptionalAccessException.cpp
     exceptions/BadParamException.cpp
+    exceptions/Exception.cpp
+    exceptions/LockedExternalAccessException.cpp
+    exceptions/NotEnoughMemoryException.cpp
     FastCdr.rc
-)
+    )
 
 configure_file(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/config.h.in
     ${PROJECT_BINARY_DIR}/include/${PROJECT_NAME}/config.h)
@@ -37,60 +46,50 @@ if(APPLE)
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 endif()
 
-# Create libraries
-if(MSVC OR MSVC_IDE AND EPROSIMA_INSTALLER AND IS_TOP_LEVEL)
-    generate_msvc_libraries(i86Win32VS2013)
-    generate_msvc_libraries(x64Win64VS2013)
-    generate_msvc_libraries(i86Win32VS2015)
-    generate_msvc_libraries(x64Win64VS2015)
-    generate_msvc_libraries(i86Win32VS2017)
-    generate_msvc_libraries(x64Win64VS2017)
-elseif(NOT EPROSIMA_INSTALLER)
-    # Create library
-    add_library(${PROJECT_NAME} ${${PROJECT_NAME}_SOURCES})
-    set_common_compile_options(${PROJECT_NAME})
-    set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION})
-    set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
+# Create library
+add_library(${PROJECT_NAME} ${${PROJECT_NAME}_source_files})
+set_common_compile_options(${PROJECT_NAME})
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+    )
 
-    target_compile_definitions(${PROJECT_NAME} PRIVATE ${PROJECT_NAME_UPPER}_SOURCE)
+target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+    ${PROJECT_NAME_UPPER}_SOURCE
+    INTERFACE
+    $<$<BOOL:${WIN32}>:${PROJECT_NAME_UPPER}_NO_LIB>
+    PUBLIC
+    $<$<STREQUAL:$<TARGET_PROPERTY:${PROJECT_NAME},TYPE>,SHARED_LIBRARY>:${PROJECT_NAME_UPPER}_DYN_LINK>
+    )
 
-    # Define public headers
-    target_include_directories(${PROJECT_NAME} PUBLIC
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-        $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>
+# Define public headers
+target_include_directories(${PROJECT_NAME} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+    $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>
+    )
+
+if(MSVC OR MSVC_IDE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES
+        RELEASE_POSTFIX -${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+        RELWITHDEBINFO_POSTFIX -${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+        DEBUG_POSTFIX d-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
         )
 
-    if(MSVC OR MSVC_IDE)
-        set_target_properties(${PROJECT_NAME} PROPERTIES RELEASE_POSTFIX -${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
-        set_target_properties(${PROJECT_NAME} PROPERTIES RELWITHDEBINFO_POSTFIX -${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
-        set_target_properties(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX d-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
-
-        get_target_property(TARGET_TYPE ${PROJECT_NAME} TYPE)
-        if(TARGET_TYPE STREQUAL "SHARED_LIBRARY")
-            # Export symbols in DLL library
-            target_compile_definitions(${PROJECT_NAME} PUBLIC ${PROJECT_NAME_UPPER}_DYN_LINK)
-            set_target_properties(${PROJECT_NAME} PROPERTIES
-                PDB_NAME_DEBUG "${PROJECT_NAME}d-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
-                PDB_OUTPUT_DIRECTORY_DEBUG "${CMAKE_CURRENT_BINARY_DIR}/symbols"
+    get_target_property(TARGET_TYPE ${PROJECT_NAME} TYPE)
+    if(TARGET_TYPE STREQUAL "SHARED_LIBRARY")
+        # Export symbols in DLL library
+        set_target_properties(${PROJECT_NAME} PROPERTIES
+            PDB_NAME_DEBUG ${PROJECT_NAME}d-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+            PDB_OUTPUT_DIRECTORY_DEBUG "${CMAKE_CURRENT_BINARY_DIR}/symbols"
             )
-        else()
-            # Rename the library to have a "lib" before.
-            set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME lib${PROJECT_NAME})
-            set_target_properties(${PROJECT_NAME} PROPERTIES
-                COMPILE_PDB_NAME_DEBUG "lib${PROJECT_NAME}d-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
-                COMPILE_PDB_OUTPUT_DIRECTORY_DEBUG "${CMAKE_CURRENT_BINARY_DIR}/symbols"
+    else()
+        # Rename the library to have a "lib" before.
+        set_target_properties(${PROJECT_NAME} PROPERTIES
+            OUTPUT_NAME lib${PROJECT_NAME}
+            COMPILE_PDB_NAME_DEBUG lib${PROJECT_NAME}d-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+            COMPILE_PDB_OUTPUT_DIRECTORY_DEBUG "${CMAKE_CURRENT_BINARY_DIR}/symbols"
             )
-        endif()
-
-        # For installing purpose.
-        if(EPROSIMA_INSTALLER_MINION)
-            set(MSVCARCH_EXTENSION "_${MSVC_ARCH}")
-            set(MSVCARCH_DIR_EXTENSION "/${MSVC_ARCH}")
-            set(MSVCARCH_DIR_EXTENSION_EXT "/${MSVC_ARCH}")
-            if(NOT TARGET_TYPE STREQUAL "SHARED_LIBRARY")
-                set(MSVCARCH_DIR_EXTENSION_EXT "${MSVCARCH_DIR_EXTENSION_EXT}_static")
-            endif()
-        endif()
     endif()
 endif()
 
@@ -99,145 +98,97 @@ endif()
 ###############################################################################
 
 # Install public headers
-set_public_headers_directory(${PROJECT_SOURCE_DIR}/include ${PROJECT_NAME}
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}
     DESTINATION ${INCLUDE_INSTALL_DIR}
     COMPONENT headers
+    FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.hpp"
+    PATTERN "*.ipp"
     )
 
 # Install config.h header
-set_public_header(${PROJECT_BINARY_DIR}/include ${PROJECT_NAME} config.h
+install(FILES ${PROJECT_BINARY_DIR}/include/${PROJECT_NAME}/config.h
     DESTINATION ${INCLUDE_INSTALL_DIR}/${PROJECT_NAME}
     COMPONENT headers
     )
 
-set(CPACK_COMPONENT_HEADERS_DISPLAY_NAME "C++ Headers" PARENT_SCOPE)
-set(CPACK_COMPONENT_HEADERS_DESCRIPTION "eProsima ${PROJECT_NAME_LARGE} C++ Headers" PARENT_SCOPE)
-
-# Install sources
-if(UNIX AND EPROSIMA_INSTALLER)
-    install(DIRECTORY ${PROJECT_SOURCE_DIR}/src/cpp
-        DESTINATION src
-        COMPONENT sources
-        FILES_MATCHING
-        PATTERN "*.c"
-        PATTERN "*.cpp"
-        PATTERN "*.h"
-        PATTERN "*.hpp"
-        )
-
-    install(DIRECTORY ${PROJECT_BINARY_DIR}/autotools/
-        DESTINATION .
-        USE_SOURCE_PERMISSIONS
-        OPTIONAL
-        COMPONENT sources
-        )
-endif()
-
 # Install libraries
+install(TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}-targets
+    RUNTIME DESTINATION ${BIN_INSTALL_DIR}
+    LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+    ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+    COMPONENT libraries
+    )
 
 # Generate different target names depending on linking
 get_target_property(TARGET_TYPE ${PROJECT_NAME} TYPE)
 if(TARGET_TYPE STREQUAL "SHARED_LIBRARY")
-    set(FASTCDR_LINKING dynamic)
+    set(FASTCDR_LINKING shared)
 else()
     set(FASTCDR_LINKING static)
 endif()
 
-if(MSVC OR MSVC_IDE AND EPROSIMA_INSTALLER)
-    if(IS_TOP_LEVEL)
-        install_msvc_libraries(i86Win32VS2013)
-        install_msvc_libraries(x64Win64VS2013)
-        install_msvc_libraries(i86Win32VS2015)
-        install_msvc_libraries(x64Win64VS2015)
-        install_msvc_libraries(i86Win32VS2017)
-        install_msvc_libraries(x64Win64VS2017)
-    endif()
+if(INSTALLER_PLATFORM)
+    set(INSTALL_DESTINATION_PATH ${DATA_INSTALL_DIR}/${PROJECT_NAME}-${INSTALLER_PLATFORM}/cmake)
+else()
+    set(INSTALL_DESTINATION_PATH ${LIB_INSTALL_DIR}/cmake/${PROJECT_NAME})
+endif()
 
-    install(FILES ${PROJECT_SOURCE_DIR}/cmake/packaging/windows/${PROJECT_NAME}-config.cmake
-        DESTINATION ${LIB_INSTALL_DIR}/cmake/${PROJECT_NAME}${MSVCARCH_DIR_EXTENSION_EXT}
-        COMPONENT cmake
-        )
-elseif(NOT EPROSIMA_INSTALLER)
-    install(TARGETS ${PROJECT_NAME}
-        EXPORT ${PROJECT_NAME}-${FASTCDR_LINKING}-targets
-        RUNTIME DESTINATION ${BIN_INSTALL_DIR}${MSVCARCH_DIR_EXTENSION}
-        LIBRARY DESTINATION ${LIB_INSTALL_DIR}${MSVCARCH_DIR_EXTENSION}
-        ARCHIVE DESTINATION ${LIB_INSTALL_DIR}${MSVCARCH_DIR_EXTENSION}
-        COMPONENT libraries${MSVCARCH_EXTENSION}
-        )
+install(EXPORT ${PROJECT_NAME}-targets
+    DESTINATION ${INSTALL_DESTINATION_PATH}
+    FILE ${PROJECT_NAME}-${FASTCDR_LINKING}-targets.cmake
+    COMPONENT cmake
+    )
 
-    export(TARGETS ${PROJECT_NAME} FILE ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-${FASTCDR_LINKING}-targets.cmake)
-
-    if(INSTALLER_PLATFORM)
-        set(INSTALL_DESTINATION_PATH ${DATA_INSTALL_DIR}/${PROJECT_NAME}-${INSTALLER_PLATFORM}/cmake)
+if(MSVC OR MSVC_IDE)
+    # first try dll symbols
+    get_target_property(PDB_FILE ${PROJECT_NAME} PDB_NAME_DEBUG)
+    if(PDB_FILE)
+        get_target_property(PDB_DIR ${PROJECT_NAME} PDB_OUTPUT_DIRECTORY_DEBUG)
+        set(PDB_FILE "${PDB_DIR}/${PDB_FILE}.pdb")
     else()
-        set(INSTALL_DESTINATION_PATH ${LIB_INSTALL_DIR}/cmake/${PROJECT_NAME}${MSVCARCH_DIR_EXTENSION_EXT})
-    endif()
-
-    install(EXPORT ${PROJECT_NAME}-${FASTCDR_LINKING}-targets
-        DESTINATION ${INSTALL_DESTINATION_PATH}
-        COMPONENT cmake
-        )
-
-    if(MSVC OR MSVC_IDE)
-        # first try dll symbols
-        get_target_property(PDB_FILE ${PROJECT_NAME} PDB_NAME_DEBUG)
+        # fallback to static lib symbols
+        get_target_property(PDB_FILE ${PROJECT_NAME} COMPILE_PDB_NAME_DEBUG)
         if(PDB_FILE)
-            get_target_property(PDB_DIR ${PROJECT_NAME} PDB_OUTPUT_DIRECTORY_DEBUG)
+            get_target_property(PDB_DIR ${PROJECT_NAME} COMPILE_PDB_OUTPUT_DIRECTORY_DEBUG)
             set(PDB_FILE "${PDB_DIR}/${PDB_FILE}.pdb")
-        else()
-            # fallback to static lib symbols
-            get_target_property(PDB_FILE ${PROJECT_NAME} COMPILE_PDB_NAME_DEBUG)
-            if(PDB_FILE)
-                get_target_property(PDB_DIR ${PROJECT_NAME} COMPILE_PDB_OUTPUT_DIRECTORY_DEBUG)
-                set(PDB_FILE "${PDB_DIR}/${PDB_FILE}.pdb")
-            endif()
-        endif()
-
-        # install symbols if any
-        if(PDB_FILE)
-            install(FILES ${PDB_FILE}
-                DESTINATION ${LIB_INSTALL_DIR}${MSVCARCH_DIR_EXTENSION}
-                COMPONENT symbols
-                CONFIGURATIONS Debug
-                )
         endif()
     endif()
 
-    ###############################################################################
-    # Create CMake package config file
-    ###############################################################################
-    include(CMakePackageConfigHelpers)
-
-    if(BUILD_SHARED_LIBS)
-        set(FASTRTPS_PACKAGE_OPT_BIN_DIR_CONDITION "if(MSVC OR MSVC_IDE)")
-    else()
-        set(FASTRTPS_PACKAGE_OPT_BIN_DIR_CONDITION "if(0)")
-    endif()
-
-    configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/packaging/Config.cmake.in
-        ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config.cmake
-	INSTALL_DESTINATION ${INSTALL_DESTINATION_PATH}
-        PATH_VARS BIN_INSTALL_DIR INCLUDE_INSTALL_DIR LIB_INSTALL_DIR
-        )
-    write_basic_package_version_file(${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config-version.cmake
-        VERSION ${PROJECT_VERSION}
-        COMPATIBILITY SameMajorVersion
-        )
-    install(FILES ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config.cmake
-        ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config-version.cmake
-        DESTINATION ${INSTALL_DESTINATION_PATH}
-        COMPONENT cmake
-        )
-
-    if(MSVCARCH_EXTENSION)
-        string(TOUPPER "${MSVC_ARCH}" MSVC_ARCH_UPPER)
-        set(CPACK_COMPONENT_LIBRARIES_${MSVC_ARCH_UPPER}_DISPLAY_NAME "${MSVC_ARCH}" PARENT_SCOPE)
-        set(CPACK_COMPONENT_LIBRARIES_${MSVC_ARCH_UPPER}_DESCRIPTION "eProsima ${PROJECT_NAME_LARGE} libraries for platform ${MSVC_ARCH}" PARENT_SCOPE)
-        set(CPACK_COMPONENT_LIBRARIES_${MSVC_ARCH_UPPER}_GROUP "Libraries" PARENT_SCOPE)
-        set(CPACK_COMPONENT_GROUP_LIBRARIES_DESCRIPTION "eProsima ${PROJECT_NAME_LARGE} libraries" PARENT_SCOPE)
-    else()
-        set(CPACK_COMPONENT_LIBRARIES_DISPLAY_NAME "Libraries" PARENT_SCOPE)
-        set(CPACK_COMPONENT_LIBRARIES_DESCRIPTION "eProsima ${PROJECT_NAME_LARGE} libraries" PARENT_SCOPE)
+    # install symbols if any
+    if(PDB_FILE)
+        install(FILES ${PDB_FILE}
+            DESTINATION ${LIB_INSTALL_DIR}
+            COMPONENT symbols
+            CONFIGURATIONS Debug
+            )
     endif()
 endif()
+
+###############################################################################
+# Create CMake package config file
+###############################################################################
+include(CMakePackageConfigHelpers)
+
+if(BUILD_SHARED_LIBS)
+    set(FASTRTPS_PACKAGE_OPT_BIN_DIR_CONDITION "if(MSVC OR MSVC_IDE)")
+else()
+    set(FASTRTPS_PACKAGE_OPT_BIN_DIR_CONDITION "if(0)")
+endif()
+
+configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/packaging/Config.cmake.in
+    ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config.cmake
+    INSTALL_DESTINATION ${INSTALL_DESTINATION_PATH}
+    PATH_VARS BIN_INSTALL_DIR INCLUDE_INSTALL_DIR LIB_INSTALL_DIR
+    )
+write_basic_package_version_file(${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config-version.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+install(FILES ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config.cmake
+    ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config-version.cmake
+    DESTINATION ${INSTALL_DESTINATION_PATH}
+    COMPONENT cmake
+    )

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/Cdr.cpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/Cdr.cpp
@@ -12,2663 +12,3297 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <fastcdr/Cdr.h>
-#include <fastcdr/exceptions/BadParamException.h>
+#include <cstring>
+#include <limits>
 
-using namespace eprosima::fastcdr;
-using namespace ::exception;
+#include <fastcdr/Cdr.h>
+
+namespace eprosima {
+namespace fastcdr {
+
+using namespace exception;
 
 #if FASTCDR_IS_BIG_ENDIAN_TARGET
 const Cdr::Endianness Cdr::DEFAULT_ENDIAN = BIG_ENDIANNESS;
 #else
 const Cdr::Endianness Cdr::DEFAULT_ENDIAN = LITTLE_ENDIANNESS;
-#endif  // if FASTCDR_IS_BIG_ENDIAN_TARGET
+#endif // if FASTCDR_IS_BIG_ENDIAN_TARGET
 
-CONSTEXPR size_t ALIGNMENT_LONG_DOUBLE = 8;
+constexpr uint16_t PID_EXTENDED = 0x3F01;
+constexpr uint16_t PID_EXTENDED_LENGTH = 0x8;
+constexpr uint16_t PID_SENTINEL = 0x3F02;
+constexpr uint16_t PID_SENTINEL_LENGTH = 0x0;
 
-Cdr::state::state(const Cdr& cdr)
-  : m_currentPosition(cdr.m_currentPosition)
-  , m_alignPosition(cdr.m_alignPosition)
-  , m_swapBytes(cdr.m_swapBytes)
-  , m_lastDataSize(cdr.m_lastDataSize)
+constexpr uint8_t operator ""_8u(
+        unsigned long long int value)
+{
+    return static_cast<uint8_t>(value);
+}
+
+inline size_t alignment_on_state(
+        const FastBuffer::iterator& origin,
+        const FastBuffer::iterator& offset,
+        size_t data_size)
+{
+    return (data_size - ((offset - origin) % data_size)) & (data_size - 1);
+}
+
+inline uint32_t Cdr::get_long_lc(
+        SerializedMemberSizeForNextInt serialized_member_size)
+{
+    uint32_t lc = 0x40000000;
+
+    switch (serialized_member_size)
+    {
+        case SERIALIZED_MEMBER_SIZE_8:
+            lc =  0x70000000;
+            break;
+        case SERIALIZED_MEMBER_SIZE_4:
+            lc =  0x60000000;
+            break;
+        case SERIALIZED_MEMBER_SIZE:
+            lc = 0x50000000;
+            break;
+        default:
+            break;
+    }
+
+    return lc;
+}
+
+inline uint32_t Cdr::get_short_lc(
+        size_t member_serialized_size)
+{
+    uint32_t lc = 0x0;
+    switch (member_serialized_size)
+    {
+        case 2:
+            lc = 0x10000000;
+            break;
+        case 4:
+            lc = 0x20000000;
+            break;
+        case 8:
+            lc = 0x30000000;
+            break;
+        default:
+            break;
+    }
+
+    return lc;
+}
+
+Cdr::state::state(
+        const Cdr& cdr)
+    : offset_(cdr.offset_)
+    , origin_(cdr.origin_)
+    , swap_bytes_(cdr.swap_bytes_)
+    , last_data_size_(cdr.last_data_size_)
+    , next_member_id_(cdr.next_member_id_)
+    , previous_encoding_(cdr.current_encoding_)
 {
 }
 
-Cdr::state::state(const state& current_state)
-  : m_currentPosition(current_state.m_currentPosition)
-  , m_alignPosition(current_state.m_alignPosition)
-  , m_swapBytes(current_state.m_swapBytes)
-  , m_lastDataSize(current_state.m_lastDataSize)
+Cdr::state::state(
+        const state& current_state)
+    : offset_(current_state.offset_)
+    , origin_(current_state.origin_)
+    , swap_bytes_(current_state.swap_bytes_)
+    , last_data_size_(current_state.last_data_size_)
+    , next_member_id_(current_state.next_member_id_)
+    , previous_encoding_(current_state.previous_encoding_)
 {
 }
 
-Cdr::Cdr(FastBuffer& cdrBuffer, const Endianness endianness, const CdrType cdrType)
-  : m_cdrBuffer(cdrBuffer)
-  , m_cdrType(cdrType)
-  , m_plFlag(DDS_CDR_WITHOUT_PL)
-  , m_options(0)
-  , m_endianness(static_cast<uint8_t>(endianness))
-  , m_swapBytes(endianness == DEFAULT_ENDIAN ? false : true)
-  , m_lastDataSize(0)
-  , m_currentPosition(cdrBuffer.begin())
-  , m_alignPosition(cdrBuffer.begin())
-  , m_lastPosition(cdrBuffer.end())
+bool Cdr::state::operator ==(
+        const Cdr::state& other_state) const
 {
+    return
+        other_state.offset_ == offset_ &&
+        other_state.origin_ == origin_ &&
+        other_state.swap_bytes_ == swap_bytes_ &&
+        (0 == other_state.last_data_size_ ||
+        0 == last_data_size_ ||
+        other_state.last_data_size_ == last_data_size_
+        );
+}
+
+Cdr::Cdr(
+        FastBuffer& cdr_buffer,
+        const Endianness endianness,
+        const CdrVersion cdr_version)
+    : cdr_buffer_(cdr_buffer)
+    , cdr_version_(cdr_version)
+    , endianness_(endianness)
+    , swap_bytes_(endianness == DEFAULT_ENDIAN ? false : true)
+    , offset_(cdr_buffer.begin())
+    , origin_(cdr_buffer.begin())
+    , end_(cdr_buffer.end())
+{
+    switch (cdr_version_)
+    {
+        case CdrVersion::XCDRv2:
+            break;
+        case CdrVersion::XCDRv1:
+            align64_ = 8;
+            encoding_flag_ = EncodingAlgorithmFlag::PLAIN_CDR;
+            current_encoding_ = EncodingAlgorithmFlag::PLAIN_CDR;
+            break;
+        default:
+            align64_ = 8;
+            encoding_flag_ = EncodingAlgorithmFlag::PLAIN_CDR;
+            current_encoding_ = EncodingAlgorithmFlag::PLAIN_CDR;
+            break;
+    }
+    reset_callbacks();
+}
+
+void Cdr::reset_callbacks()
+{
+    switch (cdr_version_)
+    {
+        case CdrVersion::XCDRv2:
+            begin_serialize_member_ = &Cdr::xcdr2_begin_serialize_member;
+            end_serialize_member_ = &Cdr::xcdr2_end_serialize_member;
+            begin_serialize_opt_member_ = &Cdr::xcdr2_begin_serialize_member;
+            end_serialize_opt_member_ = &Cdr::xcdr2_end_serialize_member;
+            begin_serialize_type_ = &Cdr::xcdr2_begin_serialize_type;
+            end_serialize_type_ = &Cdr::xcdr2_end_serialize_type;
+            deserialize_type_ = &Cdr::xcdr2_deserialize_type;
+            break;
+        case CdrVersion::XCDRv1:
+            begin_serialize_member_ = &Cdr::xcdr1_begin_serialize_member;
+            end_serialize_member_ = &Cdr::xcdr1_end_serialize_member;
+            begin_serialize_opt_member_ = &Cdr::xcdr1_begin_serialize_opt_member;
+            end_serialize_opt_member_ = &Cdr::xcdr1_end_serialize_opt_member;
+            begin_serialize_type_ = &Cdr::xcdr1_begin_serialize_type;
+            end_serialize_type_ = &Cdr::xcdr1_end_serialize_type;
+            deserialize_type_ = &Cdr::xcdr1_deserialize_type;
+            break;
+        default:
+            begin_serialize_member_ = &Cdr::cdr_begin_serialize_member;
+            end_serialize_member_ = &Cdr::cdr_end_serialize_member;
+            begin_serialize_opt_member_ = &Cdr::cdr_begin_serialize_member;
+            end_serialize_opt_member_ = &Cdr::cdr_end_serialize_member;
+            begin_serialize_type_ = &Cdr::cdr_begin_serialize_type;
+            end_serialize_type_ = &Cdr::cdr_end_serialize_type;
+            deserialize_type_ = &Cdr::cdr_deserialize_type;
+            break;
+    }
 }
 
 Cdr& Cdr::read_encapsulation()
 {
-  uint8_t dummy = 0, encapsulationKind = 0;
-  state state_before_error(*this);
+    uint8_t dummy {0};
+    uint8_t encapsulation {0};
+    state state_before_error(*this);
 
-  try
-  {
-    // If it is DDS_CDR, the first step is to get the dummy byte.
-    if (m_cdrType == DDS_CDR)
+    try
     {
-      (*this) >> dummy;
-      if (0 != dummy)
-      {
-        throw BadParamException("Unexpected non-zero initial byte received in "
-                                "Cdr::read_encapsulation");
-      }
+        // If it is DDS_CDR, the first step is to get the dummy byte.
+        if (CdrVersion::CORBA_CDR < cdr_version_)
+        {
+            (*this) >> dummy;
+            if (0 != dummy)
+            {
+                throw BadParamException("Unexpected non-zero initial byte received in Cdr::read_encapsulation");
+            }
+        }
+
+        // Get the ecampsulation byte.
+        (*this) >> encapsulation;
+
+
+        // If it is a different endianness, make changes.
+        const uint8_t endianness = encapsulation & 0x1_8u;
+        if (endianness_ != endianness)
+        {
+            swap_bytes_ = !swap_bytes_;
+            endianness_ = endianness;
+        }
+
+        // Check encapsulationKind correctness
+        const uint8_t encoding_flag = encapsulation & static_cast<uint8_t>(~0x1);
+        switch (encoding_flag)
+        {
+            case EncodingAlgorithmFlag::PLAIN_CDR2:
+            case EncodingAlgorithmFlag::DELIMIT_CDR2:
+            case EncodingAlgorithmFlag::PL_CDR2:
+                if (CdrVersion::XCDRv1 <= cdr_version_)
+                {
+                    cdr_version_ = CdrVersion::XCDRv2;
+                    align64_ = 4;
+                }
+                else
+                {
+                    throw BadParamException(
+                              "Unexpected encoding algorithm received in Cdr::read_encapsulation. XCDRv2 should be selected.");
+                }
+                break;
+            case EncodingAlgorithmFlag::PL_CDR:
+                if (CdrVersion::XCDRv1 <= cdr_version_)
+                {
+                    cdr_version_ = CdrVersion::XCDRv1;
+                    align64_ = 8;
+                }
+                else
+                {
+                    throw BadParamException(
+                              "Unexpected encoding algorithm received in Cdr::read_encapsulation. XCDRv1 should be selected");
+                }
+                break;
+            case EncodingAlgorithmFlag::PLAIN_CDR:
+                if (CdrVersion::XCDRv1 <= cdr_version_)
+                {
+                    cdr_version_ = CdrVersion::XCDRv1;
+                    align64_ = 8;
+                }
+                break;
+            default:
+                throw BadParamException("Unexpected encoding algorithm received in Cdr::read_encapsulation for DDS CDR");
+        }
+        reset_callbacks();
+
+        encoding_flag_ = static_cast<EncodingAlgorithmFlag>(encoding_flag);
+        current_encoding_ = encoding_flag_;
+
+        if (CdrVersion::CORBA_CDR < cdr_version_)
+        {
+            deserialize(options_);
+        }
+    }
+    catch (Exception& ex)
+    {
+        set_state(state_before_error);
+        ex.raise();
     }
 
-    // Get the ecampsulation byte.
-    (*this) >> encapsulationKind;
-
-    // If it is a different endianness, make changes.
-    if (m_endianness != (encapsulationKind & 0x1))
-    {
-      m_swapBytes = !m_swapBytes;
-      m_endianness = (encapsulationKind & 0x1);
-    }
-
-    // Check encapsulationKind correctness
-    uint8_t allowed_kind_mask = LITTLE_ENDIANNESS;
-    if (m_cdrType == DDS_CDR)
-    {
-      allowed_kind_mask |= DDS_CDR_WITH_PL;
-    }
-
-    if (0 != (encapsulationKind & ~allowed_kind_mask))
-    {
-      throw BadParamException("Unexpected CDR type received in Cdr::read_encapsulation");
-    }
-
-    // If it is DDS_CDR type, view if contains a parameter list.
-    if ((encapsulationKind & DDS_CDR_WITH_PL) && ((m_cdrType == DDS_CDR)))
-    {
-      m_plFlag = DDS_CDR_WITH_PL;
-    }
-
-    if (m_cdrType == DDS_CDR)
-    {
-      (*this) >> m_options;
-    }
-  }
-  catch (Exception& ex)
-  {
-    setState(state_before_error);
-    ex.raise();
-  }
-
-  resetAlignment();
-  return *this;
+    reset_alignment();
+    return *this;
 }
 
 Cdr& Cdr::serialize_encapsulation()
 {
-  uint8_t dummy = 0, encapsulationKind = 0;
-  state state_before_error(*this);
+    uint8_t dummy = 0;
+    uint8_t encapsulation = 0;
+    state state_before_error(*this);
 
-  try
-  {
-    // If it is DDS_CDR, the first step is to serialize the dummy byte.
-    if (m_cdrType == DDS_CDR)
+    try
     {
-      (*this) << dummy;
+        // If it is DDS_CDR, the first step is to serialize the dummy byte.
+        if (CdrVersion::CORBA_CDR < cdr_version_)
+        {
+            (*this) << dummy;
+        }
+
+        // Construct encapsulation byte.
+        encapsulation = (encoding_flag_ | endianness_);
+
+        // Serialize the encapsulation byte.
+        (*this) << encapsulation;
+
+        current_encoding_ = encoding_flag_;
+    }
+    catch (Exception& ex)
+    {
+        set_state(state_before_error);
+        ex.raise();
     }
 
-    // Construct encapsulation byte.
-    encapsulationKind = (static_cast<uint8_t>(m_plFlag) | m_endianness);
-
-    // Serialize the encapsulation byte.
-    (*this) << encapsulationKind;
-  }
-  catch (Exception& ex)
-  {
-    setState(state_before_error);
-    ex.raise();
-  }
-
-  try
-  {
-    if (m_cdrType == DDS_CDR)
+    try
     {
-      (*this) << m_options;
+        if (CdrVersion::CORBA_CDR < cdr_version_)
+        {
+            serialize(options_);
+        }
     }
-  }
-  catch (Exception& ex)
-  {
-    setState(state_before_error);
-    ex.raise();
-  }
+    catch (Exception& ex)
+    {
+        set_state(state_before_error);
+        ex.raise();
+    }
 
-  resetAlignment();
-  return *this;
+    reset_alignment();
+    return *this;
 }
 
-Cdr::DDSCdrPlFlag Cdr::getDDSCdrPlFlag() const
+CdrVersion Cdr::get_cdr_version() const
 {
-  return m_plFlag;
+    return cdr_version_;
 }
 
-void Cdr::setDDSCdrPlFlag(DDSCdrPlFlag plFlag)
+EncodingAlgorithmFlag Cdr::get_encoding_flag() const
 {
-  m_plFlag = plFlag;
+    return encoding_flag_;
 }
 
-uint16_t Cdr::getDDSCdrOptions() const
+bool Cdr::set_encoding_flag(
+        EncodingAlgorithmFlag encoding_flag)
 {
-  return m_options;
+    bool ret_value = false;
+
+    if (CdrVersion::CORBA_CDR != cdr_version_)
+    {
+        if (offset_ == cdr_buffer_.begin())
+        {
+            encoding_flag_ = encoding_flag;
+            ret_value = true;
+        }
+    }
+
+    return ret_value;
 }
 
-void Cdr::setDDSCdrOptions(uint16_t options)
+std::array<uint8_t, 2> Cdr::get_dds_cdr_options() const
 {
-  m_options = options;
+    return options_;
 }
 
-void Cdr::changeEndianness(Endianness endianness)
+void Cdr::set_dds_cdr_options(
+        const std::array<uint8_t, 2>& options)
 {
-  if (m_endianness != endianness)
-  {
-    m_swapBytes = !m_swapBytes;
-    m_endianness = endianness;
-  }
+    options_ = options;
 }
 
-bool Cdr::jump(size_t numBytes)
+void Cdr::change_endianness(
+        Endianness endianness)
 {
-  bool returnedValue = false;
-
-  if (((m_lastPosition - m_currentPosition) >= numBytes) || resize(numBytes))
-  {
-    m_currentPosition += numBytes;
-    returnedValue = true;
-  }
-
-  return returnedValue;
+    if (endianness_ != endianness)
+    {
+        swap_bytes_ = !swap_bytes_;
+        endianness_ = endianness;
+    }
 }
 
-char* Cdr::getBufferPointer()
+Cdr::Endianness Cdr::endianness() const
 {
-  return m_cdrBuffer.getBuffer();
+    return static_cast<Endianness>(endianness_);
 }
 
-char* Cdr::getCurrentPosition()
+bool Cdr::jump(
+        size_t num_bytes)
 {
-  return &m_currentPosition;
+    bool ret_value = false;
+
+    if (((end_ - offset_) >= num_bytes) || resize(num_bytes))
+    {
+        offset_ += num_bytes;
+        last_data_size_ = 0;
+        ret_value = true;
+    }
+
+    return ret_value;
 }
 
-Cdr::state Cdr::getState()
+char* Cdr::get_buffer_pointer()
 {
-  return Cdr::state(*this);
+    return cdr_buffer_.getBuffer();
 }
 
-void Cdr::setState(state& current_state)
+char* Cdr::get_current_position()
 {
-  m_currentPosition >> current_state.m_currentPosition;
-  m_alignPosition >> current_state.m_alignPosition;
-  m_swapBytes = current_state.m_swapBytes;
-  m_lastDataSize = current_state.m_lastDataSize;
+    return &offset_;
+}
+
+size_t Cdr::get_serialized_data_length() const
+{
+    return offset_ - cdr_buffer_.begin();
+}
+
+Cdr::state Cdr::get_state() const
+{
+    return Cdr::state(*this);
+}
+
+void Cdr::set_state(
+        const state& current_state)
+{
+    offset_ >> current_state.offset_;
+    origin_ >> current_state.origin_;
+    swap_bytes_ = current_state.swap_bytes_;
+    last_data_size_ = current_state.last_data_size_;
+    next_member_id_ = current_state.next_member_id_;
 }
 
 void Cdr::reset()
 {
-  m_currentPosition = m_cdrBuffer.begin();
-  m_alignPosition = m_cdrBuffer.begin();
-  m_swapBytes = m_endianness == DEFAULT_ENDIAN ? false : true;
-  m_lastDataSize = 0;
+    offset_ = cdr_buffer_.begin();
+    origin_ = cdr_buffer_.begin();
+    swap_bytes_ = endianness_ == DEFAULT_ENDIAN ? false : true;
+    last_data_size_ = 0;
+    encoding_flag_ = CdrVersion::XCDRv2 ==
+            cdr_version_ ? EncodingAlgorithmFlag::PLAIN_CDR2 : EncodingAlgorithmFlag::PLAIN_CDR;
+    current_encoding_ = encoding_flag_;
+    next_member_id_ = MEMBER_ID_INVALID;
+    options_ = {0, 0};
 }
 
-bool Cdr::moveAlignmentForward(size_t numBytes)
+bool Cdr::move_alignment_forward(
+        size_t num_bytes)
 {
-  bool returnedValue = false;
+    bool ret_value = false;
 
-  if (((m_lastPosition - m_alignPosition) >= numBytes) || resize(numBytes))
-  {
-    m_alignPosition += numBytes;
-    returnedValue = true;
-  }
-
-  return returnedValue;
-}
-
-bool Cdr::resize(size_t minSizeInc)
-{
-  if (m_cdrBuffer.resize(minSizeInc))
-  {
-    m_currentPosition << m_cdrBuffer.begin();
-    m_alignPosition << m_cdrBuffer.begin();
-    m_lastPosition = m_cdrBuffer.end();
-    return true;
-  }
-
-  return false;
-}
-
-Cdr& Cdr::serialize(const char char_t)
-{
-  if (((m_lastPosition - m_currentPosition) >= sizeof(char_t)) || resize(sizeof(char_t)))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(char_t);
-
-    m_currentPosition++ << char_t;
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-Cdr& Cdr::serialize(const int16_t short_t)
-{
-  size_t align = alignment(sizeof(short_t));
-  size_t sizeAligned = sizeof(short_t) + align;
-
-  if (((m_lastPosition - m_currentPosition) >= sizeAligned) || resize(sizeAligned))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(short_t);
-
-    // Align.
-    makeAlign(align);
-
-    if (m_swapBytes)
+    if (((end_ - origin_) >= num_bytes) || resize(num_bytes))
     {
-      const char* dst = reinterpret_cast<const char*>(&short_t);
-
-      m_currentPosition++ << dst[1];
-      m_currentPosition++ << dst[0];
-    }
-    else
-    {
-      m_currentPosition << short_t;
-      m_currentPosition += sizeof(short_t);
+        origin_ += num_bytes;
+        last_data_size_ = 0;
+        ret_value = true;
     }
 
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    return ret_value;
 }
 
-Cdr& Cdr::serialize(const int16_t short_t, Endianness endianness)
+bool Cdr::resize(
+        size_t min_size_inc)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    serialize(short_t);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::serialize(const int32_t long_t)
-{
-  size_t align = alignment(sizeof(long_t));
-  size_t sizeAligned = sizeof(long_t) + align;
-
-  if (((m_lastPosition - m_currentPosition) >= sizeAligned) || resize(sizeAligned))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(long_t);
-
-    // Align.
-    makeAlign(align);
-
-    if (m_swapBytes)
+    if (cdr_buffer_.resize(min_size_inc))
     {
-      const char* dst = reinterpret_cast<const char*>(&long_t);
-
-      m_currentPosition++ << dst[3];
-      m_currentPosition++ << dst[2];
-      m_currentPosition++ << dst[1];
-      m_currentPosition++ << dst[0];
-    }
-    else
-    {
-      m_currentPosition << long_t;
-      m_currentPosition += sizeof(long_t);
+        offset_ << cdr_buffer_.begin();
+        origin_ << cdr_buffer_.begin();
+        end_ = cdr_buffer_.end();
+        return true;
     }
 
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    return false;
 }
 
-Cdr& Cdr::serialize(const int32_t long_t, Endianness endianness)
+Cdr& Cdr::serialize(
+        const char char_t)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    serialize(long_t);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::serialize(const int64_t longlong_t)
-{
-  size_t align = alignment(sizeof(longlong_t));
-  size_t sizeAligned = sizeof(longlong_t) + align;
-
-  if (((m_lastPosition - m_currentPosition) >= sizeAligned) || resize(sizeAligned))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(longlong_t);
-
-    // Align.
-    makeAlign(align);
-
-    if (m_swapBytes)
+    if (((end_ - offset_) >= sizeof(char_t)) || resize(sizeof(char_t)))
     {
-      const char* dst = reinterpret_cast<const char*>(&longlong_t);
+        // Save last datasize.
+        last_data_size_ = sizeof(char_t);
 
-      m_currentPosition++ << dst[7];
-      m_currentPosition++ << dst[6];
-      m_currentPosition++ << dst[5];
-      m_currentPosition++ << dst[4];
-      m_currentPosition++ << dst[3];
-      m_currentPosition++ << dst[2];
-      m_currentPosition++ << dst[1];
-      m_currentPosition++ << dst[0];
-    }
-    else
-    {
-      m_currentPosition << longlong_t;
-      m_currentPosition += sizeof(longlong_t);
+        offset_++ << char_t;
+        return *this;
     }
 
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::serialize(const int64_t longlong_t, Endianness endianness)
+Cdr& Cdr::serialize(
+        const int16_t short_t)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
+    size_t align = alignment(sizeof(short_t));
+    size_t size_aligned = sizeof(short_t) + align;
 
-  try
-  {
-    serialize(longlong_t);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::serialize(const float float_t)
-{
-  size_t align = alignment(sizeof(float_t));
-  size_t sizeAligned = sizeof(float_t) + align;
-
-  if (((m_lastPosition - m_currentPosition) >= sizeAligned) || resize(sizeAligned))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(float_t);
-
-    // Align.
-    makeAlign(align);
-
-    if (m_swapBytes)
+    if (((end_ - offset_) >= size_aligned) || resize(size_aligned))
     {
-      const char* dst = reinterpret_cast<const char*>(&float_t);
+        // Save last datasize.
+        last_data_size_ = sizeof(short_t);
 
-      m_currentPosition++ << dst[3];
-      m_currentPosition++ << dst[2];
-      m_currentPosition++ << dst[1];
-      m_currentPosition++ << dst[0];
-    }
-    else
-    {
-      m_currentPosition << float_t;
-      m_currentPosition += sizeof(float_t);
+        // Align.
+        make_alignment(align);
+
+        if (swap_bytes_)
+        {
+            const char* dst = reinterpret_cast<const char*>(&short_t);
+
+            offset_++ << dst[1];
+            offset_++ << dst[0];
+        }
+        else
+        {
+            offset_ << short_t;
+            offset_ += sizeof(short_t);
+        }
+
+        return *this;
     }
 
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::serialize(const float float_t, Endianness endianness)
+Cdr& Cdr::serialize(
+        const int32_t long_t)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
+    size_t align = alignment(sizeof(long_t));
+    size_t size_aligned = sizeof(long_t) + align;
 
-  try
-  {
-    serialize(float_t);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::serialize(const double double_t)
-{
-  size_t align = alignment(sizeof(double_t));
-  size_t sizeAligned = sizeof(double_t) + align;
-
-  if (((m_lastPosition - m_currentPosition) >= sizeAligned) || resize(sizeAligned))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(double_t);
-
-    // Align.
-    makeAlign(align);
-
-    if (m_swapBytes)
+    if (((end_ - offset_) >= size_aligned) || resize(size_aligned))
     {
-      const char* dst = reinterpret_cast<const char*>(&double_t);
+        // Save last datasize.
+        last_data_size_ = sizeof(long_t);
 
-      m_currentPosition++ << dst[7];
-      m_currentPosition++ << dst[6];
-      m_currentPosition++ << dst[5];
-      m_currentPosition++ << dst[4];
-      m_currentPosition++ << dst[3];
-      m_currentPosition++ << dst[2];
-      m_currentPosition++ << dst[1];
-      m_currentPosition++ << dst[0];
-    }
-    else
-    {
-      m_currentPosition << double_t;
-      m_currentPosition += sizeof(double_t);
+        // Align.
+        make_alignment(align);
+
+        if (swap_bytes_)
+        {
+            const char* dst = reinterpret_cast<const char*>(&long_t);
+
+            offset_++ << dst[3];
+            offset_++ << dst[2];
+            offset_++ << dst[1];
+            offset_++ << dst[0];
+        }
+        else
+        {
+            offset_ << long_t;
+            offset_ += sizeof(long_t);
+        }
+
+        return *this;
     }
 
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::serialize(const double double_t, Endianness endianness)
+Cdr& Cdr::serialize(
+        const int64_t longlong_t)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
+    size_t align = alignment(align64_);
+    size_t size_aligned = sizeof(longlong_t) + align;
 
-  try
-  {
-    serialize(double_t);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::serialize(const long double ldouble_t)
-{
-  size_t align = alignment(ALIGNMENT_LONG_DOUBLE);
-  size_t sizeAligned = sizeof(ldouble_t) + align;
-
-  if (((m_lastPosition - m_currentPosition) >= sizeAligned) || resize(sizeAligned))
-  {
-    // Save last datasize.
-    m_lastDataSize = 16;  // sizeof(ldouble_t);
-
-    // Align.
-    makeAlign(align);
-
-    if (m_swapBytes)
+    if (((end_ - offset_) >= size_aligned) || resize(size_aligned))
     {
+        // Save last datasize.
+        last_data_size_ = align64_;
+
+        // Align.
+        make_alignment(align);
+
+        if (swap_bytes_)
+        {
+            const char* dst = reinterpret_cast<const char*>(&longlong_t);
+
+            offset_++ << dst[7];
+            offset_++ << dst[6];
+            offset_++ << dst[5];
+            offset_++ << dst[4];
+            offset_++ << dst[3];
+            offset_++ << dst[2];
+            offset_++ << dst[1];
+            offset_++ << dst[0];
+        }
+        else
+        {
+            offset_ << longlong_t;
+            offset_ += sizeof(longlong_t);
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::serialize(
+        const float float_t)
+{
+    size_t align = alignment(sizeof(float_t));
+    size_t size_aligned = sizeof(float_t) + align;
+
+    if (((end_ - offset_) >= size_aligned) || resize(size_aligned))
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(float_t);
+
+        // Align.
+        make_alignment(align);
+
+        if (swap_bytes_)
+        {
+            const char* dst = reinterpret_cast<const char*>(&float_t);
+
+            offset_++ << dst[3];
+            offset_++ << dst[2];
+            offset_++ << dst[1];
+            offset_++ << dst[0];
+        }
+        else
+        {
+            offset_ << float_t;
+            offset_ += sizeof(float_t);
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::serialize(
+        const double double_t)
+{
+    size_t align = alignment(align64_);
+    size_t size_aligned = sizeof(double_t) + align;
+
+    if (((end_ - offset_) >= size_aligned) || resize(size_aligned))
+    {
+        // Save last datasize.
+        last_data_size_ = align64_;
+
+        // Align.
+        make_alignment(align);
+
+        if (swap_bytes_)
+        {
+            const char* dst = reinterpret_cast<const char*>(&double_t);
+
+            offset_++ << dst[7];
+            offset_++ << dst[6];
+            offset_++ << dst[5];
+            offset_++ << dst[4];
+            offset_++ << dst[3];
+            offset_++ << dst[2];
+            offset_++ << dst[1];
+            offset_++ << dst[0];
+        }
+        else
+        {
+            offset_ << double_t;
+            offset_ += sizeof(double_t);
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::serialize(
+        const long double ldouble_t)
+{
+    size_t align = alignment(align64_);
+    size_t size_aligned = sizeof(ldouble_t) + align;
+
+    if (((end_ - offset_) >= size_aligned) || resize(size_aligned))
+    {
+        // Save last datasize.
+        last_data_size_ = align64_;
+
+        // Align.
+        make_alignment(align);
+
+        if (swap_bytes_)
+        {
 #if FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
-      __float128 tmp = ldouble_t;
-      const char* dst = reinterpret_cast<const char*>(&tmp);
+            __float128 tmp = ldouble_t;
+            const char* dst = reinterpret_cast<const char*>(&tmp);
 #else
-      const char* dst = reinterpret_cast<const char*>(&ldouble_t);
-#endif  // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+            const char* dst = reinterpret_cast<const char*>(&ldouble_t);
+#endif // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
 #if FASTCDR_HAVE_FLOAT128 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
-      m_currentPosition++ << dst[15];
-      m_currentPosition++ << dst[14];
-      m_currentPosition++ << dst[13];
-      m_currentPosition++ << dst[12];
-      m_currentPosition++ << dst[11];
-      m_currentPosition++ << dst[10];
-      m_currentPosition++ << dst[9];
-      m_currentPosition++ << dst[8];
-      m_currentPosition++ << dst[7];
-      m_currentPosition++ << dst[6];
-      m_currentPosition++ << dst[5];
-      m_currentPosition++ << dst[4];
-      m_currentPosition++ << dst[3];
-      m_currentPosition++ << dst[2];
-      m_currentPosition++ << dst[1];
-      m_currentPosition++ << dst[0];
+            offset_++ << dst[15];
+            offset_++ << dst[14];
+            offset_++ << dst[13];
+            offset_++ << dst[12];
+            offset_++ << dst[11];
+            offset_++ << dst[10];
+            offset_++ << dst[9];
+            offset_++ << dst[8];
+            offset_++ << dst[7];
+            offset_++ << dst[6];
+            offset_++ << dst[5];
+            offset_++ << dst[4];
+            offset_++ << dst[3];
+            offset_++ << dst[2];
+            offset_++ << dst[1];
+            offset_++ << dst[0];
 #else
 #if FASTCDR_SIZEOF_LONG_DOUBLE == 8
-      // Filled with 0's.
-      m_currentPosition++ << static_cast<char>(0);
-      m_currentPosition++ << static_cast<char>(0);
-      m_currentPosition++ << static_cast<char>(0);
-      m_currentPosition++ << static_cast<char>(0);
-      m_currentPosition++ << static_cast<char>(0);
-      m_currentPosition++ << static_cast<char>(0);
-      m_currentPosition++ << static_cast<char>(0);
-      m_currentPosition++ << static_cast<char>(0);
-      m_currentPosition++ << dst[7];
-      m_currentPosition++ << dst[6];
-      m_currentPosition++ << dst[5];
-      m_currentPosition++ << dst[4];
-      m_currentPosition++ << dst[3];
-      m_currentPosition++ << dst[2];
-      m_currentPosition++ << dst[1];
-      m_currentPosition++ << dst[0];
+            // Filled with 0's.
+            offset_++ << static_cast<char>(0);
+            offset_++ << static_cast<char>(0);
+            offset_++ << static_cast<char>(0);
+            offset_++ << static_cast<char>(0);
+            offset_++ << static_cast<char>(0);
+            offset_++ << static_cast<char>(0);
+            offset_++ << static_cast<char>(0);
+            offset_++ << static_cast<char>(0);
+            offset_++ << dst[7];
+            offset_++ << dst[6];
+            offset_++ << dst[5];
+            offset_++ << dst[4];
+            offset_++ << dst[3];
+            offset_++ << dst[2];
+            offset_++ << dst[1];
+            offset_++ << dst[0];
 #else
 #error unsupported long double type and no __float128 available
-#endif  // FASTCDR_SIZEOF_LONG_DOUBLE == 8
-#endif  // FASTCDR_HAVE_FLOAT128 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
+#endif // FASTCDR_SIZEOF_LONG_DOUBLE == 8
+#endif // FASTCDR_HAVE_FLOAT128 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
+        }
+        else
+        {
+#if FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+            __float128 tmp = ldouble_t;
+            offset_ << tmp;
+            offset_ += 16;
+#else
+#if FASTCDR_SIZEOF_LONG_DOUBLE == 8
+            offset_ << static_cast<long double>(0);
+            offset_ += sizeof(ldouble_t);
+#endif // FASTCDR_SIZEOF_LONG_DOUBLE == 8
+#if FASTCDR_SIZEOF_LONG_DOUBLE == 8 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
+            offset_ << ldouble_t;
+            offset_ += sizeof(ldouble_t);
+#else
+#error unsupported long double type and no __float128 available
+#endif // FASTCDR_SIZEOF_LONG_DOUBLE == 8 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
+#endif // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::serialize(
+        const bool bool_t)
+{
+    if (((end_ - offset_) >= sizeof(uint8_t)) || resize(sizeof(uint8_t)))
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(uint8_t);
+
+        if (bool_t)
+        {
+            offset_++ << static_cast<uint8_t>(1);
+        }
+        else
+        {
+            offset_++ << static_cast<uint8_t>(0);
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::serialize(
+        const char* string_t)
+{
+    uint32_t length = 0;
+
+    if (string_t != nullptr)
+    {
+        length = size_to_uint32(strlen(string_t)) + 1;
+    }
+
+    if (length > 0)
+    {
+        Cdr::state state_before_error(*this);
+        serialize(length);
+
+        if (((end_ - offset_) >= length) || resize(length))
+        {
+            // Save last datasize.
+            last_data_size_ = sizeof(uint8_t);
+
+            offset_.memcopy(string_t, length);
+            offset_ += length;
+        }
+        else
+        {
+            set_state(state_before_error);
+            throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        }
     }
     else
     {
+        serialize(length);
+    }
+
+    serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
+
+    return *this;
+}
+
+Cdr& Cdr::serialize(
+        const wchar_t* string_t)
+{
+    uint32_t bytes_length = 0;
+    size_t wstrlen = 0;
+
+    if (string_t != nullptr)
+    {
+        wstrlen = wcslen(string_t);
+        bytes_length = size_to_uint32(wstrlen * 2);
+    }
+
+    if (bytes_length > 0)
+    {
+        Cdr::state state_(*this);
+        serialize(size_to_uint32(wstrlen));
+
+        if (((end_ - offset_) >= bytes_length) || resize(bytes_length))
+        {
+            serialize_array(string_t, wstrlen);
+        }
+        else
+        {
+            set_state(state_);
+            throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        }
+    }
+    else
+    {
+        serialize(bytes_length);
+    }
+
+    return *this;
+}
+
+Cdr& Cdr::serialize_array(
+        const bool* bool_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*bool_t) * num_elements;
+
+    if (((end_ - offset_) >= total_size) || resize(total_size))
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(*bool_t);
+
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            uint8_t value = 0;
+
+            if (bool_t[count])
+            {
+                value = 1;
+            }
+            offset_++ << value;
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::serialize_array(
+        const char* char_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*char_t) * num_elements;
+
+    if (((end_ - offset_) >= total_size) || resize(total_size))
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(*char_t);
+
+        offset_.memcopy(char_t, total_size);
+        offset_ += total_size;
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::serialize_array(
+        const int16_t* short_t,
+        size_t num_elements)
+{
+    if (num_elements == 0)
+    {
+        return *this;
+    }
+
+    size_t align = alignment(sizeof(*short_t));
+    size_t total_size = sizeof(*short_t) * num_elements;
+    size_t size_aligned = total_size + align;
+
+    if (((end_ - offset_) >= size_aligned) || resize(size_aligned))
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(*short_t);
+
+        // Align if there are any elements
+        if (num_elements)
+        {
+            make_alignment(align);
+        }
+
+        if (swap_bytes_)
+        {
+            const char* dst = reinterpret_cast<const char*>(short_t);
+            const char* end = dst + total_size;
+
+            for (; dst < end; dst += sizeof(*short_t))
+            {
+                offset_++ << dst[1];
+                offset_++ << dst[0];
+            }
+        }
+        else
+        {
+            offset_.memcopy(short_t, total_size);
+            offset_ += total_size;
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::serialize_array(
+        const int32_t* long_t,
+        size_t num_elements)
+{
+    if (num_elements == 0)
+    {
+        return *this;
+    }
+
+    size_t align = alignment(sizeof(*long_t));
+    size_t total_size = sizeof(*long_t) * num_elements;
+    size_t size_aligned = total_size + align;
+
+    if (((end_ - offset_) >= size_aligned) || resize(size_aligned))
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(*long_t);
+
+        // Align if there are any elements
+        if (num_elements)
+        {
+            make_alignment(align);
+        }
+
+        if (swap_bytes_)
+        {
+            const char* dst = reinterpret_cast<const char*>(long_t);
+            const char* end = dst + total_size;
+
+            for (; dst < end; dst += sizeof(*long_t))
+            {
+                offset_++ << dst[3];
+                offset_++ << dst[2];
+                offset_++ << dst[1];
+                offset_++ << dst[0];
+            }
+        }
+        else
+        {
+            offset_.memcopy(long_t, total_size);
+            offset_ += total_size;
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::serialize_array(
+        const wchar_t* wchar,
+        size_t num_elements)
+{
+    if (num_elements == 0)
+    {
+        return *this;
+    }
+
+    for (size_t count = 0; count < num_elements; ++count)
+    {
+        serialize(wchar[count]);
+    }
+    return *this;
+}
+
+Cdr& Cdr::serialize_array(
+        const int64_t* longlong_t,
+        size_t num_elements)
+{
+    if (num_elements == 0)
+    {
+        return *this;
+    }
+
+    size_t align = alignment(align64_);
+    size_t total_size = sizeof(*longlong_t) * num_elements;
+    size_t size_aligned = total_size + align;
+
+    if (((end_ - offset_) >= size_aligned) || resize(size_aligned))
+    {
+        // Save last datasize.
+        last_data_size_ = align64_;
+
+        // Align if there are any elements
+        if (num_elements)
+        {
+            make_alignment(align);
+        }
+
+        if (swap_bytes_)
+        {
+            const char* dst = reinterpret_cast<const char*>(longlong_t);
+            const char* end = dst + total_size;
+
+            for (; dst < end; dst += sizeof(*longlong_t))
+            {
+                offset_++ << dst[7];
+                offset_++ << dst[6];
+                offset_++ << dst[5];
+                offset_++ << dst[4];
+                offset_++ << dst[3];
+                offset_++ << dst[2];
+                offset_++ << dst[1];
+                offset_++ << dst[0];
+            }
+        }
+        else
+        {
+            offset_.memcopy(longlong_t, total_size);
+            offset_ += total_size;
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::serialize_array(
+        const float* float_t,
+        size_t num_elements)
+{
+    if (num_elements == 0)
+    {
+        return *this;
+    }
+
+    size_t align = alignment(sizeof(*float_t));
+    size_t total_size = sizeof(*float_t) * num_elements;
+    size_t size_aligned = total_size + align;
+
+    if (((end_ - offset_) >= size_aligned) || resize(size_aligned))
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(*float_t);
+
+        // Align if there are any elements
+        if (num_elements)
+        {
+            make_alignment(align);
+        }
+
+        if (swap_bytes_)
+        {
+            const char* dst = reinterpret_cast<const char*>(float_t);
+            const char* end = dst + total_size;
+
+            for (; dst < end; dst += sizeof(*float_t))
+            {
+                offset_++ << dst[3];
+                offset_++ << dst[2];
+                offset_++ << dst[1];
+                offset_++ << dst[0];
+            }
+        }
+        else
+        {
+            offset_.memcopy(float_t, total_size);
+            offset_ += total_size;
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::serialize_array(
+        const double* double_t,
+        size_t num_elements)
+{
+    if (num_elements == 0)
+    {
+        return *this;
+    }
+
+    size_t align = alignment(align64_);
+    size_t total_size = sizeof(*double_t) * num_elements;
+    size_t size_aligned = total_size + align;
+
+    if (((end_ - offset_) >= size_aligned) || resize(size_aligned))
+    {
+        // Save last datasize.
+        last_data_size_ = align64_;
+
+        // Align if there are any elements
+        if (num_elements)
+        {
+            make_alignment(align);
+        }
+
+        if (swap_bytes_)
+        {
+            const char* dst = reinterpret_cast<const char*>(double_t);
+            const char* end = dst + total_size;
+
+            for (; dst < end; dst += sizeof(*double_t))
+            {
+                offset_++ << dst[7];
+                offset_++ << dst[6];
+                offset_++ << dst[5];
+                offset_++ << dst[4];
+                offset_++ << dst[3];
+                offset_++ << dst[2];
+                offset_++ << dst[1];
+                offset_++ << dst[0];
+            }
+        }
+        else
+        {
+            offset_.memcopy(double_t, total_size);
+            offset_ += total_size;
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::serialize_array(
+        const long double* ldouble_t,
+        size_t num_elements)
+{
+    if (num_elements == 0)
+    {
+        return *this;
+    }
+
+    size_t align = alignment(align64_);
+    // Fix for Windows ( long doubles only store 8 bytes )
+    size_t total_size = 16 * num_elements; // sizeof(*ldouble_t)
+    size_t size_aligned = total_size + align;
+
+    if (((end_ - offset_) >= size_aligned) || resize(size_aligned))
+    {
+        // Save last datasize.
+        last_data_size_ = align64_;
+
+        // Align if there are any elements
+        if (num_elements)
+        {
+            make_alignment(align);
+        }
+
 #if FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
-      __float128 tmp = ldouble_t;
-      m_currentPosition << tmp;
-      m_currentPosition += 16;
+        if (swap_bytes_)
+        {
+            for (size_t i = 0; i < num_elements; ++i, ++ldouble_t)
+            {
+                __float128 tmp = *ldouble_t;
+                const char* dst = reinterpret_cast<const char*>(&tmp);
+                offset_++ << dst[15];
+                offset_++ << dst[14];
+                offset_++ << dst[13];
+                offset_++ << dst[12];
+                offset_++ << dst[11];
+                offset_++ << dst[10];
+                offset_++ << dst[9];
+                offset_++ << dst[8];
+                offset_++ << dst[7];
+                offset_++ << dst[6];
+                offset_++ << dst[5];
+                offset_++ << dst[4];
+                offset_++ << dst[3];
+                offset_++ << dst[2];
+                offset_++ << dst[1];
+                offset_++ << dst[0];
+            }
+        }
+        else
+        {
+            for (size_t i = 0; i < num_elements; ++i, ++ldouble_t)
+            {
+                __float128 tmp = *ldouble_t;
+                offset_ << tmp;
+                offset_ += 16;
+            }
+        }
 #else
-#if FASTCDR_SIZEOF_LONG_DOUBLE == 8
-      m_currentPosition << static_cast<long double>(0);
-      m_currentPosition += sizeof(ldouble_t);
-#endif  // FASTCDR_SIZEOF_LONG_DOUBLE == 8
 #if FASTCDR_SIZEOF_LONG_DOUBLE == 8 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
-      m_currentPosition << ldouble_t;
-      m_currentPosition += sizeof(ldouble_t);
+        if (swap_bytes_)
+        {
+            const char* dst = reinterpret_cast<const char*>(ldouble_t);
+            const char* end = dst + total_size;
+
+            for (; dst < end; dst += sizeof(*ldouble_t))
+            {
+#if FASTCDR_SIZEOF_LONG_DOUBLE == 16
+                offset_++ << dst[15];
+                offset_++ << dst[14];
+                offset_++ << dst[13];
+                offset_++ << dst[12];
+                offset_++ << dst[11];
+                offset_++ << dst[10];
+                offset_++ << dst[9];
+                offset_++ << dst[8];
+#else
+                offset_++ << static_cast<char>(0);
+                offset_++ << static_cast<char>(0);
+                offset_++ << static_cast<char>(0);
+                offset_++ << static_cast<char>(0);
+                offset_++ << static_cast<char>(0);
+                offset_++ << static_cast<char>(0);
+                offset_++ << static_cast<char>(0);
+                offset_++ << static_cast<char>(0);
+#endif // FASTCDR_SIZEOF_LONG_DOUBLE == 16
+                offset_++ << dst[7];
+                offset_++ << dst[6];
+                offset_++ << dst[5];
+                offset_++ << dst[4];
+                offset_++ << dst[3];
+                offset_++ << dst[2];
+                offset_++ << dst[1];
+                offset_++ << dst[0];
+            }
+        }
+        else
+        {
+#if FASTCDR_SIZEOF_LONG_DOUBLE == 16
+            offset_.memcopy(ldouble_t, total_size);
+            offset_ += total_size;
+#else
+            for (size_t i = 0; i < num_elements; ++i)
+            {
+                offset_ << static_cast<long double>(0);
+                offset_ += 8;
+                offset_ << ldouble_t[i];
+                offset_ += 8;
+            }
+#endif // FASTCDR_SIZEOF_LONG_DOUBLE == 16
+        }
 #else
 #error unsupported long double type and no __float128 available
-#endif  // FASTCDR_SIZEOF_LONG_DOUBLE == 8 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
-#endif  // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+#endif // FASTCDR_SIZEOF_LONG_DOUBLE == 8 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
+#endif // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+
+        return *this;
     }
 
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::serialize(const long double ldouble_t, Endianness endianness)
+Cdr& Cdr::deserialize(
+        char& char_t)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    serialize(ldouble_t);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::serialize(const bool bool_t)
-{
-  uint8_t value = 0;
-
-  if (((m_lastPosition - m_currentPosition) >= sizeof(uint8_t)) ||
-      resize(sizeof(uint8_t)))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(uint8_t);
-
-    if (bool_t)
+    if ((end_ - offset_) >= sizeof(char_t))
     {
-      value = 1;
+        // Save last datasize.
+        last_data_size_ = sizeof(char_t);
+
+        offset_++ >> char_t;
+        return *this;
     }
-    m_currentPosition++ << value;
 
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::serialize(const char* string_t)
+Cdr& Cdr::deserialize(
+        int16_t& short_t)
 {
-  uint32_t length = 0;
+    size_t align = alignment(sizeof(short_t));
+    size_t size_aligned = sizeof(short_t) + align;
 
-  if (string_t != nullptr)
-  {
-    length = size_to_uint32(strlen(string_t)) + 1;
-  }
+    if ((end_ - offset_) >= size_aligned)
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(short_t);
 
-  if (length > 0)
-  {
+        // Align
+        make_alignment(align);
+
+        if (swap_bytes_)
+        {
+            char* dst = reinterpret_cast<char*>(&short_t);
+
+            offset_++ >> dst[1];
+            offset_++ >> dst[0];
+        }
+        else
+        {
+            offset_ >> short_t;
+            offset_ += sizeof(short_t);
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::deserialize(
+        int32_t& long_t)
+{
+    size_t align = alignment(sizeof(long_t));
+    size_t size_aligned = sizeof(long_t) + align;
+
+    if ((end_ - offset_) >= size_aligned)
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(long_t);
+
+        // Align
+        make_alignment(align);
+
+        if (swap_bytes_)
+        {
+            char* dst = reinterpret_cast<char*>(&long_t);
+
+            offset_++ >> dst[3];
+            offset_++ >> dst[2];
+            offset_++ >> dst[1];
+            offset_++ >> dst[0];
+        }
+        else
+        {
+            offset_ >> long_t;
+            offset_ += sizeof(long_t);
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::deserialize(
+        int64_t& longlong_t)
+{
+    size_t align = alignment(align64_);
+    size_t size_aligned = sizeof(longlong_t) + align;
+
+    if ((end_ - offset_) >= size_aligned)
+    {
+        // Save last datasize.
+        last_data_size_ = align64_;
+
+        // Align.
+        make_alignment(align);
+
+        if (swap_bytes_)
+        {
+            char* dst = reinterpret_cast<char*>(&longlong_t);
+
+            offset_++ >> dst[7];
+            offset_++ >> dst[6];
+            offset_++ >> dst[5];
+            offset_++ >> dst[4];
+            offset_++ >> dst[3];
+            offset_++ >> dst[2];
+            offset_++ >> dst[1];
+            offset_++ >> dst[0];
+        }
+        else
+        {
+            offset_ >> longlong_t;
+            offset_ += sizeof(longlong_t);
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::deserialize(
+        float& float_t)
+{
+    size_t align = alignment(sizeof(float_t));
+    size_t size_aligned = sizeof(float_t) + align;
+
+    if ((end_ - offset_) >= size_aligned)
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(float_t);
+
+        // Align.
+        make_alignment(align);
+
+        if (swap_bytes_)
+        {
+            char* dst = reinterpret_cast<char*>(&float_t);
+
+            offset_++ >> dst[3];
+            offset_++ >> dst[2];
+            offset_++ >> dst[1];
+            offset_++ >> dst[0];
+        }
+        else
+        {
+            offset_ >> float_t;
+            offset_ += sizeof(float_t);
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::deserialize(
+        double& double_t)
+{
+    size_t align = alignment(align64_);
+    size_t size_aligned = sizeof(double_t) + align;
+
+    if ((end_ - offset_) >= size_aligned)
+    {
+        // Save last datasize.
+        last_data_size_ = align64_;
+
+        // Align.
+        make_alignment(align);
+
+        if (swap_bytes_)
+        {
+            char* dst = reinterpret_cast<char*>(&double_t);
+
+            offset_++ >> dst[7];
+            offset_++ >> dst[6];
+            offset_++ >> dst[5];
+            offset_++ >> dst[4];
+            offset_++ >> dst[3];
+            offset_++ >> dst[2];
+            offset_++ >> dst[1];
+            offset_++ >> dst[0];
+        }
+        else
+        {
+            offset_ >> double_t;
+            offset_ += sizeof(double_t);
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::deserialize(
+        long double& ldouble_t)
+{
+    size_t align = alignment(align64_);
+    size_t size_aligned = sizeof(ldouble_t) + align;
+
+    if ((end_ - offset_) >= size_aligned)
+    {
+        // Save last datasize.
+        last_data_size_ = align64_;
+
+        // Align.
+        make_alignment(align);
+
+        if (swap_bytes_)
+        {
+#if FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+            __float128 tmp = ldouble_t;
+            char* dst = reinterpret_cast<char*>(&tmp);
+#else
+            char* dst = reinterpret_cast<char*>(&ldouble_t);
+#endif // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+#if FASTCDR_HAVE_FLOAT128 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
+            offset_++ >> dst[15];
+            offset_++ >> dst[14];
+            offset_++ >> dst[13];
+            offset_++ >> dst[12];
+            offset_++ >> dst[11];
+            offset_++ >> dst[10];
+            offset_++ >> dst[9];
+            offset_++ >> dst[8];
+            offset_++ >> dst[7];
+            offset_++ >> dst[6];
+            offset_++ >> dst[5];
+            offset_++ >> dst[4];
+            offset_++ >> dst[3];
+            offset_++ >> dst[2];
+            offset_++ >> dst[1];
+            offset_++ >> dst[0];
+#if FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+            ldouble_t = static_cast<long double>(tmp);
+#endif // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+#else
+#if FASTCDR_SIZEOF_LONG_DOUBLE == 8
+            offset_ += 8;
+            offset_++ >> dst[7];
+            offset_++ >> dst[6];
+            offset_++ >> dst[5];
+            offset_++ >> dst[4];
+            offset_++ >> dst[3];
+            offset_++ >> dst[2];
+            offset_++ >> dst[1];
+            offset_++ >> dst[0];
+#else
+#error unsupported long double type and no __float128 available
+#endif // FASTCDR_SIZEOF_LONG_DOUBLE == 8
+#endif // FASTCDR_HAVE_FLOAT128 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
+        }
+        else
+        {
+#if FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+            __float128 tmp;
+            offset_ >> tmp;
+            offset_ += 16;
+            ldouble_t = static_cast<long double>(tmp);
+#else
+#if FASTCDR_SIZEOF_LONG_DOUBLE == 8 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
+#if FASTCDR_SIZEOF_LONG_DOUBLE == 8
+            offset_ += 8;
+#endif // FASTCDR_SIZEOF_LONG_DOUBLE == 8
+            offset_ >> ldouble_t;
+            offset_ += sizeof(ldouble_t);
+#endif // FASTCDR_SIZEOF_LONG_DOUBLE == 8 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
+#endif // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::deserialize(
+        bool& bool_t)
+{
+    uint8_t value = 0;
+
+    if ((end_ - offset_) >= sizeof(uint8_t))
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(uint8_t);
+
+        offset_++ >> value;
+
+        if (value == 1)
+        {
+            bool_t = true;
+            return *this;
+        }
+        else if (value == 0)
+        {
+            bool_t = false;
+            return *this;
+        }
+
+        throw BadParamException("Unexpected byte value in Cdr::deserialize(bool), expected 0 or 1");
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::deserialize(
+        char*& string_t)
+{
+    uint32_t length = 0;
     Cdr::state state_before_error(*this);
-    serialize(length);
 
-    if (((m_lastPosition - m_currentPosition) >= length) || resize(length))
+    deserialize(length);
+
+    if (length == 0)
     {
-      // Save last datasize.
-      m_lastDataSize = sizeof(uint8_t);
-
-      m_currentPosition.memcopy(string_t, length);
-      m_currentPosition += length;
+        string_t = nullptr;
+        return *this;
     }
-    else
+    else if ((end_ - offset_) >= length)
     {
-      setState(state_before_error);
-      throw NotEnoughMemoryException(
-          NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-    }
-  }
-  else
-  {
-    serialize(length);
-  }
+        // Save last datasize.
+        last_data_size_ = sizeof(uint8_t);
 
-  return *this;
+        // Allocate memory.
+        string_t =
+                reinterpret_cast<char*>(calloc(length + ((&offset_)[length - 1] == '\0' ? 0 : 1),
+                sizeof(char)));
+        memcpy(string_t, &offset_, length);
+        offset_ += length;
+        return *this;
+    }
+
+    set_state(state_before_error);
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::serialize(const wchar_t* string_t)
+Cdr& Cdr::deserialize(
+        wchar_t*& string_t)
 {
-  uint32_t bytesLength = 0;
-  size_t wstrlen = 0;
+    uint32_t length = 0;
+    Cdr::state state_before_error(*this);
 
-  if (string_t != nullptr)
-  {
-    wstrlen = wcslen(string_t);
-    bytesLength = size_to_uint32(wstrlen * 4);
-  }
+    deserialize(length);
 
-  if (bytesLength > 0)
-  {
-    Cdr::state state_(*this);
-    serialize(size_to_uint32(wstrlen));
-
-    if (((m_lastPosition - m_currentPosition) >= bytesLength) || resize(bytesLength))
+    if (length == 0)
     {
-      // Save last datasize.
-      m_lastDataSize = sizeof(uint32_t);
-
-#if defined(_WIN32)
-      serializeArray(string_t, wstrlen);
-#else
-      m_currentPosition.memcopy(string_t, bytesLength);
-      m_currentPosition += bytesLength;  // size on bytes
-#endif  // if defined(_WIN32)
+        string_t = nullptr;
+        return *this;
     }
-    else
+    else if ((end_ - offset_) >= (length * 2))
     {
-      setState(state_);
-      throw NotEnoughMemoryException(
-          NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-    }
-  }
-  else
-  {
-    serialize(bytesLength);
-  }
+        // Save last datasize.
+        last_data_size_ = sizeof(uint16_t);
+        // Allocate memory.
+        string_t = reinterpret_cast<wchar_t*>(calloc(length + 1, sizeof(wchar_t))); // WStrings never serialize terminating zero
 
-  return *this;
-}
-
-Cdr& Cdr::serialize(const char* string_t, Endianness endianness)
-{
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    serialize(string_t);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::serialize(const wchar_t* string_t, Endianness endianness)
-{
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    serialize(string_t);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::serializeArray(const bool* bool_t, size_t numElements)
-{
-  size_t totalSize = sizeof(*bool_t) * numElements;
-
-  if (((m_lastPosition - m_currentPosition) >= totalSize) || resize(totalSize))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(*bool_t);
-
-    for (size_t count = 0; count < numElements; ++count)
-    {
-      uint8_t value = 0;
-
-      if (bool_t[count])
-      {
-        value = 1;
-      }
-      m_currentPosition++ << value;
+        for (size_t idx = 0; idx < length; ++idx)
+        {
+            uint16_t temp;
+            offset_ >> temp;
+            string_t[idx] = static_cast<wchar_t>(temp);
+            offset_ += sizeof(uint16_t);
+        }
+        return *this;
     }
 
+    set_state(state_before_error);
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+const char* Cdr::read_string(
+        uint32_t& length)
+{
+    const char* ret_value = "";
+    state state_before_error(*this);
+
+    *this >> length;
+
+    if (length == 0)
+    {
+        return ret_value;
+    }
+    else if ((end_ - offset_) >= length)
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(uint8_t);
+
+        ret_value = &offset_;
+        offset_ += length;
+        if (ret_value[length - 1] == '\0')
+        {
+            --length;
+        }
+        return ret_value;
+    }
+
+    set_state(state_before_error);
+    throw exception::NotEnoughMemoryException(
+              exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+const std::wstring Cdr::read_wstring(
+        uint32_t& length)
+{
+    std::wstring ret_value = L"";
+    state state_(*this);
+
+    *this >> length;
+    uint32_t bytes_length = length * 2;
+
+    if (bytes_length == 0)
+    {
+        return ret_value;
+    }
+    else if ((end_ - offset_) >= bytes_length)
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(uint16_t);
+
+        ret_value.resize(length);
+        deserialize_array(const_cast<wchar_t*>(ret_value.c_str()), length);
+        if (ret_value[length - 1] == L'\0')
+        {
+            --length;
+            ret_value.erase(length);
+        }
+        return ret_value;
+    }
+
+    set_state(state_);
+    throw exception::NotEnoughMemoryException(
+              exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::deserialize_array(
+        bool* bool_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*bool_t) * num_elements;
+
+    if ((end_ - offset_) >= total_size)
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(*bool_t);
+
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            uint8_t value = 0;
+            offset_++ >> value;
+
+            if (value == 1)
+            {
+                bool_t[count] = true;
+            }
+            else if (value == 0)
+            {
+                bool_t[count] = false;
+            }
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::deserialize_array(
+        char* char_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*char_t) * num_elements;
+
+    if ((end_ - offset_) >= total_size)
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(*char_t);
+
+        offset_.rmemcopy(char_t, total_size);
+        offset_ += total_size;
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::deserialize_array(
+        int16_t* short_t,
+        size_t num_elements)
+{
+    if (num_elements == 0)
+    {
+        return *this;
+    }
+
+    size_t align = alignment(sizeof(*short_t));
+    size_t total_size = sizeof(*short_t) * num_elements;
+    size_t size_aligned = total_size + align;
+
+    if ((end_ - offset_) >= size_aligned)
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(*short_t);
+
+        // Align if there are any elements
+        if (num_elements)
+        {
+            make_alignment(align);
+        }
+
+        if (swap_bytes_)
+        {
+            char* dst = reinterpret_cast<char*>(short_t);
+            char* end = dst + total_size;
+
+            for (; dst < end; dst += sizeof(*short_t))
+            {
+                offset_++ >> dst[1];
+                offset_++ >> dst[0];
+            }
+        }
+        else
+        {
+            offset_.rmemcopy(short_t, total_size);
+            offset_ += total_size;
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::deserialize_array(
+        int32_t* long_t,
+        size_t num_elements)
+{
+    if (num_elements == 0)
+    {
+        return *this;
+    }
+
+    size_t align = alignment(sizeof(*long_t));
+    size_t total_size = sizeof(*long_t) * num_elements;
+    size_t size_aligned = total_size + align;
+
+    if ((end_ - offset_) >= size_aligned)
+    {
+        // Save last datasize.
+        last_data_size_ = sizeof(*long_t);
+
+        // Align if there are any elements
+        if (num_elements)
+        {
+            make_alignment(align);
+        }
+
+        if (swap_bytes_)
+        {
+            char* dst = reinterpret_cast<char*>(long_t);
+            char* end = dst + total_size;
+
+            for (; dst < end; dst += sizeof(*long_t))
+            {
+                offset_++ >> dst[3];
+                offset_++ >> dst[2];
+                offset_++ >> dst[1];
+                offset_++ >> dst[0];
+            }
+        }
+        else
+        {
+            offset_.rmemcopy(long_t, total_size);
+            offset_ += total_size;
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+Cdr& Cdr::deserialize_array(
+        wchar_t* wchar,
+        size_t num_elements)
+{
+    if (num_elements == 0)
+    {
+        return *this;
+    }
+
+    uint16_t value;
+    for (size_t count = 0; count < num_elements; ++count)
+    {
+        deserialize(value);
+        wchar[count] = static_cast<wchar_t>(value);
+    }
     return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::serializeArray(const char* char_t, size_t numElements)
+Cdr& Cdr::deserialize_array(
+        int64_t* longlong_t,
+        size_t num_elements)
 {
-  size_t totalSize = sizeof(*char_t) * numElements;
+    if (num_elements == 0)
+    {
+        return *this;
+    }
 
-  if (((m_lastPosition - m_currentPosition) >= totalSize) || resize(totalSize))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(*char_t);
+    size_t align = alignment(align64_);
+    size_t total_size = sizeof(*longlong_t) * num_elements;
+    size_t size_aligned = total_size + align;
 
-    m_currentPosition.memcopy(char_t, totalSize);
-    m_currentPosition += totalSize;
-    return *this;
-  }
+    if ((end_ - offset_) >= size_aligned)
+    {
+        // Save last datasize.
+        last_data_size_ = align64_;
 
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        // Align if there are any elements
+        if (num_elements)
+        {
+            make_alignment(align);
+        }
+
+        if (swap_bytes_)
+        {
+            char* dst = reinterpret_cast<char*>(longlong_t);
+            char* end = dst + total_size;
+
+            for (; dst < end; dst += sizeof(*longlong_t))
+            {
+                offset_++ >> dst[7];
+                offset_++ >> dst[6];
+                offset_++ >> dst[5];
+                offset_++ >> dst[4];
+                offset_++ >> dst[3];
+                offset_++ >> dst[2];
+                offset_++ >> dst[1];
+                offset_++ >> dst[0];
+            }
+        }
+        else
+        {
+            offset_.rmemcopy(longlong_t, total_size);
+            offset_ += total_size;
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::serializeArray(const int16_t* short_t, size_t numElements)
+Cdr& Cdr::deserialize_array(
+        float* float_t,
+        size_t num_elements)
 {
-  if (numElements == 0)
-  {
-    return *this;
-  }
-
-  size_t align = alignment(sizeof(*short_t));
-  size_t totalSize = sizeof(*short_t) * numElements;
-  size_t sizeAligned = totalSize + align;
-
-  if (((m_lastPosition - m_currentPosition) >= sizeAligned) || resize(sizeAligned))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(*short_t);
-
-    // Align if there are any elements
-    if (numElements)
+    if (num_elements == 0)
     {
-      makeAlign(align);
+        return *this;
     }
 
-    if (m_swapBytes)
+    size_t align = alignment(sizeof(*float_t));
+    size_t total_size = sizeof(*float_t) * num_elements;
+    size_t size_aligned = total_size + align;
+
+    if ((end_ - offset_) >= size_aligned)
     {
-      const char* dst = reinterpret_cast<const char*>(&short_t);
-      const char* end = dst + totalSize;
+        // Save last datasize.
+        last_data_size_ = sizeof(*float_t);
 
-      for (; dst < end; dst += sizeof(*short_t))
-      {
-        m_currentPosition++ << dst[1];
-        m_currentPosition++ << dst[0];
-      }
+        // Align if there are any elements
+        if (num_elements)
+        {
+            make_alignment(align);
+        }
+
+        if (swap_bytes_)
+        {
+            char* dst = reinterpret_cast<char*>(float_t);
+            char* end = dst + total_size;
+
+            for (; dst < end; dst += sizeof(*float_t))
+            {
+                offset_++ >> dst[3];
+                offset_++ >> dst[2];
+                offset_++ >> dst[1];
+                offset_++ >> dst[0];
+            }
+        }
+        else
+        {
+            offset_.rmemcopy(float_t, total_size);
+            offset_ += total_size;
+        }
+
+        return *this;
     }
-    else
-    {
-      m_currentPosition.memcopy(short_t, totalSize);
-      m_currentPosition += totalSize;
-    }
 
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::serializeArray(const int16_t* short_t, size_t numElements,
-                         Endianness endianness)
+Cdr& Cdr::deserialize_array(
+        double* double_t,
+        size_t num_elements)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
+    if (num_elements == 0)
+    {
+        return *this;
+    }
 
-  try
-  {
-    serializeArray(short_t, numElements);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
+    size_t align = alignment(align64_);
+    size_t total_size = sizeof(*double_t) * num_elements;
+    size_t size_aligned = total_size + align;
 
-  return *this;
+    if ((end_ - offset_) >= size_aligned)
+    {
+        // Save last datasize.
+        last_data_size_ = align64_;
+
+        // Align if there are any elements
+        if (num_elements)
+        {
+            make_alignment(align);
+        }
+
+        if (swap_bytes_)
+        {
+            char* dst = reinterpret_cast<char*>(double_t);
+            char* end = dst + total_size;
+
+            for (; dst < end; dst += sizeof(*double_t))
+            {
+                offset_++ >> dst[7];
+                offset_++ >> dst[6];
+                offset_++ >> dst[5];
+                offset_++ >> dst[4];
+                offset_++ >> dst[3];
+                offset_++ >> dst[2];
+                offset_++ >> dst[1];
+                offset_++ >> dst[0];
+            }
+        }
+        else
+        {
+            offset_.rmemcopy(double_t, total_size);
+            offset_ += total_size;
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::serializeArray(const int32_t* long_t, size_t numElements)
+Cdr& Cdr::deserialize_array(
+        long double* ldouble_t,
+        size_t num_elements)
 {
-  if (numElements == 0)
-  {
-    return *this;
-  }
-
-  size_t align = alignment(sizeof(*long_t));
-  size_t totalSize = sizeof(*long_t) * numElements;
-  size_t sizeAligned = totalSize + align;
-
-  if (((m_lastPosition - m_currentPosition) >= sizeAligned) || resize(sizeAligned))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(*long_t);
-
-    // Align if there are any elements
-    if (numElements)
+    if (num_elements == 0)
     {
-      makeAlign(align);
+        return *this;
     }
 
-    if (m_swapBytes)
+    size_t align = alignment(align64_);
+    // Fix for Windows ( long doubles only store 8 bytes )
+    size_t total_size = 16 * num_elements;
+    size_t size_aligned = total_size + align;
+
+    if ((end_ - offset_) >= size_aligned)
     {
-      const char* dst = reinterpret_cast<const char*>(&long_t);
-      const char* end = dst + totalSize;
+        // Save last datasize.
+        last_data_size_ = align64_;
 
-      for (; dst < end; dst += sizeof(*long_t))
-      {
-        m_currentPosition++ << dst[3];
-        m_currentPosition++ << dst[2];
-        m_currentPosition++ << dst[1];
-        m_currentPosition++ << dst[0];
-      }
-    }
-    else
-    {
-      m_currentPosition.memcopy(long_t, totalSize);
-      m_currentPosition += totalSize;
-    }
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-Cdr& Cdr::serializeArray(const int32_t* long_t, size_t numElements, Endianness endianness)
-{
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    serializeArray(long_t, numElements);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::serializeArray(const wchar_t* wchar, size_t numElements)
-{
-  if (numElements == 0)
-  {
-    return *this;
-  }
-
-  for (size_t count = 0; count < numElements; ++count)
-  {
-    serialize(wchar[count]);
-  }
-  return *this;
-}
-
-Cdr& Cdr::serializeArray(const wchar_t* wchar, size_t numElements, Endianness endianness)
-{
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    serializeArray(wchar, numElements);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::serializeArray(const int64_t* longlong_t, size_t numElements)
-{
-  if (numElements == 0)
-  {
-    return *this;
-  }
-
-  size_t align = alignment(sizeof(*longlong_t));
-  size_t totalSize = sizeof(*longlong_t) * numElements;
-  size_t sizeAligned = totalSize + align;
-
-  if (((m_lastPosition - m_currentPosition) >= sizeAligned) || resize(sizeAligned))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(*longlong_t);
-
-    // Align if there are any elements
-    if (numElements)
-    {
-      makeAlign(align);
-    }
-
-    if (m_swapBytes)
-    {
-      const char* dst = reinterpret_cast<const char*>(&longlong_t);
-      const char* end = dst + totalSize;
-
-      for (; dst < end; dst += sizeof(*longlong_t))
-      {
-        m_currentPosition++ << dst[7];
-        m_currentPosition++ << dst[6];
-        m_currentPosition++ << dst[5];
-        m_currentPosition++ << dst[4];
-        m_currentPosition++ << dst[3];
-        m_currentPosition++ << dst[2];
-        m_currentPosition++ << dst[1];
-        m_currentPosition++ << dst[0];
-      }
-    }
-    else
-    {
-      m_currentPosition.memcopy(longlong_t, totalSize);
-      m_currentPosition += totalSize;
-    }
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-Cdr& Cdr::serializeArray(const int64_t* longlong_t, size_t numElements,
-                         Endianness endianness)
-{
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    serializeArray(longlong_t, numElements);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::serializeArray(const float* float_t, size_t numElements)
-{
-  if (numElements == 0)
-  {
-    return *this;
-  }
-
-  size_t align = alignment(sizeof(*float_t));
-  size_t totalSize = sizeof(*float_t) * numElements;
-  size_t sizeAligned = totalSize + align;
-
-  if (((m_lastPosition - m_currentPosition) >= sizeAligned) || resize(sizeAligned))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(*float_t);
-
-    // Align if there are any elements
-    if (numElements)
-    {
-      makeAlign(align);
-    }
-
-    if (m_swapBytes)
-    {
-      const char* dst = reinterpret_cast<const char*>(&float_t);
-      const char* end = dst + totalSize;
-
-      for (; dst < end; dst += sizeof(*float_t))
-      {
-        m_currentPosition++ << dst[3];
-        m_currentPosition++ << dst[2];
-        m_currentPosition++ << dst[1];
-        m_currentPosition++ << dst[0];
-      }
-    }
-    else
-    {
-      m_currentPosition.memcopy(float_t, totalSize);
-      m_currentPosition += totalSize;
-    }
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-Cdr& Cdr::serializeArray(const float* float_t, size_t numElements, Endianness endianness)
-{
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    serializeArray(float_t, numElements);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::serializeArray(const double* double_t, size_t numElements)
-{
-  if (numElements == 0)
-  {
-    return *this;
-  }
-
-  size_t align = alignment(sizeof(*double_t));
-  size_t totalSize = sizeof(*double_t) * numElements;
-  size_t sizeAligned = totalSize + align;
-
-  if (((m_lastPosition - m_currentPosition) >= sizeAligned) || resize(sizeAligned))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(*double_t);
-
-    // Align if there are any elements
-    if (numElements)
-    {
-      makeAlign(align);
-    }
-
-    if (m_swapBytes)
-    {
-      const char* dst = reinterpret_cast<const char*>(&double_t);
-      const char* end = dst + totalSize;
-
-      for (; dst < end; dst += sizeof(*double_t))
-      {
-        m_currentPosition++ << dst[7];
-        m_currentPosition++ << dst[6];
-        m_currentPosition++ << dst[5];
-        m_currentPosition++ << dst[4];
-        m_currentPosition++ << dst[3];
-        m_currentPosition++ << dst[2];
-        m_currentPosition++ << dst[1];
-        m_currentPosition++ << dst[0];
-      }
-    }
-    else
-    {
-      m_currentPosition.memcopy(double_t, totalSize);
-      m_currentPosition += totalSize;
-    }
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-Cdr& Cdr::serializeArray(const double* double_t, size_t numElements,
-                         Endianness endianness)
-{
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    serializeArray(double_t, numElements);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::serializeArray(const long double* ldouble_t, size_t numElements)
-{
-  if (numElements == 0)
-  {
-    return *this;
-  }
-
-  size_t align = alignment(ALIGNMENT_LONG_DOUBLE);
-  // Fix for Windows ( long doubles only store 8 bytes )
-  size_t totalSize = 16 * numElements;  // sizeof(*ldouble_t)
-  size_t sizeAligned = totalSize + align;
-
-  if (((m_lastPosition - m_currentPosition) >= sizeAligned) || resize(sizeAligned))
-  {
-    // Save last datasize.
-    m_lastDataSize = 16;
-
-    // Align if there are any elements
-    if (numElements)
-    {
-      makeAlign(align);
-    }
+        // Align if there are any elements
+        if (num_elements)
+        {
+            make_alignment(align);
+        }
 
 #if FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
-    if (m_swapBytes)
-    {
-      for (size_t i = 0; i < numElements; ++i, ++ldouble_t)
-      {
-        __float128 tmp = *ldouble_t;
-        const char* dst = reinterpret_cast<const char*>(&tmp);
-        m_currentPosition++ << dst[15];
-        m_currentPosition++ << dst[14];
-        m_currentPosition++ << dst[13];
-        m_currentPosition++ << dst[12];
-        m_currentPosition++ << dst[11];
-        m_currentPosition++ << dst[10];
-        m_currentPosition++ << dst[9];
-        m_currentPosition++ << dst[8];
-        m_currentPosition++ << dst[7];
-        m_currentPosition++ << dst[6];
-        m_currentPosition++ << dst[5];
-        m_currentPosition++ << dst[4];
-        m_currentPosition++ << dst[3];
-        m_currentPosition++ << dst[2];
-        m_currentPosition++ << dst[1];
-        m_currentPosition++ << dst[0];
-      }
-    }
-    else
-    {
-      for (size_t i = 0; i < numElements; ++i, ++ldouble_t)
-      {
-        __float128 tmp = *ldouble_t;
-        m_currentPosition << tmp;
-        m_currentPosition += 16;
-      }
-    }
+        if (swap_bytes_)
+        {
+            for (size_t i = 0; i < num_elements; ++i)
+            {
+                __float128 tmp;
+                char* dst = reinterpret_cast<char*>(&tmp);
+                offset_++ >> dst[15];
+                offset_++ >> dst[14];
+                offset_++ >> dst[13];
+                offset_++ >> dst[12];
+                offset_++ >> dst[11];
+                offset_++ >> dst[10];
+                offset_++ >> dst[9];
+                offset_++ >> dst[8];
+                offset_++ >> dst[7];
+                offset_++ >> dst[6];
+                offset_++ >> dst[5];
+                offset_++ >> dst[4];
+                offset_++ >> dst[3];
+                offset_++ >> dst[2];
+                offset_++ >> dst[1];
+                offset_++ >> dst[0];
+                ldouble_t[i] = static_cast<long double>(tmp);
+            }
+        }
+        else
+        {
+            for (size_t i = 0; i < num_elements; ++i)
+            {
+                __float128 tmp;
+                offset_ >> tmp;
+                offset_ += 16;
+                ldouble_t[i] = static_cast<long double>(tmp);
+            }
+        }
 #else
 #if FASTCDR_SIZEOF_LONG_DOUBLE == 8 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
-    if (m_swapBytes)
-    {
-      const char* dst = reinterpret_cast<const char*>(&ldouble_t);
-      const char* end = dst + totalSize;
+        if (swap_bytes_)
+        {
+            char* dst = reinterpret_cast<char*>(ldouble_t);
+            char* end = dst + num_elements * sizeof(*ldouble_t);
 
-      for (; dst < end; dst += sizeof(*ldouble_t))
-      {
+            for (; dst < end; dst += sizeof(*ldouble_t))
+            {
 #if FASTCDR_SIZEOF_LONG_DOUBLE == 16
-        m_currentPosition++ << dst[15];
-        m_currentPosition++ << dst[14];
-        m_currentPosition++ << dst[13];
-        m_currentPosition++ << dst[12];
-        m_currentPosition++ << dst[11];
-        m_currentPosition++ << dst[10];
-        m_currentPosition++ << dst[9];
-        m_currentPosition++ << dst[8];
+                offset_++ >> dst[15];
+                offset_++ >> dst[14];
+                offset_++ >> dst[13];
+                offset_++ >> dst[12];
+                offset_++ >> dst[11];
+                offset_++ >> dst[10];
+                offset_++ >> dst[9];
+                offset_++ >> dst[8];
 #else
-        m_currentPosition++ << static_cast<char>(0);
-        m_currentPosition++ << static_cast<char>(0);
-        m_currentPosition++ << static_cast<char>(0);
-        m_currentPosition++ << static_cast<char>(0);
-        m_currentPosition++ << static_cast<char>(0);
-        m_currentPosition++ << static_cast<char>(0);
-        m_currentPosition++ << static_cast<char>(0);
-        m_currentPosition++ << static_cast<char>(0);
-#endif  // FASTCDR_SIZEOF_LONG_DOUBLE == 16
-        m_currentPosition++ << dst[7];
-        m_currentPosition++ << dst[6];
-        m_currentPosition++ << dst[5];
-        m_currentPosition++ << dst[4];
-        m_currentPosition++ << dst[3];
-        m_currentPosition++ << dst[2];
-        m_currentPosition++ << dst[1];
-        m_currentPosition++ << dst[0];
-      }
-    }
-    else
-    {
+                offset_ += 8;
+#endif // FASTCDR_SIZEOF_LONG_DOUBLE == 16
+                offset_++ >> dst[7];
+                offset_++ >> dst[6];
+                offset_++ >> dst[5];
+                offset_++ >> dst[4];
+                offset_++ >> dst[3];
+                offset_++ >> dst[2];
+                offset_++ >> dst[1];
+                offset_++ >> dst[0];
+            }
+        }
+        else
+        {
 #if FASTCDR_SIZEOF_LONG_DOUBLE == 16
-      m_currentPosition.memcopy(ldouble_t, totalSize);
-      m_currentPosition += totalSize;
+            offset_.rmemcopy(ldouble_t, total_size);
+            offset_ += total_size;
 #else
-      for (size_t i = 0; i < numElements; ++i)
-      {
-        m_currentPosition << static_cast<long double>(0);
-        m_currentPosition += 8;
-        m_currentPosition << ldouble_t[i];
-        m_currentPosition += 8;
-      }
-#endif  // FASTCDR_SIZEOF_LONG_DOUBLE == 16
+            for (size_t i = 0; i < num_elements; ++i)
+            {
+                offset_ += 8; // ignore first 8 bytes
+                offset_ >> ldouble_t[i];
+                offset_ += 8;
+            }
+#endif // FASTCDR_SIZEOF_LONG_DOUBLE == 16
+        }
+#endif // FASTCDR_SIZEOF_LONG_DOUBLE == 8 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
+#endif // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+
+        return *this;
     }
-#else
-#error unsupported long double type and no __float128 available
-#endif  // FASTCDR_SIZEOF_LONG_DOUBLE == 8 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
-#endif  // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
 
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::serializeArray(const long double* ldouble_t, size_t numElements,
-                         Endianness endianness)
+Cdr& Cdr::serialize_bool_sequence(
+        const std::vector<bool>& vector_t)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
+    state state_before_error(*this);
 
-  try
-  {
-    serializeArray(ldouble_t, numElements);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
+    *this << static_cast<int32_t>(vector_t.size());
 
-  return *this;
-}
+    size_t total_size = vector_t.size() * sizeof(bool);
 
-Cdr& Cdr::deserialize(char& char_t)
-{
-  if ((m_lastPosition - m_currentPosition) >= sizeof(char_t))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(char_t);
-
-    m_currentPosition++ >> char_t;
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-Cdr& Cdr::deserialize(int16_t& short_t)
-{
-  size_t align = alignment(sizeof(short_t));
-  size_t sizeAligned = sizeof(short_t) + align;
-
-  if ((m_lastPosition - m_currentPosition) >= sizeAligned)
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(short_t);
-
-    // Align
-    makeAlign(align);
-
-    if (m_swapBytes)
+    if (((end_ - offset_) >= total_size) || resize(total_size))
     {
-      char* dst = reinterpret_cast<char*>(&short_t);
+        // Save last datasize.
+        last_data_size_ = sizeof(bool);
 
-      m_currentPosition++ >> dst[1];
-      m_currentPosition++ >> dst[0];
+        for (size_t count = 0; count < vector_t.size(); ++count)
+        {
+            uint8_t value = 0;
+            std::vector<bool>::const_reference ref = vector_t[count];
+
+            if (ref)
+            {
+                value = 1;
+            }
+            offset_++ << value;
+        }
     }
     else
     {
-      m_currentPosition >> short_t;
-      m_currentPosition += sizeof(short_t);
+        set_state(state_before_error);
+        throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    }
+
+    if (CdrVersion::XCDRv2 == cdr_version_)
+    {
+        serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
     }
 
     return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::deserialize(int16_t& short_t, Endianness endianness)
+Cdr& Cdr::deserialize_bool_sequence(
+        std::vector<bool>& vector_t)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
+    uint32_t sequence_length {0};
+    state state_before_error(*this);
 
-  try
-  {
-    deserialize(short_t);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
+    *this >> sequence_length;
 
-  return *this;
-}
+    size_t total_size = sequence_length * sizeof(bool);
 
-Cdr& Cdr::deserialize(int32_t& long_t)
-{
-  size_t align = alignment(sizeof(long_t));
-  size_t sizeAligned = sizeof(long_t) + align;
-
-  if ((m_lastPosition - m_currentPosition) >= sizeAligned)
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(long_t);
-
-    // Align
-    makeAlign(align);
-
-    if (m_swapBytes)
+    if ((end_ - offset_) >= total_size)
     {
-      char* dst = reinterpret_cast<char*>(&long_t);
+        vector_t.resize(sequence_length);
+        // Save last datasize.
+        last_data_size_ = sizeof(bool);
 
-      m_currentPosition++ >> dst[3];
-      m_currentPosition++ >> dst[2];
-      m_currentPosition++ >> dst[1];
-      m_currentPosition++ >> dst[0];
+        for (uint32_t count = 0; count < sequence_length; ++count)
+        {
+            uint8_t value = 0;
+            offset_++ >> value;
+
+            if (value == 1)
+            {
+                vector_t[count] = true;
+            }
+            else if (value == 0)
+            {
+                vector_t[count] = false;
+            }
+            else
+            {
+                throw BadParamException("Unexpected byte value in Cdr::deserialize_bool_sequence, expected 0 or 1");
+            }
+        }
     }
     else
     {
-      m_currentPosition >> long_t;
-      m_currentPosition += sizeof(long_t);
+        set_state(state_before_error);
+        throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
     return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::deserialize(int32_t& long_t, Endianness endianness)
+Cdr& Cdr::deserialize_string_sequence(
+        std::string*& sequence_t,
+        size_t& num_elements)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
+    uint32_t sequence_length {0};
 
-  try
-  {
-    deserialize(long_t);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::deserialize(int64_t& longlong_t)
-{
-  size_t align = alignment(sizeof(longlong_t));
-  size_t sizeAligned = sizeof(longlong_t) + align;
-
-  if ((m_lastPosition - m_currentPosition) >= sizeAligned)
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(longlong_t);
-
-    // Align.
-    makeAlign(align);
-
-    if (m_swapBytes)
+    if (CdrVersion::XCDRv2 == cdr_version_)
     {
-      char* dst = reinterpret_cast<char*>(&longlong_t);
+        uint32_t dheader {0};
+        deserialize(dheader);
 
-      m_currentPosition++ >> dst[7];
-      m_currentPosition++ >> dst[6];
-      m_currentPosition++ >> dst[5];
-      m_currentPosition++ >> dst[4];
-      m_currentPosition++ >> dst[3];
-      m_currentPosition++ >> dst[2];
-      m_currentPosition++ >> dst[1];
-      m_currentPosition++ >> dst[0];
+        auto offset = offset_;
+
+        deserialize(sequence_length);
+
+        try
+        {
+            sequence_t = new std::string[sequence_length];
+
+            uint32_t count {0};
+            while (offset_ - offset < dheader && count < sequence_length)
+            {
+                deserialize(sequence_t[count]);
+                ++count;
+            }
+
+            if (offset_ - offset != dheader)
+            {
+                throw BadParamException("Member size greater than size specified by DHEADER");
+            }
+        }
+        catch (exception::Exception& ex)
+        {
+            delete [] sequence_t;
+            sequence_t = nullptr;
+            ex.raise();
+        }
     }
     else
     {
-      m_currentPosition >> longlong_t;
-      m_currentPosition += sizeof(longlong_t);
+        state state_before_error(*this);
+
+        deserialize(sequence_length);
+
+        try
+        {
+            sequence_t = new std::string[sequence_length];
+            deserialize_array(sequence_t, sequence_length);
+        }
+        catch (exception::Exception& ex)
+        {
+            delete [] sequence_t;
+            sequence_t = nullptr;
+            set_state(state_before_error);
+            ex.raise();
+        }
     }
 
+    num_elements = sequence_length;
     return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::deserialize(int64_t& longlong_t, Endianness endianness)
+Cdr& Cdr::deserialize_wstring_sequence(
+        std::wstring*& sequence_t,
+        size_t& num_elements)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
+    uint32_t sequence_length {0};
 
-  try
-  {
-    deserialize(longlong_t);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::deserialize(float& float_t)
-{
-  size_t align = alignment(sizeof(float_t));
-  size_t sizeAligned = sizeof(float_t) + align;
-
-  if ((m_lastPosition - m_currentPosition) >= sizeAligned)
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(float_t);
-
-    // Align.
-    makeAlign(align);
-
-    if (m_swapBytes)
+    if (CdrVersion::XCDRv2 == cdr_version_)
     {
-      char* dst = reinterpret_cast<char*>(&float_t);
+        uint32_t dheader {0};
+        deserialize(dheader);
 
-      m_currentPosition++ >> dst[3];
-      m_currentPosition++ >> dst[2];
-      m_currentPosition++ >> dst[1];
-      m_currentPosition++ >> dst[0];
+        auto offset = offset_;
+
+        deserialize(sequence_length);
+
+        try
+        {
+            sequence_t = new std::wstring[sequence_length];
+
+            uint32_t count {0};
+            while (offset_ - offset < dheader && count < sequence_length)
+            {
+                deserialize(sequence_t[count]);
+                ++count;
+            }
+
+            if (offset_ - offset != dheader)
+            {
+                throw BadParamException("Member size greater than size specified by DHEADER");
+            }
+        }
+        catch (exception::Exception& ex)
+        {
+            delete [] sequence_t;
+            sequence_t = nullptr;
+            ex.raise();
+        }
     }
     else
     {
-      m_currentPosition >> float_t;
-      m_currentPosition += sizeof(float_t);
+        state state_before_error(*this);
+
+        deserialize(sequence_length);
+
+        try
+        {
+            sequence_t = new std::wstring[sequence_length];
+            deserialize_array(sequence_t, sequence_length);
+        }
+        catch (exception::Exception& ex)
+        {
+            delete [] sequence_t;
+            sequence_t = nullptr;
+            set_state(state_before_error);
+            ex.raise();
+        }
     }
 
+    num_elements = sequence_length;
     return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::deserialize(float& float_t, Endianness endianness)
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// XCDR extensions
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void Cdr::xcdr1_serialize_short_member_header(
+        const MemberId& member_id)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
+    assert(0x3F00 >= member_id.id);
 
-  try
-  {
-    deserialize(float_t);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
+    make_alignment(alignment(4));
 
-  return *this;
+    uint16_t flags_and_member_id = static_cast<uint16_t>(member_id.must_understand ? 0x4000 : 0x0) |
+            static_cast<uint16_t>(member_id.id);
+    serialize(flags_and_member_id);
+    uint16_t size = 0;
+    serialize(size);
+    reset_alignment();
 }
 
-Cdr& Cdr::deserialize(double& double_t)
+void Cdr::xcdr1_end_short_member_header(
+        const MemberId& member_id,
+        size_t member_serialized_size)
 {
-  size_t align = alignment(sizeof(double_t));
-  size_t sizeAligned = sizeof(double_t) + align;
+    static_cast<void>(member_id);
+    assert(0x3F00 >= member_id.id);
+    assert(std::numeric_limits<uint16_t>::max() >= member_serialized_size );
+    make_alignment(alignment(4));
+    jump(sizeof(uint16_t));
+    uint16_t size = static_cast<uint16_t>(member_serialized_size);
+    serialize(size);
+}
 
-  if ((m_lastPosition - m_currentPosition) >= sizeAligned)
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(double_t);
+void Cdr::xcdr1_serialize_long_member_header(
+        const MemberId& member_id)
+{
+    make_alignment(alignment(4));
 
-    // Align.
-    makeAlign(align);
+    uint16_t flags_and_extended_pid = static_cast<uint16_t>(member_id.must_understand ? 0x4000 : 0x0) |
+            static_cast<uint16_t>(PID_EXTENDED);
+    serialize(flags_and_extended_pid);
+    uint16_t size = PID_EXTENDED_LENGTH;
+    serialize(size);
+    uint32_t id = member_id.id;
+    serialize(id);
+    uint32_t msize = 0;
+    serialize(msize);
+    reset_alignment();
+}
 
-    if (m_swapBytes)
+void Cdr::xcdr1_end_long_member_header(
+        const MemberId&,
+        size_t member_serialized_size)
+{
+    jump(sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint32_t));
+    uint32_t msize = static_cast<uint32_t>(member_serialized_size);
+    serialize(msize);
+}
+
+void Cdr::xcdr1_change_to_short_member_header(
+        const MemberId& member_id,
+        size_t member_serialized_size)
+{
+    assert(0x3F00 >= member_id.id);
+    assert(std::numeric_limits<uint16_t>::max() >= member_serialized_size );
+
+    uint16_t flags_and_member_id = static_cast<uint16_t>(member_id.must_understand ? 0x4000 : 0x0) |
+            static_cast<uint16_t>(member_id.id);
+    serialize(flags_and_member_id);
+    uint16_t size = static_cast<uint16_t>(member_serialized_size);
+    serialize(size);
+    memmove(&offset_, &offset_ + 8, member_serialized_size);
+}
+
+void Cdr::xcdr1_change_to_long_member_header(
+        const MemberId& member_id,
+        size_t member_serialized_size)
+{
+    if (0 < (end_ - offset_ - member_serialized_size - 11))
     {
-      char* dst = reinterpret_cast<char*>(&double_t);
-
-      m_currentPosition++ >> dst[7];
-      m_currentPosition++ >> dst[6];
-      m_currentPosition++ >> dst[5];
-      m_currentPosition++ >> dst[4];
-      m_currentPosition++ >> dst[3];
-      m_currentPosition++ >> dst[2];
-      m_currentPosition++ >> dst[1];
-      m_currentPosition++ >> dst[0];
+        memmove(&offset_ + 12, &offset_ + 4, member_serialized_size);
     }
     else
     {
-      m_currentPosition >> double_t;
-      m_currentPosition += sizeof(double_t);
+        throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    }
+    uint16_t flags_and_extended_pid = static_cast<uint16_t>(member_id.must_understand ? 0x4000 : 0x0) |
+            static_cast<uint16_t>(PID_EXTENDED);
+    serialize(flags_and_extended_pid);
+    uint16_t size = PID_EXTENDED_LENGTH;
+    serialize(size);
+    uint32_t id = member_id.id;
+    serialize(id);
+    uint32_t msize = static_cast<uint32_t>(member_serialized_size);
+    serialize(msize);
+}
+
+bool Cdr::xcdr1_deserialize_member_header(
+        MemberId& member_id,
+        Cdr::state& current_state)
+{
+    bool ret_value = true;
+    make_alignment(alignment(4));
+    uint16_t flags_and_member_id = 0;
+    deserialize(flags_and_member_id);
+    member_id.must_understand = (flags_and_member_id & 0x4000);
+    uint16_t id = (flags_and_member_id & 0x3FFF);
+
+
+    if (PID_EXTENDED > id)
+    {
+        member_id.id = id;
+        uint16_t size = 0;
+        deserialize(size);
+        current_state.member_size_ = size;
+        current_state.header_serialized_ = XCdrHeaderSelection::SHORT_HEADER;
+        reset_alignment();
+    }
+    else if (PID_EXTENDED == id) // PID_EXTENDED
+    {
+        uint16_t size = 0;
+        deserialize(size);
+        if (PID_EXTENDED_LENGTH != size)
+        {
+            throw BadParamException("PID_EXTENDED comes with a size different than 8");
+        }
+        uint32_t mid = 0;
+        deserialize(mid);
+        member_id.id = mid;
+        deserialize(current_state.member_size_);
+        current_state.header_serialized_ = XCdrHeaderSelection::LONG_HEADER;
+        reset_alignment();
+    }
+    else if (PID_SENTINEL == id) // PID_SENTINEL
+    {
+        uint16_t size = 0;
+        deserialize(size);
+        if (0 != size)
+        {
+            throw BadParamException("PID_SENTINEL comes with a size different than 0");
+        }
+        current_state.member_size_ = size;
+        ret_value = false;
     }
 
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    return ret_value;
 }
 
-Cdr& Cdr::deserialize(double& double_t, Endianness endianness)
+void Cdr::xcdr2_serialize_short_member_header(
+        const MemberId& member_id)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
+    assert(0x10000000 > member_id.id);
 
-  try
-  {
-    deserialize(double_t);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
+    uint32_t flags_and_member_id = (member_id.must_understand ? 0x80000000 : 0x0) | member_id.id;
+    serialize(flags_and_member_id);
 }
 
-Cdr& Cdr::deserialize(long double& ldouble_t)
+void Cdr::xcdr2_end_short_member_header(
+        const MemberId& member_id,
+        size_t member_serialized_size)
 {
-  size_t align = alignment(ALIGNMENT_LONG_DOUBLE);
-  size_t sizeAligned = sizeof(ldouble_t) + align;
+    assert(0x10000000 > member_id.id);
+    assert(8 >= member_serialized_size);
 
-  if ((m_lastPosition - m_currentPosition) >= sizeAligned)
-  {
-    // Save last datasize.
-    m_lastDataSize = 16;  // sizeof(ldouble_t);
+    uint32_t lc = get_short_lc(member_serialized_size);
+    uint32_t flags_and_member_id = (member_id.must_understand ? 0x80000000 : 0x0) | lc | member_id.id;
+    serialize(flags_and_member_id);
+}
 
-    // Align.
-    makeAlign(align);
+void Cdr::xcdr2_serialize_long_member_header(
+        const MemberId& member_id)
+{
+    assert(0x10000000 > member_id.id);
 
-    if (m_swapBytes)
+    uint32_t flags_and_member_id = (member_id.must_understand ? 0x80000000 : 0x0) | member_id.id;
+    serialize(flags_and_member_id);
+    uint32_t size = 0;
+    serialize(size);
+}
+
+void Cdr::xcdr2_end_long_member_header(
+        const MemberId& member_id,
+        size_t member_serialized_size)
+{
+    assert(0x10000000 > member_id.id);
+
+    uint32_t lc = 0 == member_serialized_size ? get_long_lc(serialized_member_size_) : 0x40000000;
+    uint32_t flags_and_member_id = (member_id.must_understand ? 0x80000000 : 0x0) | lc | member_id.id;
+    serialize(flags_and_member_id);
+    if (0 < member_serialized_size)
     {
-#if FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
-      __float128 tmp = ldouble_t;
-      char* dst = reinterpret_cast<char*>(&tmp);
-#else
-      char* dst = reinterpret_cast<char*>(&ldouble_t);
-#endif  // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
-#if FASTCDR_HAVE_FLOAT128 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
-      m_currentPosition++ >> dst[15];
-      m_currentPosition++ >> dst[14];
-      m_currentPosition++ >> dst[13];
-      m_currentPosition++ >> dst[12];
-      m_currentPosition++ >> dst[11];
-      m_currentPosition++ >> dst[10];
-      m_currentPosition++ >> dst[9];
-      m_currentPosition++ >> dst[8];
-      m_currentPosition++ >> dst[7];
-      m_currentPosition++ >> dst[6];
-      m_currentPosition++ >> dst[5];
-      m_currentPosition++ >> dst[4];
-      m_currentPosition++ >> dst[3];
-      m_currentPosition++ >> dst[2];
-      m_currentPosition++ >> dst[1];
-      m_currentPosition++ >> dst[0];
-#if FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
-      ldouble_t = static_cast<long double>(tmp);
-#endif  // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
-#else
-#if FASTCDR_SIZEOF_LONG_DOUBLE == 8
-      m_currentPosition += 8;
-      m_currentPosition++ >> dst[7];
-      m_currentPosition++ >> dst[6];
-      m_currentPosition++ >> dst[5];
-      m_currentPosition++ >> dst[4];
-      m_currentPosition++ >> dst[3];
-      m_currentPosition++ >> dst[2];
-      m_currentPosition++ >> dst[1];
-      m_currentPosition++ >> dst[0];
-#else
-#error unsupported long double type and no __float128 available
-#endif  // FASTCDR_SIZEOF_LONG_DOUBLE == 8
-#endif  // FASTCDR_HAVE_FLOAT128 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
+        uint32_t size = static_cast<uint32_t>(member_serialized_size);
+        serialize(size);
+    }
+}
+
+void Cdr::xcdr2_change_to_short_member_header(
+        const MemberId& member_id,
+        size_t member_serialized_size)
+{
+    assert(0x10000000 > member_id.id);
+    assert(8 >= member_serialized_size);
+
+    uint32_t lc = get_short_lc(member_serialized_size);
+    uint32_t flags_and_member_id = (member_id.must_understand ? 0x80000000 : 0x0) | lc | member_id.id;
+    serialize(flags_and_member_id);
+    memmove(&offset_, &offset_ + 4, member_serialized_size);
+}
+
+void Cdr::xcdr2_change_to_long_member_header(
+        const MemberId& member_id,
+        size_t member_serialized_size)
+{
+    assert(0x10000000 > member_id.id);
+
+    if (0 < (end_ - offset_ - member_serialized_size - 7))
+    {
+        memmove(&offset_ + 8, &offset_ + 4, member_serialized_size);
     }
     else
     {
-#if FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
-      __float128 tmp;
-      m_currentPosition >> tmp;
-      m_currentPosition += 16;
-      ldouble_t = static_cast<long double>(tmp);
-#else
-#if FASTCDR_SIZEOF_LONG_DOUBLE == 8 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
-#if FASTCDR_SIZEOF_LONG_DOUBLE == 8
-      m_currentPosition += 8;
-#endif  // FASTCDR_SIZEOF_LONG_DOUBLE == 8
-      m_currentPosition >> ldouble_t;
-      m_currentPosition += sizeof(ldouble_t);
-#endif  // FASTCDR_SIZEOF_LONG_DOUBLE == 8 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
-#endif  // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+        throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
+    uint32_t lc = get_long_lc(serialized_member_size_);
+    uint32_t flags_and_member_id = (member_id.must_understand ? 0x80000000 : 0x0) | lc | member_id.id;
+    serialize(flags_and_member_id);
+    uint32_t size = static_cast<uint32_t>(member_serialized_size);
+    serialize(size);
+}
+
+void Cdr::xcdr2_shrink_to_long_member_header(
+        const MemberId& member_id,
+        const FastBuffer::iterator& offset)
+{
+    assert(0x10000000 > member_id.id);
+
+    memmove(&offset_ + 4, &offset_ + 8, offset - offset_ - 8);
+    uint32_t lc = get_long_lc(serialized_member_size_);
+    uint32_t flags_and_member_id = (member_id.must_understand ? 0x80000000 : 0x0) | lc | member_id.id;
+    serialize(flags_and_member_id);
+}
+
+Cdr& Cdr::xcdr1_begin_serialize_member(
+        const MemberId& member_id,
+        bool is_present,
+        Cdr::state& current_state,
+        Cdr::XCdrHeaderSelection header_selection)
+{
+    static_cast<void>(is_present);
+    assert(is_present);
+    assert(MEMBER_ID_INVALID != member_id);
+    assert(MEMBER_ID_INVALID == next_member_id_ || member_id == next_member_id_);
+    assert(current_state == Cdr::state(*this));
+    assert(EncodingAlgorithmFlag::PLAIN_CDR == current_encoding_ ||
+            EncodingAlgorithmFlag::PL_CDR == current_encoding_);
+
+    if (EncodingAlgorithmFlag::PL_CDR == current_encoding_)
+    {
+        if (0x3F00 >= member_id.id)
+        {
+            switch (header_selection)
+            {
+                case XCdrHeaderSelection::AUTO_WITH_SHORT_HEADER_BY_DEFAULT:
+                case XCdrHeaderSelection::SHORT_HEADER:
+                    xcdr1_serialize_short_member_header(member_id);
+                    current_state.header_serialized_ = XCdrHeaderSelection::SHORT_HEADER;
+                    break;
+                case XCdrHeaderSelection::AUTO_WITH_LONG_HEADER_BY_DEFAULT:
+                case XCdrHeaderSelection::LONG_HEADER:
+                    xcdr1_serialize_long_member_header(member_id);
+                    current_state.header_serialized_ = XCdrHeaderSelection::LONG_HEADER;
+                    break;
+            }
+        }
+        else
+        {
+            switch (header_selection)
+            {
+                case XCdrHeaderSelection::AUTO_WITH_SHORT_HEADER_BY_DEFAULT:
+                case XCdrHeaderSelection::AUTO_WITH_LONG_HEADER_BY_DEFAULT:
+                case XCdrHeaderSelection::LONG_HEADER:
+                    xcdr1_serialize_long_member_header(member_id);
+                    current_state.header_serialized_ = XCdrHeaderSelection::LONG_HEADER;
+                    break;
+                default:
+                    throw BadParamException(
+                              "Cannot encode XCDRv1 ShortMemberHeader when member_id is bigger than 0x3F00");
+            }
+        }
+        current_state.header_selection_ = header_selection;
+    }
+    current_state.next_member_id_ = member_id;
+    next_member_id_ = MEMBER_ID_INVALID;
 
     return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::deserialize(long double& ldouble_t, Endianness endianness)
+Cdr& Cdr::xcdr1_end_serialize_member(
+        const Cdr::state& current_state)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
+    assert(MEMBER_ID_INVALID != current_state.next_member_id_);
+    assert(EncodingAlgorithmFlag::PLAIN_CDR == current_encoding_ ||
+            EncodingAlgorithmFlag::PL_CDR == current_encoding_);
 
-  try
-  {
-    deserialize(ldouble_t);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::deserialize(bool& bool_t)
-{
-  uint8_t value = 0;
-
-  if ((m_lastPosition - m_currentPosition) >= sizeof(uint8_t))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(uint8_t);
-
-    m_currentPosition++ >> value;
-
-    if (value == 1)
+    if (EncodingAlgorithmFlag::PL_CDR == current_encoding_)
     {
-      bool_t = true;
-      return *this;
-    }
-    else if (value == 0)
-    {
-      bool_t = false;
-      return *this;
-    }
-
-    throw BadParamException("Unexpected byte value in Cdr::deserialize(bool), expected 0 "
-                            "or 1");
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-Cdr& Cdr::deserialize(char*& string_t)
-{
-  uint32_t length = 0;
-  Cdr::state state_before_error(*this);
-
-  deserialize(length);
-
-  if (length == 0)
-  {
-    string_t = NULL;
-    return *this;
-  }
-  else if ((m_lastPosition - m_currentPosition) >= length)
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(uint8_t);
-
-    // Allocate memory.
-    string_t = reinterpret_cast<char*>(calloc(
-        length + ((&m_currentPosition)[length - 1] == '\0' ? 0 : 1), sizeof(char)));
-    memcpy(string_t, &m_currentPosition, length);
-    m_currentPosition += length;
-    return *this;
-  }
-
-  setState(state_before_error);
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-Cdr& Cdr::deserialize(wchar_t*& string_t)
-{
-  uint32_t length = 0;
-  Cdr::state state_before_error(*this);
-
-  deserialize(length);
-
-  if (length == 0)
-  {
-    string_t = NULL;
-    return *this;
-  }
-  else if ((m_lastPosition - m_currentPosition) >= length)
-  {
-    // Save last datasize.
-    m_lastDataSize = 4;
-    // Allocate memory.
-    string_t = reinterpret_cast<wchar_t*>(calloc(
-        length + 1, sizeof(wchar_t)));  // WStrings never serialize terminating zero
-
-#if defined(_WIN32)
-    for (size_t idx = 0; idx < length; ++idx)
-    {
-      uint32_t temp;
-      m_currentPosition >> temp;
-      string_t[idx] = static_cast<wchar_t>(temp);
-      m_currentPosition += 4;
-    }
-#else
-    memcpy(string_t, &m_currentPosition, length * sizeof(wchar_t));
-    m_currentPosition += length * sizeof(wchar_t);
-#endif  // if defined(_WIN32)
-    return *this;
-  }
-
-  setState(state_before_error);
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-Cdr& Cdr::deserialize(char*& string_t, Endianness endianness)
-{
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    deserialize(string_t);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::deserialize(wchar_t*& string_t, Endianness endianness)
-{
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    deserialize(string_t);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-const char* Cdr::readString(uint32_t& length)
-{
-  const char* returnedValue = "";
-  state state_before_error(*this);
-
-  *this >> length;
-
-  if (length == 0)
-  {
-    return returnedValue;
-  }
-  else if ((m_lastPosition - m_currentPosition) >= length)
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(uint8_t);
-
-    returnedValue = &m_currentPosition;
-    m_currentPosition += length;
-    if (returnedValue[length - 1] == '\0')
-    {
-      --length;
-    }
-    return returnedValue;
-  }
-
-  setState(state_before_error);
-  throw eprosima::fastcdr::exception::NotEnoughMemoryException(
-      eprosima::fastcdr::exception::NotEnoughMemoryException::
-          NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-const std::wstring Cdr::readWString(uint32_t& length)
-{
-  std::wstring returnedValue = L"";
-  state state_(*this);
-
-  *this >> length;
-  uint32_t bytesLength = length * 4;
-
-  if (bytesLength == 0)
-  {
-    return returnedValue;
-  }
-  else if ((m_lastPosition - m_currentPosition) >= bytesLength)
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(uint32_t);
-
-    returnedValue.resize(length);
-    deserializeArray(const_cast<wchar_t*>(returnedValue.c_str()), length);
-    if (returnedValue[length - 1] == L'\0')
-    {
-      --length;
-      returnedValue.erase(length);
-    }
-    return returnedValue;
-  }
-
-  setState(state_);
-  throw eprosima::fastcdr::exception::NotEnoughMemoryException(
-      eprosima::fastcdr::exception::NotEnoughMemoryException::
-          NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-Cdr& Cdr::deserializeArray(bool* bool_t, size_t numElements)
-{
-  size_t totalSize = sizeof(*bool_t) * numElements;
-
-  if ((m_lastPosition - m_currentPosition) >= totalSize)
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(*bool_t);
-
-    for (size_t count = 0; count < numElements; ++count)
-    {
-      uint8_t value = 0;
-      m_currentPosition++ >> value;
-
-      if (value == 1)
-      {
-        bool_t[count] = true;
-      }
-      else if (value == 0)
-      {
-        bool_t[count] = false;
-      }
+        auto last_offset = offset_;
+        auto member_origin = origin_;
+        set_state(current_state);
+        make_alignment(alignment(4));
+        const size_t member_serialized_size = last_offset - offset_ -
+                (current_state.header_serialized_ == XCdrHeaderSelection::SHORT_HEADER ? 4 : 12);
+        if (member_serialized_size > std::numeric_limits<uint16_t>::max())
+        {
+            switch (current_state.header_serialized_)
+            {
+                case XCdrHeaderSelection::SHORT_HEADER:
+                    if (AUTO_WITH_SHORT_HEADER_BY_DEFAULT == current_state.header_selection_)
+                    {
+                        xcdr1_change_to_long_member_header(current_state.next_member_id_, member_serialized_size);
+                        member_origin += 8;
+                    }
+                    else
+                    {
+                        throw BadParamException(
+                                  "Cannot encode XCDRv1 ShortMemberHeader when serialized member size is greater than 0xFFFF");
+                    }
+                    break;
+                case XCdrHeaderSelection::LONG_HEADER:
+                    xcdr1_end_long_member_header(current_state.next_member_id_, member_serialized_size);
+                    break;
+                default:
+                    assert(false); // header_serialized_ must have only SHORT_HEADER or LONG_HEADER
+            }
+        }
+        else
+        {
+            switch (current_state.header_serialized_)
+            {
+                case XCdrHeaderSelection::SHORT_HEADER:
+                    xcdr1_end_short_member_header(current_state.next_member_id_, member_serialized_size);
+                    break;
+                case XCdrHeaderSelection::LONG_HEADER:
+                    if (LONG_HEADER == current_state.header_selection_ ||
+                            0x3F00 < current_state.next_member_id_.id)
+                    {
+                        xcdr1_end_long_member_header(current_state.next_member_id_, member_serialized_size);
+                    }
+                    else if (AUTO_WITH_LONG_HEADER_BY_DEFAULT == current_state.header_selection_)
+                    {
+                        xcdr1_change_to_short_member_header(current_state.next_member_id_, member_serialized_size);
+                        member_origin -= 8;
+                    }
+                    break;
+                default:
+                    assert(false); // header_serialized_ must have only SHORT_HEADER or LONG_HEADER
+            }
+        }
+        origin_ = member_origin; // Don't POP(origin)
+        jump(member_serialized_size);
     }
 
-    return *this;
-  }
+    next_member_id_ = MEMBER_ID_INVALID;
 
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+    return *this;
 }
 
-Cdr& Cdr::deserializeArray(char* char_t, size_t numElements)
+Cdr& Cdr::xcdr1_begin_serialize_opt_member(
+        const MemberId& member_id,
+        bool is_present,
+        Cdr::state& current_state,
+        Cdr::XCdrHeaderSelection header_selection)
 {
-  size_t totalSize = sizeof(*char_t) * numElements;
+    assert(MEMBER_ID_INVALID != member_id);
+    assert(MEMBER_ID_INVALID == next_member_id_ || member_id == next_member_id_);
+    assert(current_state == Cdr::state(*this));
+    assert(EncodingAlgorithmFlag::PLAIN_CDR == current_encoding_ ||
+            EncodingAlgorithmFlag::PL_CDR == current_encoding_);
 
-  if ((m_lastPosition - m_currentPosition) >= totalSize)
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(*char_t);
-
-    m_currentPosition.rmemcopy(char_t, totalSize);
-    m_currentPosition += totalSize;
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-Cdr& Cdr::deserializeArray(int16_t* short_t, size_t numElements)
-{
-  if (numElements == 0)
-  {
-    return *this;
-  }
-
-  size_t align = alignment(sizeof(*short_t));
-  size_t totalSize = sizeof(*short_t) * numElements;
-  size_t sizeAligned = totalSize + align;
-
-  if ((m_lastPosition - m_currentPosition) >= sizeAligned)
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(*short_t);
-
-    // Align if there are any elements
-    if (numElements)
+    if (is_present || EncodingAlgorithmFlag::PL_CDR != current_encoding_)
     {
-      makeAlign(align);
+        if (0x3F00 >= member_id.id)
+        {
+            switch (header_selection)
+            {
+                case XCdrHeaderSelection::AUTO_WITH_SHORT_HEADER_BY_DEFAULT:
+                case XCdrHeaderSelection::SHORT_HEADER:
+                    xcdr1_serialize_short_member_header(member_id);
+                    current_state.header_serialized_ = XCdrHeaderSelection::SHORT_HEADER;
+                    break;
+                case XCdrHeaderSelection::AUTO_WITH_LONG_HEADER_BY_DEFAULT:
+                case XCdrHeaderSelection::LONG_HEADER:
+                    xcdr1_serialize_long_member_header(member_id);
+                    current_state.header_serialized_ = XCdrHeaderSelection::LONG_HEADER;
+                    break;
+            }
+        }
+        else
+        {
+            switch (header_selection)
+            {
+                case XCdrHeaderSelection::AUTO_WITH_SHORT_HEADER_BY_DEFAULT:
+                case XCdrHeaderSelection::AUTO_WITH_LONG_HEADER_BY_DEFAULT:
+                case XCdrHeaderSelection::LONG_HEADER:
+                    xcdr1_serialize_long_member_header(member_id);
+                    current_state.header_serialized_ = XCdrHeaderSelection::LONG_HEADER;
+                    break;
+                default:
+                    throw BadParamException(
+                              "Cannot encode XCDRv1 ShortMemberHeader when member_id is bigger than 0x3F00");
+            }
+        }
+        current_state.header_selection_ = header_selection;
+    }
+    current_state.member_size_ = is_present ? 1 : 0;
+    current_state.next_member_id_ = member_id;
+    next_member_id_ = MEMBER_ID_INVALID;
+
+    return *this;
+}
+
+Cdr& Cdr::xcdr1_end_serialize_opt_member(
+        const Cdr::state& current_state)
+{
+    assert(MEMBER_ID_INVALID != current_state.next_member_id_);
+    assert(EncodingAlgorithmFlag::PLAIN_CDR == current_encoding_ ||
+            EncodingAlgorithmFlag::PL_CDR == current_encoding_);
+
+    if (0 < current_state.member_size_)
+    {
+        auto last_offset = offset_;
+        auto member_origin = origin_;
+        set_state(current_state);
+        make_alignment(alignment(4));
+        const size_t member_serialized_size = last_offset - offset_ -
+                (current_state.header_serialized_ == XCdrHeaderSelection::SHORT_HEADER ? 4 : 12);
+        if (member_serialized_size > std::numeric_limits<uint16_t>::max())
+        {
+            switch (current_state.header_serialized_)
+            {
+                case XCdrHeaderSelection::SHORT_HEADER:
+                    if (AUTO_WITH_SHORT_HEADER_BY_DEFAULT == current_state.header_selection_)
+                    {
+                        xcdr1_change_to_long_member_header(current_state.next_member_id_, member_serialized_size);
+                        member_origin += 8;
+                    }
+                    else
+                    {
+                        throw BadParamException(
+                                  "Cannot encode XCDRv1 ShortMemberHeader when serialized member size is greater than 0xFFFF");
+                    }
+                    break;
+                case XCdrHeaderSelection::LONG_HEADER:
+                    xcdr1_end_long_member_header(current_state.next_member_id_, member_serialized_size);
+                    break;
+                default:
+                    assert(false); // header_serialized_ must have only SHORT_HEADER or LONG_HEADER
+            }
+        }
+        else
+        {
+            switch (current_state.header_serialized_)
+            {
+                case XCdrHeaderSelection::SHORT_HEADER:
+                    xcdr1_end_short_member_header(current_state.next_member_id_, member_serialized_size);
+                    break;
+                case XCdrHeaderSelection::LONG_HEADER:
+                    if (LONG_HEADER == current_state.header_selection_ ||
+                            0x3F00 < current_state.next_member_id_.id)
+                    {
+                        xcdr1_end_long_member_header(current_state.next_member_id_, member_serialized_size);
+                    }
+                    else if (AUTO_WITH_LONG_HEADER_BY_DEFAULT == current_state.header_selection_)
+                    {
+                        xcdr1_change_to_short_member_header(current_state.next_member_id_, member_serialized_size);
+                        member_origin -= 8;
+                    }
+                    break;
+                default:
+                    assert(false); // header_serialized_ must have only SHORT_HEADER or LONG_HEADER
+            }
+        }
+        origin_ = member_origin; // Don't POP(origin)
+        jump(member_serialized_size);
     }
 
-    if (m_swapBytes)
-    {
-      char* dst = reinterpret_cast<char*>(short_t);
-      char* end = dst + totalSize;
+    next_member_id_ = MEMBER_ID_INVALID;
 
-      for (; dst < end; dst += sizeof(*short_t))
-      {
-        m_currentPosition++ >> dst[1];
-        m_currentPosition++ >> dst[0];
-      }
+    return *this;
+}
+
+Cdr& Cdr::xcdr2_begin_serialize_member(
+        const MemberId& member_id,
+        bool is_present,
+        Cdr::state& current_state,
+        XCdrHeaderSelection header_selection)
+{
+    assert(MEMBER_ID_INVALID != member_id);
+    assert(MEMBER_ID_INVALID == next_member_id_ || member_id == next_member_id_);
+    assert(current_state == Cdr::state(*this));
+    assert(EncodingAlgorithmFlag::PLAIN_CDR2 == current_encoding_ ||
+            EncodingAlgorithmFlag::DELIMIT_CDR2 == current_encoding_ ||
+            EncodingAlgorithmFlag::PL_CDR2 == current_encoding_);
+
+    if (is_present && EncodingAlgorithmFlag::PL_CDR2 == current_encoding_)
+    {
+        if (0x10000000 <= member_id.id)
+        {
+            throw BadParamException("Cannot serialize a member identifier equal or greater than 0x10000000");
+        }
+
+        switch (header_selection)
+        {
+            case XCdrHeaderSelection::SHORT_HEADER:
+            case XCdrHeaderSelection::AUTO_WITH_SHORT_HEADER_BY_DEFAULT:
+                xcdr2_serialize_short_member_header(member_id);
+                current_state.header_serialized_ = XCdrHeaderSelection::SHORT_HEADER;
+                break;
+            case XCdrHeaderSelection::LONG_HEADER:
+            case XCdrHeaderSelection::AUTO_WITH_LONG_HEADER_BY_DEFAULT:
+                xcdr2_serialize_long_member_header(member_id);
+                current_state.header_serialized_ = XCdrHeaderSelection::LONG_HEADER;
+                break;
+        }
+        current_state.header_selection_ = header_selection;
+    }
+
+    current_state.member_size_ = is_present ? 1 : 0;
+    current_state.next_member_id_ = member_id;
+    next_member_id_ = MEMBER_ID_INVALID;
+
+    return *this;
+}
+
+Cdr& Cdr::xcdr2_end_serialize_member(
+        const Cdr::state& current_state)
+{
+    assert(MEMBER_ID_INVALID != current_state.next_member_id_);
+    assert(EncodingAlgorithmFlag::PLAIN_CDR2 == current_encoding_ ||
+            EncodingAlgorithmFlag::DELIMIT_CDR2 == current_encoding_ ||
+            EncodingAlgorithmFlag::PL_CDR2 == current_encoding_);
+
+    if (0 < current_state.member_size_ && EncodingAlgorithmFlag::PL_CDR2 == current_encoding_)
+    {
+        auto last_offset = offset_;
+        set_state(current_state);
+        make_alignment(alignment(sizeof(uint32_t)));
+        if (NO_SERIALIZED_MEMBER_SIZE == serialized_member_size_)
+        {
+            const size_t member_serialized_size = last_offset - offset_ -
+                    (current_state.header_serialized_ == XCdrHeaderSelection::SHORT_HEADER ? 4 : 8);
+            if (8 < member_serialized_size)
+            {
+                switch (current_state.header_serialized_)
+                {
+                    case XCdrHeaderSelection::SHORT_HEADER:
+                        if (AUTO_WITH_SHORT_HEADER_BY_DEFAULT == current_state.header_selection_)
+                        {
+                            xcdr2_change_to_long_member_header(current_state.next_member_id_, member_serialized_size);
+                        }
+                        else
+                        {
+                            throw BadParamException("Cannot encode XCDRv2 LongMemberHeader");
+                        }
+                        break;
+                    case XCdrHeaderSelection::LONG_HEADER:
+                        xcdr2_end_long_member_header(current_state.next_member_id_, member_serialized_size);
+                        break;
+                    default:
+                        assert(false); // header_serialized_ must have only SHORT_HEADER or LONG_HEADER
+                }
+            }
+            else
+            {
+                switch (current_state.header_serialized_)
+                {
+                    case XCdrHeaderSelection::SHORT_HEADER:
+                        xcdr2_end_short_member_header(current_state.next_member_id_, member_serialized_size);
+                        break;
+                    case XCdrHeaderSelection::LONG_HEADER:
+                        if (AUTO_WITH_LONG_HEADER_BY_DEFAULT == current_state.header_selection_)
+                        {
+                            xcdr2_change_to_short_member_header(current_state.next_member_id_, member_serialized_size);
+                        }
+                        else
+                        {
+                            xcdr2_end_long_member_header(current_state.next_member_id_, member_serialized_size);
+                        }
+                        break;
+                    default:
+                        assert(false); // header_serialized_ must have only SHORT_HEADER or LONG_HEADER
+                }
+            }
+
+            jump(member_serialized_size);
+        }
+        else
+        {
+            // Use inner type DHEADER as NEXTINT
+            switch (current_state.header_serialized_)
+            {
+                case XCdrHeaderSelection::SHORT_HEADER:
+                    if (AUTO_WITH_SHORT_HEADER_BY_DEFAULT == current_state.header_selection_)
+                    {
+                        xcdr2_end_long_member_header(current_state.next_member_id_, 0);
+                        offset_ = last_offset;
+                    }
+                    else
+                    {
+                        throw BadParamException("Cannot encode XCDRv2 LongMemberHeader");
+                    }
+                    break;
+                case XCdrHeaderSelection::LONG_HEADER:
+                    xcdr2_shrink_to_long_member_header(current_state.next_member_id_, last_offset);
+                    offset_ = last_offset;
+                    offset_ -= sizeof(uint32_t);
+                    break;
+                default:
+                    assert(false); // header_serialized_ must have only SHORT_HEADER or LONG_HEADER
+            }
+
+            last_data_size_ = 0;
+        }
+    }
+
+    next_member_id_ = MEMBER_ID_INVALID;
+    serialized_member_size_ = NO_SERIALIZED_MEMBER_SIZE;
+
+    return *this;
+}
+
+void Cdr::xcdr2_deserialize_member_header(
+        MemberId& member_id,
+        Cdr::state& current_state)
+{
+    uint32_t flags_and_member_id = 0;
+    deserialize(flags_and_member_id);
+    member_id.must_understand = (flags_and_member_id & 0x80000000);
+    uint32_t mid = (flags_and_member_id & 0x0FFFFFFF);
+    uint32_t lc = (flags_and_member_id & 0x70000000) >> 28;
+
+    member_id.id = mid;
+
+    if (4 > lc)
+    {
+        switch (lc)
+        {
+            case 0:
+                current_state.member_size_ = 1;
+                break;
+            case 1:
+                current_state.member_size_ = 2;
+                break;
+            case 2:
+                current_state.member_size_ = 4;
+                break;
+            case 3:
+                current_state.member_size_ = 8;
+                break;
+            default:
+                break;
+        }
+        current_state.header_serialized_ = XCdrHeaderSelection::SHORT_HEADER;
+    }
+    else if (4 == lc)
+    {
+        uint32_t size = 0;
+        deserialize(size);
+        current_state.member_size_ = size;
+        current_state.header_serialized_ = XCdrHeaderSelection::LONG_HEADER;
     }
     else
     {
-      m_currentPosition.rmemcopy(short_t, totalSize);
-      m_currentPosition += totalSize;
+        uint32_t size = 0;
+        deserialize(size);
+        current_state.member_size_ = 4 + (size * (5 == lc ? 1 : (6 == lc ? 4 : 8)));
+        current_state.header_serialized_ = XCdrHeaderSelection::SHORT_HEADER; // Avoid take into account DHEADER after.
+        offset_ -= sizeof(uint32_t);
     }
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::deserializeArray(int16_t* short_t, size_t numElements, Endianness endianness)
+Cdr& Cdr::xcdr1_begin_serialize_type(
+        Cdr::state& current_state,
+        EncodingAlgorithmFlag type_encoding) noexcept
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    deserializeArray(short_t, numElements);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
+    assert(current_state == Cdr::state(*this));
+    assert(EncodingAlgorithmFlag::PLAIN_CDR == current_encoding_ ||
+            EncodingAlgorithmFlag::PL_CDR == current_encoding_);
+    assert(EncodingAlgorithmFlag::PLAIN_CDR == type_encoding ||
+            EncodingAlgorithmFlag::PL_CDR == type_encoding);
+    current_state.previous_encoding_ = current_encoding_;
+    current_encoding_ = type_encoding;
+    return *this;
 }
 
-Cdr& Cdr::deserializeArray(int32_t* long_t, size_t numElements)
+Cdr& Cdr::xcdr1_end_serialize_type(
+        const Cdr::state& current_state)
 {
-  if (numElements == 0)
-  {
-    return *this;
-  }
+    assert(EncodingAlgorithmFlag::PLAIN_CDR == current_encoding_ ||
+            EncodingAlgorithmFlag::PL_CDR == current_encoding_);
 
-  size_t align = alignment(sizeof(*long_t));
-  size_t totalSize = sizeof(*long_t) * numElements;
-  size_t sizeAligned = totalSize + align;
-
-  if ((m_lastPosition - m_currentPosition) >= sizeAligned)
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(*long_t);
-
-    // Align if there are any elements
-    if (numElements)
+    if (EncodingAlgorithmFlag::PL_CDR == current_encoding_)
     {
-      makeAlign(align);
+        make_alignment(alignment(4));
+        serialize(PID_SENTINEL);
+        serialize(PID_SENTINEL_LENGTH);
     }
 
-    if (m_swapBytes)
-    {
-      char* dst = reinterpret_cast<char*>(long_t);
-      char* end = dst + totalSize;
+    current_encoding_ = current_state.previous_encoding_;
 
-      for (; dst < end; dst += sizeof(*long_t))
-      {
-        m_currentPosition++ >> dst[3];
-        m_currentPosition++ >> dst[2];
-        m_currentPosition++ >> dst[1];
-        m_currentPosition++ >> dst[0];
-      }
+    return *this;
+}
+
+Cdr& Cdr::xcdr2_begin_serialize_type(
+        Cdr::state& current_state,
+        EncodingAlgorithmFlag type_encoding)
+{
+    assert(current_state == Cdr::state(*this));
+    assert(EncodingAlgorithmFlag::PLAIN_CDR2 == current_encoding_ ||
+            EncodingAlgorithmFlag::DELIMIT_CDR2 == current_encoding_ ||
+            EncodingAlgorithmFlag::PL_CDR2 == current_encoding_);
+    assert(EncodingAlgorithmFlag::PLAIN_CDR2 == type_encoding ||
+            EncodingAlgorithmFlag::DELIMIT_CDR2 == type_encoding ||
+            EncodingAlgorithmFlag::PL_CDR2 == type_encoding);
+    if (EncodingAlgorithmFlag::PLAIN_CDR2 != type_encoding)
+    {
+        uint32_t dheader {0};
+        serialize(dheader);
+    }
+    serialized_member_size_ = NO_SERIALIZED_MEMBER_SIZE; // Avoid error when serializing arrays, sequences, etc..
+    current_state.previous_encoding_ = current_encoding_;
+    current_encoding_ = type_encoding;
+    return *this;
+}
+
+Cdr& Cdr::xcdr2_end_serialize_type(
+        const Cdr::state& current_state)
+{
+    assert(EncodingAlgorithmFlag::PLAIN_CDR2 == current_encoding_ ||
+            EncodingAlgorithmFlag::DELIMIT_CDR2 == current_encoding_ ||
+            EncodingAlgorithmFlag::PL_CDR2 == current_encoding_);
+    if (EncodingAlgorithmFlag::PLAIN_CDR2 != current_encoding_)
+    {
+        auto last_offset = offset_;
+        set_state(current_state);
+        const size_t member_serialized_size = last_offset - offset_ /*DHEADER ->*/ - 4 - alignment(4);
+        serialize(static_cast<uint32_t>(member_serialized_size));
+        jump(member_serialized_size);
+        serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
+    }
+    current_encoding_ = current_state.previous_encoding_;
+    return *this;
+}
+
+Cdr& Cdr::xcdr1_deserialize_type(
+        EncodingAlgorithmFlag type_encoding,
+        std::function<bool (Cdr&, const MemberId&)> functor)
+{
+    assert(EncodingAlgorithmFlag::PLAIN_CDR == type_encoding ||
+            EncodingAlgorithmFlag::PL_CDR == type_encoding);
+    Cdr::state current_state(*this);
+
+    if (EncodingAlgorithmFlag::PL_CDR == type_encoding)
+    {
+        while (xcdr1_deserialize_member_header(next_member_id_, current_state))
+        {
+            auto prev_offset = offset_;
+            bool deser_value = functor(*this, next_member_id_);
+
+            if (!deser_value)
+            {
+                if (next_member_id_.must_understand)
+                {
+                    throw BadParamException("Cannot deserialize a member with flag must_understand");
+                }
+                else
+                {
+                    jump(current_state.member_size_);
+                }
+            }
+
+            if (current_state.member_size_ != offset_ - prev_offset)
+            {
+                throw BadParamException(
+                          "Member size provided by member header is not equal to the real decoded member size");
+            }
+        }
     }
     else
     {
-      m_currentPosition.rmemcopy(long_t, totalSize);
-      m_currentPosition += totalSize;
+        next_member_id_ = MemberId(0);
+
+        while (offset_ != end_ && functor(*this, next_member_id_))
+        {
+            ++next_member_id_.id;
+        }
     }
 
+    next_member_id_ = current_state.next_member_id_;
+
     return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::deserializeArray(int32_t* long_t, size_t numElements, Endianness endianness)
+Cdr& Cdr::xcdr2_deserialize_type(
+        EncodingAlgorithmFlag type_encoding,
+        std::function<bool (Cdr&, const MemberId&)> functor)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
+    assert(EncodingAlgorithmFlag::PLAIN_CDR2 == type_encoding ||
+            EncodingAlgorithmFlag::DELIMIT_CDR2 == type_encoding ||
+            EncodingAlgorithmFlag::PL_CDR2 == type_encoding);
 
-  try
-  {
-    deserializeArray(long_t, numElements);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
 
-  return *this;
-}
-
-Cdr& Cdr::deserializeArray(wchar_t* wchar, size_t numElements)
-{
-  if (numElements == 0)
-  {
-    return *this;
-  }
-
-  uint32_t value;
-  for (size_t count = 0; count < numElements; ++count)
-  {
-    deserialize(value);
-    wchar[count] = static_cast<wchar_t>(value);
-  }
-  return *this;
-}
-
-Cdr& Cdr::deserializeArray(wchar_t* wchar, size_t numElements, Endianness endianness)
-{
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    deserializeArray(wchar, numElements);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::deserializeArray(int64_t* longlong_t, size_t numElements)
-{
-  if (numElements == 0)
-  {
-    return *this;
-  }
-
-  size_t align = alignment(sizeof(*longlong_t));
-  size_t totalSize = sizeof(*longlong_t) * numElements;
-  size_t sizeAligned = totalSize + align;
-
-  if ((m_lastPosition - m_currentPosition) >= sizeAligned)
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(*longlong_t);
-
-    // Align if there are any elements
-    if (numElements)
+    if (EncodingAlgorithmFlag::PLAIN_CDR2 != type_encoding)
     {
-      makeAlign(align);
-    }
+        uint32_t dheader {0};
+        deserialize(dheader);
 
-    if (m_swapBytes)
-    {
-      char* dst = reinterpret_cast<char*>(longlong_t);
-      char* end = dst + totalSize;
+        Cdr::state current_state(*this);
 
-      for (; dst < end; dst += sizeof(*longlong_t))
-      {
-        m_currentPosition++ >> dst[7];
-        m_currentPosition++ >> dst[6];
-        m_currentPosition++ >> dst[5];
-        m_currentPosition++ >> dst[4];
-        m_currentPosition++ >> dst[3];
-        m_currentPosition++ >> dst[2];
-        m_currentPosition++ >> dst[1];
-        m_currentPosition++ >> dst[0];
-      }
+        if (EncodingAlgorithmFlag::PL_CDR2 == type_encoding)
+        {
+            while (offset_ - current_state.offset_ != dheader)
+            {
+                if (offset_ - current_state.offset_ > dheader)
+                {
+                    throw BadParamException("Member size greater than size specified by DHEADER");
+                }
+
+                auto offset = offset_;
+
+                xcdr2_deserialize_member_header(next_member_id_, current_state);
+                bool deser_value = functor(*this, next_member_id_);
+                if (!deser_value)
+                {
+                    if (next_member_id_.must_understand)
+                    {
+                        throw BadParamException("Cannot deserialize a member with flag must_understand");
+                    }
+                    else
+                    {
+                        jump(current_state.member_size_);
+                    }
+                }
+
+                if (!(0 == current_state.member_size_ &&
+                        0 == offset_ - offset) &&
+                        !(0 < current_state.member_size_ &&
+                        current_state.member_size_ == offset_ - offset -
+                        alignment_on_state(current_state.origin_, offset, sizeof(uint32_t)) -
+                        (XCdrHeaderSelection::SHORT_HEADER == current_state.header_serialized_ ? 4 : 8)))
+                {
+                    throw BadParamException(
+                              "Member size provided by member header is not equal to the real decoded size");
+                }
+            }
+
+            next_member_id_ = current_state.next_member_id_;
+        }
+        else
+        {
+            next_member_id_ = MemberId(0);
+
+            while (offset_ - current_state.offset_ < dheader && functor(*this, next_member_id_))
+            {
+                ++next_member_id_.id;
+            }
+            size_t jump_size = dheader - (offset_ - current_state.offset_);
+            jump(jump_size);
+
+            next_member_id_ = current_state.next_member_id_;
+        }
     }
     else
     {
-      m_currentPosition.rmemcopy(longlong_t, totalSize);
-      m_currentPosition += totalSize;
+        Cdr::state current_state(*this);
+        next_member_id_ = MemberId(0);
+
+        while (offset_ != end_ && functor(*this, next_member_id_))
+        {
+            ++next_member_id_.id;
+        }
+
+        next_member_id_ = current_state.next_member_id_;
     }
 
     return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::deserializeArray(int64_t* longlong_t, size_t numElements, Endianness endianness)
+Cdr& Cdr::cdr_begin_serialize_member(
+        const MemberId&,
+        bool,
+        Cdr::state&,
+        XCdrHeaderSelection )
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    deserializeArray(longlong_t, numElements);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::deserializeArray(float* float_t, size_t numElements)
-{
-  if (numElements == 0)
-  {
+    next_member_id_ = MEMBER_ID_INVALID;
     return *this;
-  }
+}
 
-  size_t align = alignment(sizeof(*float_t));
-  size_t totalSize = sizeof(*float_t) * numElements;
-  size_t sizeAligned = totalSize + align;
-
-  if ((m_lastPosition - m_currentPosition) >= sizeAligned)
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(*float_t);
-
-    // Align if there are any elements
-    if (numElements)
-    {
-      makeAlign(align);
-    }
-
-    if (m_swapBytes)
-    {
-      char* dst = reinterpret_cast<char*>(float_t);
-      char* end = dst + totalSize;
-
-      for (; dst < end; dst += sizeof(*float_t))
-      {
-        m_currentPosition++ >> dst[3];
-        m_currentPosition++ >> dst[2];
-        m_currentPosition++ >> dst[1];
-        m_currentPosition++ >> dst[0];
-      }
-    }
-    else
-    {
-      m_currentPosition.rmemcopy(float_t, totalSize);
-      m_currentPosition += totalSize;
-    }
-
+Cdr& Cdr::cdr_end_serialize_member(
+        const Cdr::state&)
+{
+    next_member_id_ = MEMBER_ID_INVALID;
     return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::deserializeArray(float* float_t, size_t numElements, Endianness endianness)
+Cdr& Cdr::cdr_begin_serialize_type(
+        Cdr::state& current_state,
+        EncodingAlgorithmFlag type_encoding)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    deserializeArray(float_t, numElements);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::deserializeArray(double* double_t, size_t numElements)
-{
-  if (numElements == 0)
-  {
+    static_cast<void>(type_encoding);
+    assert(EncodingAlgorithmFlag::PLAIN_CDR == type_encoding);
+    current_state.previous_encoding_ = current_encoding_;
+    current_encoding_ = type_encoding;
     return *this;
-  }
+}
 
-  size_t align = alignment(sizeof(*double_t));
-  size_t totalSize = sizeof(*double_t) * numElements;
-  size_t sizeAligned = totalSize + align;
-
-  if ((m_lastPosition - m_currentPosition) >= sizeAligned)
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(*double_t);
-
-    // Align if there are any elements
-    if (numElements)
-    {
-      makeAlign(align);
-    }
-
-    if (m_swapBytes)
-    {
-      char* dst = reinterpret_cast<char*>(double_t);
-      char* end = dst + totalSize;
-
-      for (; dst < end; dst += sizeof(*double_t))
-      {
-        m_currentPosition++ >> dst[7];
-        m_currentPosition++ >> dst[6];
-        m_currentPosition++ >> dst[5];
-        m_currentPosition++ >> dst[4];
-        m_currentPosition++ >> dst[3];
-        m_currentPosition++ >> dst[2];
-        m_currentPosition++ >> dst[1];
-        m_currentPosition++ >> dst[0];
-      }
-    }
-    else
-    {
-      m_currentPosition.rmemcopy(double_t, totalSize);
-      m_currentPosition += totalSize;
-    }
-
+Cdr& Cdr::cdr_end_serialize_type(
+        const Cdr::state& current_state)
+{
+    current_encoding_ = current_state.previous_encoding_;
     return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::deserializeArray(double* double_t, size_t numElements, Endianness endianness)
+Cdr& Cdr::cdr_deserialize_type(
+        EncodingAlgorithmFlag type_encoding,
+        std::function<bool (Cdr&, const MemberId&)> functor)
 {
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
+    static_cast<void>(type_encoding);
+    assert(EncodingAlgorithmFlag::PLAIN_CDR == type_encoding);
 
-  try
-  {
-    deserializeArray(double_t, numElements);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
+    Cdr::state current_state(*this);
+    next_member_id_ = MemberId(0);
 
-  return *this;
-}
+    while (offset_ != end_ && functor(*this, next_member_id_))
+    {
+        ++next_member_id_.id;
+    }
 
-Cdr& Cdr::deserializeArray(long double* ldouble_t, size_t numElements)
-{
-  if (numElements == 0)
-  {
+    next_member_id_ = current_state.next_member_id_;
     return *this;
-  }
-
-  size_t align = alignment(ALIGNMENT_LONG_DOUBLE);
-  // Fix for Windows ( long doubles only store 8 bytes )
-  size_t totalSize = 16 * numElements;
-  size_t sizeAligned = totalSize + align;
-
-  if ((m_lastPosition - m_currentPosition) >= sizeAligned)
-  {
-    // Save last datasize.
-    m_lastDataSize = 16;
-
-    // Align if there are any elements
-    if (numElements)
-    {
-      makeAlign(align);
-    }
-
-#if FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
-    if (m_swapBytes)
-    {
-      for (size_t i = 0; i < numElements; ++i)
-      {
-        __float128 tmp;
-        char* dst = reinterpret_cast<char*>(&tmp);
-        m_currentPosition++ >> dst[15];
-        m_currentPosition++ >> dst[14];
-        m_currentPosition++ >> dst[13];
-        m_currentPosition++ >> dst[12];
-        m_currentPosition++ >> dst[11];
-        m_currentPosition++ >> dst[10];
-        m_currentPosition++ >> dst[9];
-        m_currentPosition++ >> dst[8];
-        m_currentPosition++ >> dst[7];
-        m_currentPosition++ >> dst[6];
-        m_currentPosition++ >> dst[5];
-        m_currentPosition++ >> dst[4];
-        m_currentPosition++ >> dst[3];
-        m_currentPosition++ >> dst[2];
-        m_currentPosition++ >> dst[1];
-        m_currentPosition++ >> dst[0];
-        ldouble_t[i] = static_cast<long double>(tmp);
-      }
-    }
-    else
-    {
-      for (size_t i = 0; i < numElements; ++i)
-      {
-        __float128 tmp;
-        m_currentPosition >> tmp;
-        m_currentPosition += 16;
-        ldouble_t[i] = static_cast<long double>(tmp);
-      }
-    }
-#else
-#if FASTCDR_SIZEOF_LONG_DOUBLE == 8 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
-    if (m_swapBytes)
-    {
-      char* dst = reinterpret_cast<char*>(ldouble_t);
-      char* end = dst + numElements * sizeof(*ldouble_t);
-
-      for (; dst < end; dst += sizeof(*ldouble_t))
-      {
-#if FASTCDR_SIZEOF_LONG_DOUBLE == 16
-        m_currentPosition++ >> dst[15];
-        m_currentPosition++ >> dst[14];
-        m_currentPosition++ >> dst[13];
-        m_currentPosition++ >> dst[12];
-        m_currentPosition++ >> dst[11];
-        m_currentPosition++ >> dst[10];
-        m_currentPosition++ >> dst[9];
-        m_currentPosition++ >> dst[8];
-#else
-        m_currentPosition += 8;
-#endif  // FASTCDR_SIZEOF_LONG_DOUBLE == 16
-        m_currentPosition++ >> dst[7];
-        m_currentPosition++ >> dst[6];
-        m_currentPosition++ >> dst[5];
-        m_currentPosition++ >> dst[4];
-        m_currentPosition++ >> dst[3];
-        m_currentPosition++ >> dst[2];
-        m_currentPosition++ >> dst[1];
-        m_currentPosition++ >> dst[0];
-      }
-    }
-    else
-    {
-#if FASTCDR_SIZEOF_LONG_DOUBLE == 16
-      m_currentPosition.rmemcopy(ldouble_t, totalSize);
-      m_currentPosition += totalSize;
-#else
-      for (size_t i = 0; i < numElements; ++i)
-      {
-        m_currentPosition += 8;  // ignore first 8 bytes
-        m_currentPosition >> ldouble_t[i];
-        m_currentPosition += 8;
-      }
-#endif  // FASTCDR_SIZEOF_LONG_DOUBLE == 16
-    }
-#endif  // FASTCDR_SIZEOF_LONG_DOUBLE == 8 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
-#endif  // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-Cdr& Cdr::deserializeArray(long double* ldouble_t, size_t numElements,
-                           Endianness endianness)
-{
-  bool auxSwap = m_swapBytes;
-  m_swapBytes = (m_swapBytes && (m_endianness == endianness)) ||
-                (!m_swapBytes && (m_endianness != endianness));
-
-  try
-  {
-    deserializeArray(ldouble_t, numElements);
-    m_swapBytes = auxSwap;
-  }
-  catch (Exception& ex)
-  {
-    m_swapBytes = auxSwap;
-    ex.raise();
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::serializeBoolSequence(const std::vector<bool>& vector_t)
-{
-  state state_before_error(*this);
-
-  *this << static_cast<int32_t>(vector_t.size());
-
-  size_t totalSize = vector_t.size() * sizeof(bool);
-
-  if (((m_lastPosition - m_currentPosition) >= totalSize) || resize(totalSize))
-  {
-    // Save last datasize.
-    m_lastDataSize = sizeof(bool);
-
-    for (size_t count = 0; count < vector_t.size(); ++count)
-    {
-      uint8_t value = 0;
-      std::vector<bool>::const_reference ref = vector_t[count];
-
-      if (ref)
-      {
-        value = 1;
-      }
-      m_currentPosition++ << value;
-    }
-  }
-  else
-  {
-    setState(state_before_error);
-    throw NotEnoughMemoryException(
-        NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::deserializeBoolSequence(std::vector<bool>& vector_t)
-{
-  uint32_t seqLength = 0;
-  state state_before_error(*this);
-
-  *this >> seqLength;
-
-  size_t totalSize = seqLength * sizeof(bool);
-
-  if ((m_lastPosition - m_currentPosition) >= totalSize)
-  {
-    vector_t.resize(seqLength);
-    // Save last datasize.
-    m_lastDataSize = sizeof(bool);
-
-    for (uint32_t count = 0; count < seqLength; ++count)
-    {
-      uint8_t value = 0;
-      m_currentPosition++ >> value;
-
-      if (value == 1)
-      {
-        vector_t[count] = true;
-      }
-      else if (value == 0)
-      {
-        vector_t[count] = false;
-      }
-      else
-      {
-        throw BadParamException("Unexpected byte value in Cdr::deserializeBoolSequence, "
-                                "expected 0 or 1");
-      }
-    }
-  }
-  else
-  {
-    setState(state_before_error);
-    throw NotEnoughMemoryException(
-        NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
-
-  return *this;
-}
-
-Cdr& Cdr::deserializeStringSequence(std::string*& sequence_t, size_t& numElements)
-{
-  uint32_t seqLength = 0;
-  state state_before_error(*this);
-
-  deserialize(seqLength);
-
-  try
-  {
-    sequence_t = new std::string[seqLength];
-    deserializeArray(sequence_t, seqLength);
-  }
-  catch (eprosima::fastcdr::exception::Exception& ex)
-  {
-    delete[] sequence_t;
-    sequence_t = NULL;
-    setState(state_before_error);
-    ex.raise();
-  }
-
-  numElements = seqLength;
-  return *this;
-}
-
-Cdr& Cdr::deserializeWStringSequence(std::wstring*& sequence_t, size_t& numElements)
-{
-  uint32_t seqLength = 0;
-  state state_before_error(*this);
-
-  deserialize(seqLength);
-
-  try
-  {
-    sequence_t = new std::wstring[seqLength];
-    deserializeArray(sequence_t, seqLength);
-  }
-  catch (eprosima::fastcdr::exception::Exception& ex)
-  {
-    delete[] sequence_t;
-    sequence_t = NULL;
-    setState(state_before_error);
-    ex.raise();
-  }
-
-  numElements = seqLength;
-  return *this;
-}
+} // namespace fastcdr
+} // namespace eprosima

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/CdrSizeCalculator.cpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/CdrSizeCalculator.cpp
@@ -1,0 +1,87 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fastcdr/CdrSizeCalculator.hpp>
+
+namespace eprosima {
+namespace fastcdr {
+
+CdrSizeCalculator::CdrSizeCalculator(
+        CdrVersion cdr_version)
+    : cdr_version_(cdr_version)
+{
+    switch (cdr_version_)
+    {
+        case CdrVersion::XCDRv2:
+            break;
+        default:
+            current_encoding_ = EncodingAlgorithmFlag::PLAIN_CDR;
+            align64_ = 8;
+            break;
+    }
+}
+
+CdrVersion CdrSizeCalculator::get_cdr_version() const
+{
+    return cdr_version_;
+}
+
+EncodingAlgorithmFlag CdrSizeCalculator::get_encoding() const
+{
+    return current_encoding_;
+}
+
+size_t CdrSizeCalculator::begin_calculate_type_serialized_size(
+        EncodingAlgorithmFlag new_encoding,
+        size_t& current_alignment)
+{
+    size_t calculated_size {0};
+    current_encoding_ = new_encoding;
+
+    if (CdrVersion::XCDRv2 == cdr_version_ && EncodingAlgorithmFlag::PLAIN_CDR2 != current_encoding_)
+    {
+        calculated_size = 4 + alignment(current_alignment, 4);     // DHEADER
+    }
+
+    current_alignment += calculated_size;
+
+    serialized_member_size_ = NO_SERIALIZED_MEMBER_SIZE;     // Avoid error when serializing arrays, sequences, etc..
+
+    return calculated_size;
+}
+
+size_t CdrSizeCalculator::end_calculate_type_serialized_size(
+        EncodingAlgorithmFlag new_encoding,
+        size_t& current_alignment)
+{
+    size_t calculated_size {0};
+
+    if (CdrVersion::XCDRv1 == cdr_version_ && EncodingAlgorithmFlag::PL_CDR == current_encoding_)
+    {
+        calculated_size = 4 + alignment(current_alignment, 4);     // Sentinel
+    }
+    else if (CdrVersion::XCDRv2 == cdr_version_ && EncodingAlgorithmFlag::PLAIN_CDR2 != current_encoding_)
+    {
+        serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
+    }
+
+    current_alignment += calculated_size;
+
+    current_encoding_ = new_encoding;
+
+    return calculated_size;
+}
+
+} // namespace fastcdr
+} // namespace eprosima

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/FastBuffer.cpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/FastBuffer.cpp
@@ -18,77 +18,79 @@
 #include <malloc.h>
 #else
 #include <stdlib.h>
-#endif  // if !__APPLE__ && !__FreeBSD__ && !__VXWORKS__
+#endif // if !__APPLE__ && !__FreeBSD__ && !__VXWORKS__
 
 #define BUFFER_START_LENGTH 200
 
 using namespace eprosima::fastcdr;
 
-FastBuffer::FastBuffer() : m_buffer(nullptr), m_bufferSize(0), m_internalBuffer(true)
-{
-}
-
-FastBuffer::FastBuffer(char* const buffer, const size_t bufferSize)
-  : m_buffer(buffer), m_bufferSize(bufferSize), m_internalBuffer(false)
+FastBuffer::FastBuffer(
+        char* const buffer,
+        const size_t bufferSize)
+    : buffer_(buffer)
+    , size_(bufferSize)
+    , m_internalBuffer(false)
 {
 }
 
 FastBuffer::~FastBuffer()
 {
-  if (m_internalBuffer && m_buffer != nullptr)
-  {
-    free(m_buffer);
-  }
+    if (m_internalBuffer && buffer_ != nullptr)
+    {
+        free(buffer_);
+    }
 }
 
-bool FastBuffer::reserve(size_t size)
+bool FastBuffer::reserve(
+        size_t size)
 {
-  if (m_internalBuffer && m_buffer == NULL)
-  {
-    m_buffer = reinterpret_cast<char*>(malloc(size));
-    if (m_buffer)
+    if (m_internalBuffer && buffer_ == NULL)
     {
-      m_bufferSize = size;
-      return true;
+        buffer_ = reinterpret_cast<char*>(malloc(size));
+        if (buffer_)
+        {
+            size_ = size;
+            return true;
+        }
     }
-  }
-  return false;
+    return false;
 }
 
-bool FastBuffer::resize(size_t minSizeInc)
+bool FastBuffer::resize(
+        size_t min_size_inc)
 {
-  size_t incBufferSize = BUFFER_START_LENGTH;
+    size_t incBufferSize = BUFFER_START_LENGTH;
 
-  if (m_internalBuffer)
-  {
-    if (minSizeInc > BUFFER_START_LENGTH)
+    if (m_internalBuffer)
     {
-      incBufferSize = minSizeInc;
+        if (min_size_inc > BUFFER_START_LENGTH)
+        {
+            incBufferSize = min_size_inc;
+        }
+
+        if (buffer_ == NULL)
+        {
+            size_ = incBufferSize;
+
+            buffer_ = reinterpret_cast<char*>(malloc(size_));
+
+            if (buffer_ != NULL)
+            {
+                return true;
+            }
+        }
+        else
+        {
+            size_ += incBufferSize;
+
+            buffer_ = reinterpret_cast<char*>(realloc(buffer_, size_));
+
+            if (buffer_ != NULL)
+            {
+                return true;
+            }
+        }
     }
 
-    if (m_buffer == NULL)
-    {
-      m_bufferSize = incBufferSize;
-
-      m_buffer = reinterpret_cast<char*>(malloc(m_bufferSize));
-
-      if (m_buffer != NULL)
-      {
-        return true;
-      }
-    }
-    else
-    {
-      m_bufferSize += incBufferSize;
-
-      m_buffer = reinterpret_cast<char*>(realloc(m_buffer, m_bufferSize));
-
-      if (m_buffer != NULL)
-      {
-        return true;
-      }
-    }
-  }
-
-  return false;
+    return false;
 }

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/FastCdr.cpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/FastCdr.cpp
@@ -19,767 +19,795 @@
 using namespace eprosima::fastcdr;
 using namespace ::exception;
 
-FastCdr::state::state(const FastCdr& fastcdr)
-  : m_currentPosition(fastcdr.m_currentPosition)
+FastCdr::state::state(
+        const FastCdr& fastcdr)
+    : current_position_(fastcdr.current_position_)
 {
 }
 
-FastCdr::state::state(const state& current_state)
-  : m_currentPosition(current_state.m_currentPosition)
+FastCdr::state::state(
+        const state& current_state)
+    : current_position_(current_state.current_position_)
 {
 }
 
-FastCdr::FastCdr(FastBuffer& cdrBuffer)
-  : m_cdrBuffer(cdrBuffer)
-  , m_currentPosition(cdrBuffer.begin())
-  , m_lastPosition(cdrBuffer.end())
+FastCdr::FastCdr(
+        FastBuffer& cdr_buffer)
+    : cdr_buffer_(cdr_buffer)
+    , current_position_(cdr_buffer.begin())
+    , last_position_(cdr_buffer.end())
 {
 }
 
-bool FastCdr::jump(size_t numBytes)
+bool FastCdr::jump(
+        size_t num_bytes)
 {
-  bool returnedValue = false;
+    bool ret_value = false;
 
-  if (((m_lastPosition - m_currentPosition) >= numBytes) || resize(numBytes))
-  {
-    m_currentPosition += numBytes;
-    returnedValue = true;
-  }
+    if (((last_position_ - current_position_) >= num_bytes) || resize(num_bytes))
+    {
+        current_position_ += num_bytes;
+        ret_value = true;
+    }
 
-  return returnedValue;
+    return ret_value;
 }
 
-char* FastCdr::getCurrentPosition()
+char* FastCdr::get_current_position()
 {
-  return &m_currentPosition;
+    return &current_position_;
 }
 
-FastCdr::state FastCdr::getState()
+FastCdr::state FastCdr::get_state()
 {
-  return FastCdr::state(*this);
+    return FastCdr::state(*this);
 }
 
-void FastCdr::setState(FastCdr::state& current_state)
+void FastCdr::set_state(
+        FastCdr::state& current_state)
 {
-  m_currentPosition >> current_state.m_currentPosition;
+    current_position_ >> current_state.current_position_;
 }
 
 void FastCdr::reset()
 {
-  m_currentPosition = m_cdrBuffer.begin();
+    current_position_ = cdr_buffer_.begin();
 }
 
-bool FastCdr::resize(size_t minSizeInc)
+bool FastCdr::resize(
+        size_t min_size_inc)
 {
-  if (m_cdrBuffer.resize(minSizeInc))
-  {
-    m_currentPosition << m_cdrBuffer.begin();
-    m_lastPosition = m_cdrBuffer.end();
-    return true;
-  }
-
-  return false;
-}
-
-FastCdr& FastCdr::serialize(const bool bool_t)
-{
-  uint8_t value = 0;
-
-  if (((m_lastPosition - m_currentPosition) >= sizeof(uint8_t)) ||
-      resize(sizeof(uint8_t)))
-  {
-    if (bool_t)
+    if (cdr_buffer_.resize(min_size_inc))
     {
-      value = 1;
+        current_position_ << cdr_buffer_.begin();
+        last_position_ = cdr_buffer_.end();
+        return true;
     }
-    m_currentPosition++ << value;
+
+    return false;
+}
+
+FastCdr& FastCdr::serialize(
+        const bool bool_t)
+{
+    uint8_t value = 0;
+
+    if (((last_position_ - current_position_) >= sizeof(uint8_t)) || resize(sizeof(uint8_t)))
+    {
+        if (bool_t)
+        {
+            value = 1;
+        }
+        current_position_++ << value;
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::serialize(
+        const char* string_t)
+{
+    uint32_t length = 0;
+
+    if (string_t != nullptr)
+    {
+        length = size_to_uint32(strlen(string_t)) + 1;
+    }
+
+    if (length > 0)
+    {
+        FastCdr::state state_before_error(*this);
+        serialize(length);
+
+        if (((last_position_ - current_position_) >= length) || resize(length))
+        {
+            current_position_.memcopy(string_t, length);
+            current_position_ += length;
+        }
+        else
+        {
+            set_state(state_before_error);
+            throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        }
+    }
+    else
+    {
+        serialize(length);
+    }
 
     return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
-FastCdr& FastCdr::serialize(const char* string_t)
+FastCdr& FastCdr::serialize(
+        const wchar_t* string_t)
 {
-  uint32_t length = 0;
+    uint32_t bytes_length = 0;
+    size_t wstrlen = 0;
 
-  if (string_t != nullptr)
-  {
-    length = size_to_uint32(strlen(string_t)) + 1;
-  }
+    if (string_t != nullptr)
+    {
+        wstrlen = wcslen(string_t);
+        bytes_length = size_to_uint32(wstrlen * 4);
+    }
 
-  if (length > 0)
-  {
+    if (bytes_length > 0)
+    {
+        FastCdr::state state_(*this);
+        serialize(size_to_uint32(wstrlen));
+
+        if (((last_position_ - current_position_) >= bytes_length) || resize(bytes_length))
+        {
+#if defined(_WIN32)
+            serialize_array(string_t, wstrlen);
+#else
+            current_position_.memcopy(string_t, bytes_length);
+            current_position_ += bytes_length; // size on bytes
+#endif // if defined(_WIN32)
+        }
+        else
+        {
+            set_state(state_);
+            throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        }
+    }
+    else
+    {
+        serialize(bytes_length);
+    }
+
+    return *this;
+}
+
+FastCdr& FastCdr::serialize_array(
+        const bool* bool_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*bool_t) * num_elements;
+
+    if (((last_position_ - current_position_) >= total_size) || resize(total_size))
+    {
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            uint8_t value = 0;
+
+            if (bool_t[count])
+            {
+                value = 1;
+            }
+            current_position_++ << value;
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::serialize_array(
+        const char* char_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*char_t) * num_elements;
+
+    if (((last_position_ - current_position_) >= total_size) || resize(total_size))
+    {
+        current_position_.memcopy(char_t, total_size);
+        current_position_ += total_size;
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::serialize_array(
+        const int16_t* short_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*short_t) * num_elements;
+
+    if (((last_position_ - current_position_) >= total_size) || resize(total_size))
+    {
+        current_position_.memcopy(short_t, total_size);
+        current_position_ += total_size;
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::serialize_array(
+        const int32_t* long_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*long_t) * num_elements;
+
+    if (((last_position_ - current_position_) >= total_size) || resize(total_size))
+    {
+        current_position_.memcopy(long_t, total_size);
+        current_position_ += total_size;
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::serialize_array(
+        const wchar_t* wchar,
+        size_t num_elements)
+{
+    for (size_t count = 0; count < num_elements; ++count)
+    {
+        serialize(wchar[count]);
+    }
+    return *this;
+}
+
+FastCdr& FastCdr::serialize_array(
+        const int64_t* longlong_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*longlong_t) * num_elements;
+
+    if (((last_position_ - current_position_) >= total_size) || resize(total_size))
+    {
+        current_position_.memcopy(longlong_t, total_size);
+        current_position_ += total_size;
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::serialize_array(
+        const float* float_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*float_t) * num_elements;
+
+    if (((last_position_ - current_position_) >= total_size) || resize(total_size))
+    {
+        current_position_.memcopy(float_t, total_size);
+        current_position_ += total_size;
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::serialize_array(
+        const double* double_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*double_t) * num_elements;
+
+    if (((last_position_ - current_position_) >= total_size) || resize(total_size))
+    {
+        current_position_.memcopy(double_t, total_size);
+        current_position_ += total_size;
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::serialize_array(
+        const long double* ldouble_t,
+        size_t num_elements)
+{
+    size_t total_size = 16 * num_elements;
+
+    if (((last_position_ - current_position_) >= total_size) || resize(total_size))
+    {
+#if FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+        for (size_t idx = 0; idx < num_elements; ++idx)
+        {
+            __float128 tmp = ldouble_t[idx];
+            current_position_ << tmp;
+            current_position_ += 16;
+        }
+#else
+#if FASTCDR_SIZEOF_LONG_DOUBLE == 16
+        current_position_.memcopy(ldouble_t, total_size);
+        current_position_ += total_size;
+#else
+#if FASTCDR_SIZEOF_LONG_DOUBLE == 8
+        for (size_t idx = 0; idx < num_elements; ++idx)
+        {
+            current_position_ << static_cast<long double>(0);
+            current_position_ += 8;
+            current_position_ << ldouble_t[idx];
+            current_position_ += 8;
+        }
+#else
+#error unsupported long double type and no __float128 available
+#endif // FASTCDR_SIZEOF_LONG_DOUBLE == 8
+#endif // FASTCDR_SIZEOF_LONG_DOUBLE == 16
+#endif // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::deserialize(
+        bool& bool_t)
+{
+    uint8_t value = 0;
+
+    if ((last_position_ - current_position_) >= sizeof(uint8_t))
+    {
+        current_position_++ >> value;
+
+        if (value == 1)
+        {
+            bool_t = true;
+            return *this;
+        }
+        else if (value == 0)
+        {
+            bool_t = false;
+            return *this;
+        }
+
+        throw BadParamException("Got unexpected byte value in deserialize for bool (expected 0 or 1)");
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::deserialize(
+        char*& string_t)
+{
+    uint32_t length = 0;
     FastCdr::state state_before_error(*this);
-    serialize(length);
 
-    if (((m_lastPosition - m_currentPosition) >= length) || resize(length))
+    deserialize(length);
+
+    if (length == 0)
     {
-      m_currentPosition.memcopy(string_t, length);
-      m_currentPosition += length;
+        string_t = NULL;
+        return *this;
+    }
+    else if ((last_position_ - current_position_) >= length)
+    {
+        // Allocate memory.
+        string_t =
+                reinterpret_cast<char*>(calloc(length + ((&current_position_)[length - 1] == '\0' ? 0 : 1),
+                sizeof(char)));
+        memcpy(string_t, &current_position_, length);
+        current_position_ += length;
+        return *this;
+    }
+
+    set_state(state_before_error);
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::deserialize(
+        wchar_t*& string_t)
+{
+    uint32_t length = 0;
+    FastCdr::state state_before_error(*this);
+
+    deserialize(length);
+
+    if (length == 0)
+    {
+        string_t = NULL;
+        return *this;
+    }
+    else if ((last_position_ - current_position_) >= length)
+    {
+        // Allocate memory.
+        string_t = reinterpret_cast<wchar_t*>(calloc(length + 1, sizeof(wchar_t))); // WStrings never serialize terminating zero
+
+#if defined(_WIN32)
+        for (size_t idx = 0; idx < length; ++idx)
+        {
+            uint32_t temp;
+            current_position_ >> temp;
+            string_t[idx] = static_cast<wchar_t>(temp);
+            current_position_ += 4;
+        }
+#else
+        memcpy(string_t, &current_position_, length * sizeof(wchar_t));
+        current_position_ += length * sizeof(wchar_t);
+#endif // if defined(_WIN32)
+
+        return *this;
+    }
+
+    set_state(state_before_error);
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+const char* FastCdr::read_string(
+        uint32_t& length)
+{
+    const char* ret_value = "";
+    state state_before_error(*this);
+
+    *this >> length;
+
+    if (length == 0)
+    {
+        return ret_value;
+    }
+    else if ((last_position_ - current_position_) >= length)
+    {
+        ret_value = &current_position_;
+        current_position_ += length;
+        if (ret_value[length - 1] == '\0')
+        {
+            --length;
+        }
+        return ret_value;
+    }
+
+    set_state(state_before_error);
+    throw eprosima::fastcdr::exception::NotEnoughMemoryException(
+              eprosima::fastcdr::exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+std::wstring FastCdr::read_wstring(
+        uint32_t& length)
+{
+    std::wstring ret_value = L"";
+    state state_(*this);
+
+    *this >> length;
+    uint32_t bytes_length = length * 4;
+
+    if (bytes_length == 0)
+    {
+        return ret_value;
+    }
+    else if ((last_position_ - current_position_) >= bytes_length)
+    {
+
+        ret_value.resize(length);
+        deserialize_array(const_cast<wchar_t*>(ret_value.c_str()), length);
+        if (ret_value[length - 1] == L'\0')
+        {
+            --length;
+            ret_value.erase(length);
+        }
+        return ret_value;
+    }
+
+    set_state(state_);
+    throw eprosima::fastcdr::exception::NotEnoughMemoryException(
+              eprosima::fastcdr::exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::deserialize_array(
+        bool* bool_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*bool_t) * num_elements;
+
+    if ((last_position_ - current_position_) >= total_size)
+    {
+        for (size_t count = 0; count < num_elements; ++count)
+        {
+            uint8_t value = 0;
+            current_position_++ >> value;
+
+            if (value == 1)
+            {
+                bool_t[count] = true;
+            }
+            else if (value == 0)
+            {
+                bool_t[count] = false;
+            }
+        }
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::deserialize_array(
+        char* char_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*char_t) * num_elements;
+
+    if ((last_position_ - current_position_) >= total_size)
+    {
+        current_position_.rmemcopy(char_t, total_size);
+        current_position_ += total_size;
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::deserialize_array(
+        int16_t* short_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*short_t) * num_elements;
+
+    if ((last_position_ - current_position_) >= total_size)
+    {
+        current_position_.rmemcopy(short_t, total_size);
+        current_position_ += total_size;
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::deserialize_array(
+        int32_t* long_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*long_t) * num_elements;
+
+    if ((last_position_ - current_position_) >= total_size)
+    {
+        current_position_.rmemcopy(long_t, total_size);
+        current_position_ += total_size;
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::deserialize_array(
+        wchar_t* wchar,
+        size_t num_elements)
+{
+    uint32_t value = 0;
+    for (size_t count = 0; count < num_elements; ++count)
+    {
+        deserialize(value);
+        wchar[count] = static_cast<wchar_t>(value);
+    }
+    return *this;
+}
+
+FastCdr& FastCdr::deserialize_array(
+        int64_t* longlong_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*longlong_t) * num_elements;
+
+    if ((last_position_ - current_position_) >= total_size)
+    {
+        current_position_.rmemcopy(longlong_t, total_size);
+        current_position_ += total_size;
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::deserialize_array(
+        float* float_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*float_t) * num_elements;
+
+    if ((last_position_ - current_position_) >= total_size)
+    {
+        current_position_.rmemcopy(float_t, total_size);
+        current_position_ += total_size;
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::deserialize_array(
+        double* double_t,
+        size_t num_elements)
+{
+    size_t total_size = sizeof(*double_t) * num_elements;
+
+    if ((last_position_ - current_position_) >= total_size)
+    {
+        current_position_.rmemcopy(double_t, total_size);
+        current_position_ += total_size;
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::deserialize_array(
+        long double* ldouble_t,
+        size_t num_elements)
+{
+    size_t total_size = 16 * num_elements;
+
+    if ((last_position_ - current_position_) >= total_size)
+    {
+#if FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+        for (size_t idx = 0; idx < num_elements; ++idx)
+        {
+            __float128 tmp;
+            current_position_ >> tmp;
+            current_position_ += 16;
+            ldouble_t[idx] = static_cast<long double>(tmp);
+        }
+#else
+#if FASTCDR_SIZEOF_LONG_DOUBLE == 16
+        current_position_.rmemcopy(ldouble_t, total_size);
+        current_position_ += total_size;
+#else
+#if FASTCDR_SIZEOF_LONG_DOUBLE == 8
+        for (size_t idx = 0; idx < num_elements; ++idx)
+        {
+            current_position_ += 8;
+            current_position_ >> ldouble_t[idx];
+            current_position_ += 8;
+        }
+#else
+#error unsupported long double type and no __float128 available
+#endif // FASTCDR_SIZEOF_LONG_DOUBLE == 8
+#endif // FASTCDR_SIZEOF_LONG_DOUBLE == 16
+#endif // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
+
+        return *this;
+    }
+
+    throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+}
+
+FastCdr& FastCdr::serialize_bool_sequence(
+        const std::vector<bool>& vector_t)
+{
+    state state_before_error(*this);
+
+    *this << static_cast<int32_t>(vector_t.size());
+
+    size_t total_size = vector_t.size() * sizeof(bool);
+
+    if (((last_position_ - current_position_) >= total_size) || resize(total_size))
+    {
+        for (size_t count = 0; count < vector_t.size(); ++count)
+        {
+            uint8_t value = 0;
+            std::vector<bool>::const_reference ref = vector_t[count];
+
+            if (ref)
+            {
+                value = 1;
+            }
+            current_position_++ << value;
+        }
     }
     else
     {
-      setState(state_before_error);
-      throw NotEnoughMemoryException(
-          NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        set_state(state_before_error);
+        throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
-  }
-  else
-  {
-    serialize(length);
-  }
 
-  return *this;
+    return *this;
 }
 
-FastCdr& FastCdr::serialize(const wchar_t* string_t)
+FastCdr& FastCdr::deserialize_bool_sequence(
+        std::vector<bool>& vector_t)
 {
-  uint32_t bytesLength = 0;
-  size_t wstrlen = 0;
+    uint32_t sequence_length = 0;
+    state state_before_error(*this);
 
-  if (string_t != nullptr)
-  {
-    wstrlen = wcslen(string_t);
-    bytesLength = size_to_uint32(wstrlen * 4);
-  }
+    *this >> sequence_length;
 
-  if (bytesLength > 0)
-  {
-    FastCdr::state state_(*this);
-    serialize(size_to_uint32(wstrlen));
+    size_t total_size = sequence_length * sizeof(bool);
 
-    if (((m_lastPosition - m_currentPosition) >= bytesLength) || resize(bytesLength))
+    if ((last_position_ - current_position_) >= total_size)
     {
-#if defined(_WIN32)
-      serializeArray(string_t, wstrlen);
-#else
-      m_currentPosition.memcopy(string_t, bytesLength);
-      m_currentPosition += bytesLength;  // size on bytes
-#endif  // if defined(_WIN32)
+        vector_t.resize(sequence_length);
+        for (uint32_t count = 0; count < sequence_length; ++count)
+        {
+            uint8_t value = 0;
+            current_position_++ >> value;
+
+            if (value == 1)
+            {
+                vector_t[count] = true;
+            }
+            else if (value == 0)
+            {
+                vector_t[count] = false;
+            }
+        }
     }
     else
     {
-      setState(state_);
-      throw NotEnoughMemoryException(
-          NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        set_state(state_before_error);
+        throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
-  }
-  else
-  {
-    serialize(bytesLength);
-  }
 
-  return *this;
+    return *this;
 }
 
-FastCdr& FastCdr::serializeArray(const bool* bool_t, size_t numElements)
+FastCdr& FastCdr::deserialize_string_sequence(
+        std::string*& sequence_t,
+        size_t& num_elements)
 {
-  size_t totalSize = sizeof(*bool_t) * numElements;
+    uint32_t sequence_length = 0;
+    state state_before_error(*this);
 
-  if (((m_lastPosition - m_currentPosition) >= totalSize) || resize(totalSize))
-  {
-    for (size_t count = 0; count < numElements; ++count)
+    deserialize(sequence_length);
+
+    try
     {
-      uint8_t value = 0;
-
-      if (bool_t[count])
-      {
-        value = 1;
-      }
-      m_currentPosition++ << value;
+        sequence_t = new std::string[sequence_length];
+        deserialize_array(sequence_t, sequence_length);
     }
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::serializeArray(const char* char_t, size_t numElements)
-{
-  size_t totalSize = sizeof(*char_t) * numElements;
-
-  if (((m_lastPosition - m_currentPosition) >= totalSize) || resize(totalSize))
-  {
-    m_currentPosition.memcopy(char_t, totalSize);
-    m_currentPosition += totalSize;
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::serializeArray(const int16_t* short_t, size_t numElements)
-{
-  size_t totalSize = sizeof(*short_t) * numElements;
-
-  if (((m_lastPosition - m_currentPosition) >= totalSize) || resize(totalSize))
-  {
-    m_currentPosition.memcopy(short_t, totalSize);
-    m_currentPosition += totalSize;
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::serializeArray(const int32_t* long_t, size_t numElements)
-{
-  size_t totalSize = sizeof(*long_t) * numElements;
-
-  if (((m_lastPosition - m_currentPosition) >= totalSize) || resize(totalSize))
-  {
-    m_currentPosition.memcopy(long_t, totalSize);
-    m_currentPosition += totalSize;
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::serializeArray(const wchar_t* wchar, size_t numElements)
-{
-  for (size_t count = 0; count < numElements; ++count)
-  {
-    serialize(wchar[count]);
-  }
-  return *this;
-}
-
-FastCdr& FastCdr::serializeArray(const int64_t* longlong_t, size_t numElements)
-{
-  size_t totalSize = sizeof(*longlong_t) * numElements;
-
-  if (((m_lastPosition - m_currentPosition) >= totalSize) || resize(totalSize))
-  {
-    m_currentPosition.memcopy(longlong_t, totalSize);
-    m_currentPosition += totalSize;
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::serializeArray(const float* float_t, size_t numElements)
-{
-  size_t totalSize = sizeof(*float_t) * numElements;
-
-  if (((m_lastPosition - m_currentPosition) >= totalSize) || resize(totalSize))
-  {
-    m_currentPosition.memcopy(float_t, totalSize);
-    m_currentPosition += totalSize;
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::serializeArray(const double* double_t, size_t numElements)
-{
-  size_t totalSize = sizeof(*double_t) * numElements;
-
-  if (((m_lastPosition - m_currentPosition) >= totalSize) || resize(totalSize))
-  {
-    m_currentPosition.memcopy(double_t, totalSize);
-    m_currentPosition += totalSize;
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::serializeArray(const long double* ldouble_t, size_t numElements)
-{
-  size_t totalSize = 16 * numElements;
-
-  if (((m_lastPosition - m_currentPosition) >= totalSize) || resize(totalSize))
-  {
-#if FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
-    for (size_t idx = 0; idx < numElements; ++idx)
+    catch (eprosima::fastcdr::exception::Exception& ex)
     {
-      __float128 tmp = ldouble_t[idx];
-      m_currentPosition << tmp;
-      m_currentPosition += 16;
+        delete [] sequence_t;
+        sequence_t = NULL;
+        set_state(state_before_error);
+        ex.raise();
     }
-#else
-#if FASTCDR_SIZEOF_LONG_DOUBLE == 16
-    m_currentPosition.memcopy(ldouble_t, totalSize);
-    m_currentPosition += totalSize;
-#else
-#if FASTCDR_SIZEOF_LONG_DOUBLE == 8
-    for (size_t idx = 0; idx < numElements; ++idx)
+
+    num_elements = sequence_length;
+    return *this;
+}
+
+FastCdr& FastCdr::deserialize_wstring_sequence(
+        std::wstring*& sequence_t,
+        size_t& num_elements)
+{
+    uint32_t sequence_length = 0;
+    state state_before_error(*this);
+
+    deserialize(sequence_length);
+
+    try
     {
-      m_currentPosition << static_cast<long double>(0);
-      m_currentPosition += 8;
-      m_currentPosition << ldouble_t[idx];
-      m_currentPosition += 8;
+        sequence_t = new std::wstring[sequence_length];
+        deserialize_array(sequence_t, sequence_length);
     }
-#else
-#error unsupported long double type and no __float128 available
-#endif  // FASTCDR_SIZEOF_LONG_DOUBLE == 8
-#endif  // FASTCDR_SIZEOF_LONG_DOUBLE == 16
-#endif  // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::deserialize(bool& bool_t)
-{
-  uint8_t value = 0;
-
-  if ((m_lastPosition - m_currentPosition) >= sizeof(uint8_t))
-  {
-    m_currentPosition++ >> value;
-
-    if (value == 1)
+    catch (eprosima::fastcdr::exception::Exception& ex)
     {
-      bool_t = true;
-      return *this;
-    }
-    else if (value == 0)
-    {
-      bool_t = false;
-      return *this;
+        delete [] sequence_t;
+        sequence_t = NULL;
+        set_state(state_before_error);
+        ex.raise();
     }
 
-    throw BadParamException("Got unexpected byte value in deserialize for bool (expected "
-                            "0 or 1)");
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::deserialize(char*& string_t)
-{
-  uint32_t length = 0;
-  FastCdr::state state_before_error(*this);
-
-  deserialize(length);
-
-  if (length == 0)
-  {
-    string_t = NULL;
+    num_elements = sequence_length;
     return *this;
-  }
-  else if ((m_lastPosition - m_currentPosition) >= length)
-  {
-    // Allocate memory.
-    string_t = reinterpret_cast<char*>(calloc(
-        length + ((&m_currentPosition)[length - 1] == '\0' ? 0 : 1), sizeof(char)));
-    memcpy(string_t, &m_currentPosition, length);
-    m_currentPosition += length;
-    return *this;
-  }
-
-  setState(state_before_error);
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::deserialize(wchar_t*& string_t)
-{
-  uint32_t length = 0;
-  FastCdr::state state_before_error(*this);
-
-  deserialize(length);
-
-  if (length == 0)
-  {
-    string_t = NULL;
-    return *this;
-  }
-  else if ((m_lastPosition - m_currentPosition) >= length)
-  {
-    // Allocate memory.
-    string_t = reinterpret_cast<wchar_t*>(calloc(
-        length + 1, sizeof(wchar_t)));  // WStrings never serialize terminating zero
-
-#if defined(_WIN32)
-    for (size_t idx = 0; idx < length; ++idx)
-    {
-      uint32_t temp;
-      m_currentPosition >> temp;
-      string_t[idx] = static_cast<wchar_t>(temp);
-      m_currentPosition += 4;
-    }
-#else
-    memcpy(string_t, &m_currentPosition, length * sizeof(wchar_t));
-    m_currentPosition += length * sizeof(wchar_t);
-#endif  // if defined(_WIN32)
-
-    return *this;
-  }
-
-  setState(state_before_error);
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-const char* FastCdr::readString(uint32_t& length)
-{
-  const char* returnedValue = "";
-  state state_before_error(*this);
-
-  *this >> length;
-
-  if (length == 0)
-  {
-    return returnedValue;
-  }
-  else if ((m_lastPosition - m_currentPosition) >= length)
-  {
-    returnedValue = &m_currentPosition;
-    m_currentPosition += length;
-    if (returnedValue[length - 1] == '\0')
-    {
-      --length;
-    }
-    return returnedValue;
-  }
-
-  setState(state_before_error);
-  throw eprosima::fastcdr::exception::NotEnoughMemoryException(
-      eprosima::fastcdr::exception::NotEnoughMemoryException::
-          NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-std::wstring FastCdr::readWString(uint32_t& length)
-{
-  std::wstring returnedValue = L"";
-  state state_(*this);
-
-  *this >> length;
-  uint32_t bytesLength = length * 4;
-
-  if (bytesLength == 0)
-  {
-    return returnedValue;
-  }
-  else if ((m_lastPosition - m_currentPosition) >= bytesLength)
-  {
-    returnedValue.resize(length);
-    deserializeArray(const_cast<wchar_t*>(returnedValue.c_str()), length);
-    if (returnedValue[length - 1] == L'\0')
-    {
-      --length;
-      returnedValue.erase(length);
-    }
-    return returnedValue;
-  }
-
-  setState(state_);
-  throw eprosima::fastcdr::exception::NotEnoughMemoryException(
-      eprosima::fastcdr::exception::NotEnoughMemoryException::
-          NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::deserializeArray(bool* bool_t, size_t numElements)
-{
-  size_t totalSize = sizeof(*bool_t) * numElements;
-
-  if ((m_lastPosition - m_currentPosition) >= totalSize)
-  {
-    for (size_t count = 0; count < numElements; ++count)
-    {
-      uint8_t value = 0;
-      m_currentPosition++ >> value;
-
-      if (value == 1)
-      {
-        bool_t[count] = true;
-      }
-      else if (value == 0)
-      {
-        bool_t[count] = false;
-      }
-    }
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::deserializeArray(char* char_t, size_t numElements)
-{
-  size_t totalSize = sizeof(*char_t) * numElements;
-
-  if ((m_lastPosition - m_currentPosition) >= totalSize)
-  {
-    m_currentPosition.rmemcopy(char_t, totalSize);
-    m_currentPosition += totalSize;
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::deserializeArray(int16_t* short_t, size_t numElements)
-{
-  size_t totalSize = sizeof(*short_t) * numElements;
-
-  if ((m_lastPosition - m_currentPosition) >= totalSize)
-  {
-    m_currentPosition.rmemcopy(short_t, totalSize);
-    m_currentPosition += totalSize;
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::deserializeArray(int32_t* long_t, size_t numElements)
-{
-  size_t totalSize = sizeof(*long_t) * numElements;
-
-  if ((m_lastPosition - m_currentPosition) >= totalSize)
-  {
-    m_currentPosition.rmemcopy(long_t, totalSize);
-    m_currentPosition += totalSize;
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::deserializeArray(wchar_t* wchar, size_t numElements)
-{
-  uint32_t value = 0;
-  for (size_t count = 0; count < numElements; ++count)
-  {
-    deserialize(value);
-    wchar[count] = static_cast<wchar_t>(value);
-  }
-  return *this;
-}
-
-FastCdr& FastCdr::deserializeArray(int64_t* longlong_t, size_t numElements)
-{
-  size_t totalSize = sizeof(*longlong_t) * numElements;
-
-  if ((m_lastPosition - m_currentPosition) >= totalSize)
-  {
-    m_currentPosition.rmemcopy(longlong_t, totalSize);
-    m_currentPosition += totalSize;
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::deserializeArray(float* float_t, size_t numElements)
-{
-  size_t totalSize = sizeof(*float_t) * numElements;
-
-  if ((m_lastPosition - m_currentPosition) >= totalSize)
-  {
-    m_currentPosition.rmemcopy(float_t, totalSize);
-    m_currentPosition += totalSize;
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::deserializeArray(double* double_t, size_t numElements)
-{
-  size_t totalSize = sizeof(*double_t) * numElements;
-
-  if ((m_lastPosition - m_currentPosition) >= totalSize)
-  {
-    m_currentPosition.rmemcopy(double_t, totalSize);
-    m_currentPosition += totalSize;
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::deserializeArray(long double* ldouble_t, size_t numElements)
-{
-  size_t totalSize = 16 * numElements;
-
-  if ((m_lastPosition - m_currentPosition) >= totalSize)
-  {
-#if FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
-    for (size_t idx = 0; idx < numElements; ++idx)
-    {
-      __float128 tmp;
-      m_currentPosition >> tmp;
-      m_currentPosition += 16;
-      ldouble_t[idx] = static_cast<long double>(tmp);
-    }
-#else
-#if FASTCDR_SIZEOF_LONG_DOUBLE == 16
-    m_currentPosition.rmemcopy(ldouble_t, totalSize);
-    m_currentPosition += totalSize;
-#else
-#if FASTCDR_SIZEOF_LONG_DOUBLE == 8
-    for (size_t idx = 0; idx < numElements; ++idx)
-    {
-      m_currentPosition += 8;
-      m_currentPosition >> ldouble_t[idx];
-      m_currentPosition += 8;
-    }
-#else
-#error unsupported long double type and no __float128 available
-#endif  // FASTCDR_SIZEOF_LONG_DOUBLE == 8
-#endif  // FASTCDR_SIZEOF_LONG_DOUBLE == 16
-#endif  // FASTCDR_HAVE_FLOAT128 && FASTCDR_SIZEOF_LONG_DOUBLE < 16
-
-    return *this;
-  }
-
-  throw NotEnoughMemoryException(
-      NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-}
-
-FastCdr& FastCdr::serializeBoolSequence(const std::vector<bool>& vector_t)
-{
-  state state_before_error(*this);
-
-  *this << static_cast<int32_t>(vector_t.size());
-
-  size_t totalSize = vector_t.size() * sizeof(bool);
-
-  if (((m_lastPosition - m_currentPosition) >= totalSize) || resize(totalSize))
-  {
-    for (size_t count = 0; count < vector_t.size(); ++count)
-    {
-      uint8_t value = 0;
-      std::vector<bool>::const_reference ref = vector_t[count];
-
-      if (ref)
-      {
-        value = 1;
-      }
-      m_currentPosition++ << value;
-    }
-  }
-  else
-  {
-    setState(state_before_error);
-    throw NotEnoughMemoryException(
-        NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
-
-  return *this;
-}
-
-FastCdr& FastCdr::deserializeBoolSequence(std::vector<bool>& vector_t)
-{
-  uint32_t seqLength = 0;
-  state state_before_error(*this);
-
-  *this >> seqLength;
-
-  size_t totalSize = seqLength * sizeof(bool);
-
-  if ((m_lastPosition - m_currentPosition) >= totalSize)
-  {
-    vector_t.resize(seqLength);
-    for (uint32_t count = 0; count < seqLength; ++count)
-    {
-      uint8_t value = 0;
-      m_currentPosition++ >> value;
-
-      if (value == 1)
-      {
-        vector_t[count] = true;
-      }
-      else if (value == 0)
-      {
-        vector_t[count] = false;
-      }
-    }
-  }
-  else
-  {
-    setState(state_before_error);
-    throw NotEnoughMemoryException(
-        NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
-  }
-
-  return *this;
-}
-
-FastCdr& FastCdr::deserializeStringSequence(std::string*& sequence_t, size_t& numElements)
-{
-  uint32_t seqLength = 0;
-  state state_before_error(*this);
-
-  deserialize(seqLength);
-
-  try
-  {
-    sequence_t = new std::string[seqLength];
-    deserializeArray(sequence_t, seqLength);
-  }
-  catch (eprosima::fastcdr::exception::Exception& ex)
-  {
-    delete[] sequence_t;
-    sequence_t = NULL;
-    setState(state_before_error);
-    ex.raise();
-  }
-
-  numElements = seqLength;
-  return *this;
-}
-
-FastCdr& FastCdr::deserializeWStringSequence(std::wstring*& sequence_t,
-                                             size_t& numElements)
-{
-  uint32_t seqLength = 0;
-  state state_before_error(*this);
-
-  deserialize(seqLength);
-
-  try
-  {
-    sequence_t = new std::wstring[seqLength];
-    deserializeArray(sequence_t, seqLength);
-  }
-  catch (eprosima::fastcdr::exception::Exception& ex)
-  {
-    delete[] sequence_t;
-    sequence_t = NULL;
-    setState(state_before_error);
-    ex.raise();
-  }
-
-  numElements = seqLength;
-  return *this;
 }

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/exceptions/BadOptionalAccessException.cpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/exceptions/BadOptionalAccessException.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,32 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <fastcdr/exceptions/BadParamException.h>
+#include <fastcdr/exceptions/BadOptionalAccessException.hpp>
 
 using namespace eprosima::fastcdr::exception;
 
-const char* const BadParamException::BAD_PARAM_MESSAGE_DEFAULT = "Bad parameter";
+const char* const BadOptionalAccessException::BAD_OPTIONAL_ACCESS_MESSAGE_DEFAULT =
+        "Bad optional access: value not set";
 
-BadParamException::BadParamException(
+BadOptionalAccessException::BadOptionalAccessException(
         const char* const& message) noexcept
     : Exception(message)
 {
 }
 
-BadParamException::BadParamException(
-        const BadParamException& ex) noexcept
+BadOptionalAccessException::BadOptionalAccessException(
+        const BadOptionalAccessException& ex) noexcept
     : Exception(ex)
 {
 }
 
-BadParamException::BadParamException(
-        BadParamException&& ex) noexcept
+BadOptionalAccessException::BadOptionalAccessException(
+        BadOptionalAccessException&& ex) noexcept
     : Exception(std::move(ex))
 {
 }
 
-BadParamException& BadParamException::operator =(
-        const BadParamException& ex) noexcept
+BadOptionalAccessException& BadOptionalAccessException::operator =(
+        const BadOptionalAccessException& ex) noexcept
 {
     if (this != &ex)
     {
@@ -48,8 +49,8 @@ BadParamException& BadParamException::operator =(
     return *this;
 }
 
-BadParamException& BadParamException::operator =(
-        BadParamException&& ex) noexcept
+BadOptionalAccessException& BadOptionalAccessException::operator =(
+        BadOptionalAccessException&& ex) noexcept
 {
     if (this != &ex)
     {
@@ -60,11 +61,11 @@ BadParamException& BadParamException::operator =(
     return *this;
 }
 
-BadParamException::~BadParamException() noexcept
+BadOptionalAccessException::~BadOptionalAccessException() noexcept
 {
 }
 
-void BadParamException::raise() const
+void BadOptionalAccessException::raise() const
 {
     throw *this;
 }

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/exceptions/Exception.cpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/exceptions/Exception.cpp
@@ -16,35 +16,37 @@
 
 using namespace eprosima::fastcdr::exception;
 
-Exception::Exception(const char* const& message) noexcept : m_message(message)
+Exception::Exception(
+        const char* const& message) noexcept
+    : m_message(message)
 {
 }
 
-Exception::Exception(const Exception& ex) noexcept : m_message(ex.m_message)
+Exception::Exception(
+        const Exception& ex) noexcept
+    : m_message(ex.m_message)
 {
 }
 
-#if HAVE_CXX0X
-Exception::Exception(Exception&& ex) noexcept : m_message(std::move(ex.m_message))
+Exception::Exception(
+        Exception&& ex) noexcept
+    : m_message(std::move(ex.m_message))
 {
 }
 
-#endif  // if HAVE_CXX0X
-
-Exception& Exception::operator=(const Exception& ex) noexcept
+Exception& Exception::operator =(
+        const Exception& ex) noexcept
 {
-  m_message = ex.m_message;
-  return *this;
+    m_message = ex.m_message;
+    return *this;
 }
 
-#if HAVE_CXX0X
-Exception& Exception::operator=(Exception&& ex) noexcept
+Exception& Exception::operator =(
+        Exception&& ex) noexcept
 {
-  m_message = std::move(ex.m_message);
-  return *this;
+    m_message = std::move(ex.m_message);
+    return *this;
 }
-
-#endif  // if HAVE_CXX0X
 
 Exception::~Exception() noexcept
 {
@@ -52,5 +54,5 @@ Exception::~Exception() noexcept
 
 const char* Exception::what() const noexcept
 {
-  return m_message;
+    return m_message;
 }

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/exceptions/LockedExternalAccessException.cpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/exceptions/LockedExternalAccessException.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,32 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <fastcdr/exceptions/BadParamException.h>
+#include <fastcdr/exceptions/LockedExternalAccessException.hpp>
 
 using namespace eprosima::fastcdr::exception;
 
-const char* const BadParamException::BAD_PARAM_MESSAGE_DEFAULT = "Bad parameter";
+const char* const LockedExternalAccessException::LOCKED_EXTERNAL_ACCESS_MESSAGE_DEFAULT =
+        "Locked external: value cannot be set";
 
-BadParamException::BadParamException(
+LockedExternalAccessException::LockedExternalAccessException(
         const char* const& message) noexcept
     : Exception(message)
 {
 }
 
-BadParamException::BadParamException(
-        const BadParamException& ex) noexcept
+LockedExternalAccessException::LockedExternalAccessException(
+        const LockedExternalAccessException& ex) noexcept
     : Exception(ex)
 {
 }
 
-BadParamException::BadParamException(
-        BadParamException&& ex) noexcept
+LockedExternalAccessException::LockedExternalAccessException(
+        LockedExternalAccessException&& ex) noexcept
     : Exception(std::move(ex))
 {
 }
 
-BadParamException& BadParamException::operator =(
-        const BadParamException& ex) noexcept
+LockedExternalAccessException& LockedExternalAccessException::operator =(
+        const LockedExternalAccessException& ex) noexcept
 {
     if (this != &ex)
     {
@@ -48,8 +49,8 @@ BadParamException& BadParamException::operator =(
     return *this;
 }
 
-BadParamException& BadParamException::operator =(
-        BadParamException&& ex) noexcept
+LockedExternalAccessException& LockedExternalAccessException::operator =(
+        LockedExternalAccessException&& ex) noexcept
 {
     if (this != &ex)
     {
@@ -60,11 +61,11 @@ BadParamException& BadParamException::operator =(
     return *this;
 }
 
-BadParamException::~BadParamException() noexcept
+LockedExternalAccessException::~LockedExternalAccessException() noexcept
 {
 }
 
-void BadParamException::raise() const
+void LockedExternalAccessException::raise() const
 {
     throw *this;
 }

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/exceptions/NotEnoughMemoryException.cpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/exceptions/NotEnoughMemoryException.cpp
@@ -16,56 +16,50 @@
 
 using namespace eprosima::fastcdr::exception;
 
-const char* const NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT = "Not "
-                                                                                "enough "
-                                                                                "memory "
-                                                                                "in the "
-                                                                                "buffer "
-                                                                                "stream";
+const char* const NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT =
+        "Not enough memory in the buffer stream";
 
-NotEnoughMemoryException::NotEnoughMemoryException(const char* const& message) noexcept
-  : Exception(message)
+NotEnoughMemoryException::NotEnoughMemoryException(
+        const char* const& message) noexcept
+    : Exception(message)
 {
 }
 
 NotEnoughMemoryException::NotEnoughMemoryException(
-    const NotEnoughMemoryException& ex) noexcept
-  : Exception(ex)
+        const NotEnoughMemoryException& ex) noexcept
+    : Exception(ex)
 {
 }
 
-#if HAVE_CXX0X
-NotEnoughMemoryException::NotEnoughMemoryException(NotEnoughMemoryException&& ex) noexcept
-  : Exception(std::move(ex))
+NotEnoughMemoryException::NotEnoughMemoryException(
+        NotEnoughMemoryException&& ex) noexcept
+    : Exception(std::move(ex))
 {
 }
 
-#endif  // if HAVE_CXX0X
-
-NotEnoughMemoryException&
-NotEnoughMemoryException::operator=(const NotEnoughMemoryException& ex) noexcept
+NotEnoughMemoryException& NotEnoughMemoryException::operator =(
+        const NotEnoughMemoryException& ex) noexcept
 {
-  if (this != &ex)
-  {
-    Exception::operator=(ex);
-  }
+    if (this != &ex)
+    {
+        Exception::operator =(
+                ex);
+    }
 
-  return *this;
+    return *this;
 }
 
-#if HAVE_CXX0X
-NotEnoughMemoryException&
-NotEnoughMemoryException::operator=(NotEnoughMemoryException&& ex) noexcept
+NotEnoughMemoryException& NotEnoughMemoryException::operator =(
+        NotEnoughMemoryException&& ex) noexcept
 {
-  if (this != &ex)
-  {
-    Exception::operator=(std::move(ex));
-  }
+    if (this != &ex)
+    {
+        Exception::operator =(
+                std::move(ex));
+    }
 
-  return *this;
+    return *this;
 }
-
-#endif  // if HAVE_CXX0X
 
 NotEnoughMemoryException::~NotEnoughMemoryException() noexcept
 {
@@ -73,5 +67,5 @@ NotEnoughMemoryException::~NotEnoughMemoryException() noexcept
 
 void NotEnoughMemoryException::raise() const
 {
-  throw *this;
+    throw *this;
 }

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/src/deserializer.cpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/src/deserializer.cpp
@@ -193,7 +193,7 @@ Span<const uint8_t> FastCDR_Deserializer::deserializeByteSequence()
   _cdr->deserialize(seqLength);
 
   // dirty trick to change the internal state of cdr
-  auto* ptr = _cdr->getCurrentPosition();
+  auto* ptr = _cdr->get_current_position();
 
   uint8_t dummy;
   _cdr->deserialize(dummy);
@@ -204,7 +204,7 @@ Span<const uint8_t> FastCDR_Deserializer::deserializeByteSequence()
 
 const uint8_t* FastCDR_Deserializer::getCurrentPtr() const
 {
-  return reinterpret_cast<const uint8_t*>(_cdr->getBufferPointer());
+  return reinterpret_cast<const uint8_t*>(_cdr->get_buffer_pointer());
 }
 
 void FastCDR_Deserializer::jump(size_t bytes)
@@ -219,7 +219,7 @@ void FastCDR_Deserializer::reset()
   char* buffer_ptr = reinterpret_cast<char*>(const_cast<uint8_t*>(_buffer.data()));
 
   _cdr_buffer = std::make_shared<FastBuffer>(buffer_ptr, _buffer.size());
-  _cdr = std::make_shared<Cdr>(*_cdr_buffer, Cdr::DEFAULT_ENDIAN, Cdr::DDS_CDR);
+  _cdr = std::make_shared<Cdr>(*_cdr_buffer, Cdr::DEFAULT_ENDIAN, CdrVersion::DDS_CDR);
   _cdr->read_encapsulation();
 }
 


### PR DESCRIPTION
Resolve: #919 #861 

I would like to be able to use PlotJuggler with the latest fast-CDR from eProsima which is why I propose:
- Update local thirdparty files from eProsima to version 2.x.x
- Update cmake version so that it is possible to compile with fastcdr installed on the dev machine.

Tested with eProsima helloword example: Ok
![Capture d’écran du 2024-01-21 16-21-28](https://github.com/facontidavide/PlotJuggler/assets/157283158/c1f2e886-24eb-4644-ac6c-dcc64e79ccad)

Helloworld example: https://fast-dds.docs.eprosima.com/en/latest/fastdds/getting_started/simple_app/simple_app.html

Configuration file: https://plotjuggler-fastdds-plugins.readthedocs.io/en/latest/rst/user_manual/configuration.html

configuration file to be able to read from a Topic:
```
<types>
    <type>
        <struct name="HelloWorld">
            <member name="index" type="uint32"/>
            <member name="message" type="string"/>
        </struct>
    </type>
</types>
```

tested on:
``` 
Static hostname: ubuntu-H610M-S2H-DDR4
       Icon name: computer-desktop
         Chassis: desktop
      Machine ID: f15bb09bbaa74f77be0ee3e9db35aca0
         Boot ID: ec841c97061f43a89768b3b36538327f
Operating System: Ubuntu 22.04.3 LTS              
          Kernel: Linux 6.5.0-14-generic
    Architecture: x86-64
 Hardware Vendor: Gigabyte Technology Co., Ltd.
  Hardware Model: H610M S2H DDR4
```

with PlotJuggler version 3.8.8