### PR TITLE
Fixed parsing JointState messages

### DIFF
--- a/plotjuggler_plugins/ParserROS/ros_parser.cpp
+++ b/plotjuggler_plugins/ParserROS/ros_parser.cpp
@@ -409,17 +409,17 @@ void ParserROS::parseJointStateMsg(const std::string& prefix, double& timestamp)
   }
   //---------------------------
   std::string series_name;
-  for (size_t i = 0; i < std::max(name_size, pos_size); i++)
+  for (size_t i = 0; i < std::min(name_size, pos_size); i++)
   {
     series_name = fmt::format("{}/{}/position", _topic, msg.name[i]);
     getSeries(series_name).pushBack({ timestamp, msg.position[i] });
   }
-  for (size_t i = 0; i < std::max(name_size, vel_size); i++)
+  for (size_t i = 0; i < std::min(name_size, vel_size); i++)
   {
     series_name = fmt::format("{}/{}/velocity", _topic, msg.name[i]);
     getSeries(series_name).pushBack({ timestamp, msg.velocity[i] });
   }
-  for (size_t i = 0; i < std::max(name_size, eff_size); i++)
+  for (size_t i = 0; i < std::min(name_size, eff_size); i++)
   {
     series_name = fmt::format("{}/{}/effort", _topic, msg.name[i]);
     getSeries(series_name).pushBack({ timestamp, msg.effort[i] });


### PR DESCRIPTION
Without this fix, parsing of JointState messages is broken if `velocity` or `effort` fields are empty (which is allowed in the message definition).