### PR TITLE
Bugfix: Dereferencing wrong pointer for ULog information message value

### DIFF
--- a/plotjuggler_plugins/DataLoadULog/ulog_parser.cpp
+++ b/plotjuggler_plugins/DataLoadULog/ulog_parser.cpp
@@ -656,44 +656,45 @@ bool ULogParser::readInfo(DataStream& datastream, uint16_t msg_size)
   message++;
   std::string raw_key((char*)message, key_len);
   message += key_len;
+  std::string raw_value((char*)message, msg_size - key_len - 1);
 
   auto key_parts = splitString(raw_key, ' ');
 
   std::string key = key_parts[1].to_string();
-
   std::string value;
+  
   if (key_parts[0].starts_with("char["))
   {
-    value = std::string((char*)message, msg_size - key_len - 1);
+    value = raw_value;
   }
   else if (key_parts[0] == StringView("bool"))
   {
-    bool val = *reinterpret_cast<const bool*>(key_parts[0].data());
+    bool val = *reinterpret_cast<const bool*>(raw_value.data());
     value = std::to_string(val);
   }
   else if (key_parts[0] == StringView("uint8_t"))
   {
-    uint8_t val = *reinterpret_cast<const uint8_t*>(key_parts[0].data());
+    uint8_t val = *reinterpret_cast<const uint8_t*>(raw_value.data());
     value = std::to_string(val);
   }
   else if (key_parts[0] == StringView("int8_t"))
   {
-    int8_t val = *reinterpret_cast<const int8_t*>(key_parts[0].data());
+    int8_t val = *reinterpret_cast<const int8_t*>(raw_value.data());
     value = std::to_string(val);
   }
   else if (key_parts[0] == StringView("uint16_t"))
   {
-    uint16_t val = *reinterpret_cast<const uint16_t*>(key_parts[0].data());
+    uint16_t val = *reinterpret_cast<const uint16_t*>(raw_value.data());
     value = std::to_string(val);
   }
   else if (key_parts[0] == StringView("int16_t"))
   {
-    int16_t val = *reinterpret_cast<const int16_t*>(key_parts[0].data());
+    int16_t val = *reinterpret_cast<const int16_t*>(raw_value.data());
     value = std::to_string(val);
   }
   else if (key_parts[0] == StringView("uint32_t"))
   {
-    uint32_t val = *reinterpret_cast<const uint32_t*>(key_parts[0].data());
+    uint32_t val = *reinterpret_cast<const uint32_t*>(raw_value.data());
     if (key_parts[1].starts_with("ver_") && key_parts[1].ends_with("_release"))
     {
       value = int_to_hex(val);
@@ -705,27 +706,27 @@ bool ULogParser::readInfo(DataStream& datastream, uint16_t msg_size)
   }
   else if (key_parts[0] == StringView("int32_t"))
   {
-    int32_t val = *reinterpret_cast<const int32_t*>(key_parts[0].data());
+    int32_t val = *reinterpret_cast<const int32_t*>(raw_value.data());
     value = std::to_string(val);
   }
   else if (key_parts[0] == StringView("float"))
   {
-    float val = *reinterpret_cast<const float*>(key_parts[0].data());
+    float val = *reinterpret_cast<const float*>(raw_value.data());
     value = std::to_string(val);
   }
   else if (key_parts[0] == StringView("double"))
   {
-    double val = *reinterpret_cast<const double*>(key_parts[0].data());
+    double val = *reinterpret_cast<const double*>(raw_value.data());
     value = std::to_string(val);
   }
   else if (key_parts[0] == StringView("uint64_t"))
   {
-    uint64_t val = *reinterpret_cast<const uint64_t*>(key_parts[0].data());
+    uint64_t val = *reinterpret_cast<const uint64_t*>(raw_value.data());
     value = std::to_string(val);
   }
   else if (key_parts[0] == StringView("int64_t"))
   {
-    int64_t val = *reinterpret_cast<const int64_t*>(key_parts[0].data());
+    int64_t val = *reinterpret_cast<const int64_t*>(raw_value.data());
     value = std::to_string(val);
   }
 


### PR DESCRIPTION
The Info tab is displaying the wrong values for non string types. The first part of the key (the type name) is getting de-referenced as the value for the information messages. I have created a string containing the value section of the message to use for de-referencing the raw data.

The Info tab previously:
![image](https://github.com/facontidavide/PlotJuggler/assets/90937622/90c8286b-f1a4-46b6-8716-79b71f94efa6)

The Info tab with this fix:
![image](https://github.com/facontidavide/PlotJuggler/assets/90937622/9755e6a2-88c2-4a54-851f-79b17158515b)

Note, the ULog used for testing only has float and char[] information messages. Those are not int information messages in the images.