### PR TITLE
Bugfix: Guess ROS msgs types within package before selecting external to package type

### DIFF
--- a/plotjuggler_plugins/ParserROS/rosx_introspection/src/ros_message.cpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/src/ros_message.cpp
@@ -126,12 +126,34 @@ std::vector<ROSMessage::Ptr> ParseMessageDefinitions(const std::string& multi_de
       // if package name is missing, try to find msgName in the list of known_type
       if (field.type().pkgName().empty())
       {
+        std::vector<ROSType> guessed_type;
+
         for (const ROSType& known_type : known_type)
         {
           if (field.type().msgName() == known_type.msgName())
           {
-            field.changeType(known_type);
-            break;
+            guessed_type.push_back(known_type);
+          }
+        }
+
+        if (!guessed_type.empty())
+        {
+          bool better_match = false;
+
+          // attempt to match ambiguous ros msg within package before
+          // using external known type
+          for (const ROSType& guessed_type : guessed_type) {
+            if (guessed_type.pkgName() == root_type.pkgName()) {
+              field.changeType(guessed_type);
+              better_match = true;
+              break;
+            }
+          }
+
+          // if nothing from the same package, take a guess with the first matching msg name
+          if (!better_match)
+          {
+            field.changeType(guessed_type[0]);
           }
         }
       }


### PR DESCRIPTION
In some scenarios for msg types defined with fields of types with the same type name as types that exist in other packages, the type will be resolved to a package which is not that of the root type containing the field. As an example:

`motion_msgs/Motion` defined as:
```
uint8 type
float64 start_time
float64 duration
Point start_point
Point end_point

etc..
```

The `Point` in this type is part of our `motion_msgs` package and thus is referred to without a package name. When being deserialized it current is resolved to `geometry_msgs/Point` instead of `motion_msgs/Point`, resulting in a size mismatch and overrun further into deserializing the msg.


The change in the PR would check for the existence of a `Point` type with the same package as `motion_msgs/Motion`, matching `motion_msgs/Point` first instead of `geometry_msgs`, before matching a type outside the root type's package.


This appears to have been introduced in the latest ROS refactor somehow as we haven't had any issues loading bag files with this type in the past.


Attached bag showing a buffer overrun in the deserialization due to using `geometry_msgs/Point` instead of the custom defined `motion_msgs/Point` when deserializing the `motion_msgs/Motion` type. Bag contains exactly one of the offending msg.

[plotjuggler_test_case.zip](https://github.com/facontidavide/PlotJuggler/files/14015232/plotjuggler_test_case.zip)