### PR TITLE
Bugfix: Wrong curvestyle is preselected

### DIFF
--- a/plotjuggler_app/plotwidget_editor.cpp
+++ b/plotjuggler_app/plotwidget_editor.cpp
@@ -70,7 +70,7 @@ PlotwidgetEditor::PlotwidgetEditor(PlotWidget* plotwidget, QWidget* parent)
   }
   else if (_plotwidget->curveStyle() == PlotWidgetBase::STEPSINV)
   {
-    ui->radioSteps->setChecked(true);
+    ui->radioStepsInv->setChecked(true);
   }
   else
   {


### PR DESCRIPTION
On selecting the relatively new curve style "Steps(Post)," the style was correctly applied to the plot.

However, on reopening the "Edit the Plot Area" dialog, the radio button wrongly showed that the curve style "Steps(Pre)" would be selected. 

This problem is fixed with this PR.
Everything else already worked correctly beforehand. The correct curve style was applied and also saved in the layout.
Just the preselection of the radio buttons was wrong.

Hopefully, my description is clear enough!
