### PR TITLE
ZMQ plugin improvements

### DIFF
--- a/plotjuggler_plugins/DataStreamZMQ/datastream_zmq.h
+++ b/plotjuggler_plugins/DataStreamZMQ/datastream_zmq.h
@@ -1,12 +1,14 @@
 #pragma once
 #include <QDialog>
 
-#include <QtPlugin>
-#include <thread>
 #include "PlotJuggler/datastreamer_base.h"
 #include "PlotJuggler/messageparser_base.h"
 #include "ui_datastream_zmq.h"
 #include "zmq.hpp"
+#include <QtPlugin>
+#include <map>
+#include <string>
+#include <thread>
 
 class StreamZMQDialog : public QDialog
 {
@@ -57,9 +59,13 @@ private:
   std::string _socket_address;
   std::thread _receive_thread;
   std::vector<std::string> _topic_filters;
-
+  std::map<std::string, PJ::MessageParserPtr> _parsers;
+  PJ::ParserFactoryPlugin::Ptr _parser_creator;
+  bool _is_connect = false;
   void receiveLoop();
   bool parseMessage(const PJ::MessageRef& msg, double& timestamp);
+  bool parseMessage(const std::string& topic, const PJ::MessageRef& msg,
+                    double& timestamp);
   void parseTopicFilters(const QString& filters);
   void subscribeTopics();
   void unsubscribeTopics();

--- a/plotjuggler_plugins/DataStreamZMQ/utilities/start_test_publisher.py
+++ b/plotjuggler_plugins/DataStreamZMQ/utilities/start_test_publisher.py
@@ -5,21 +5,31 @@ import math
 import json
 import argparse
 
-from time import sleep
+from time import sleep, time_ns
 import numpy as np
 
 PORT = 9872
 
 parser = argparse.ArgumentParser("start_test_publisher")
 
-parser.add_argument("--topic|-t",
-                    dest="topic",
-                    help="Topic on which messages will be published",
-                    type=str,
-                    required=False)
+parser.add_argument(
+    "--topic|-t",
+    dest="topic",
+    help="Topic on which messages will be published",
+    type=str,
+    required=False,
+)
+parser.add_argument(
+    "--timestamp",
+    dest="timestamp",
+    help="Send timestamp as message part, requires topic to work properly",
+    required=False,
+    action="store_true",
+)
 
 args = parser.parse_args()
 topic = args.topic
+timestamp = args.timestamp
 
 
 def main():
@@ -29,28 +39,37 @@ def main():
     ticks = 0
 
     while True:
+        out_str = []
+        packet = []
         data = {
             "ticks": ticks,
             "data": {
                 "cos": math.cos(ticks),
                 "sin": math.sin(ticks),
                 "floor": np.floor(np.cos(ticks)),
-                "ceil": np.ceil(np.cos(ticks))
-            }
+                "ceil": np.ceil(np.cos(ticks)),
+            },
         }
 
         if topic:
-            print(f"[{topic}] - " + json.dumps(data))
-            server_socket.send_multipart(
-                [topic.encode(), json.dumps(data).encode()])
-        else:
-            print(json.dumps(data))
-            server_socket.send(json.dumps(data).encode())
+            out_str.append(f"[{topic}] - ")
+            packet.append(topic.encode())
+
+        out_str.append(json.dumps(data))
+        packet.append(out_str[-1].encode())
+
+        if timestamp:
+            timestamp_s = str(time_ns() * 1e-9)
+            out_str.append(" - timestamp: " + timestamp_s)
+            packet.append(timestamp_s.encode())
+
+        print("".join(out_str))
+        server_socket.send_multipart(packet)
 
         ticks += 1
 
         sleep(0.1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Good evening,

I have done what you suggested on the last pull request, it was closed so I guess I have to open a new one.

The pre-commit passed and the changes should be backward compatible from my tests. I will paste what the same message I had on the previous pull request.

## Topics

Topic support was present, but did not ground incoming messages in said topics, resulting in overriding duplicate keys (e.g., the timestamp). In addition, no multipart messages were used, making it difficult to actually use it with a real PUB/SUB structure.

I propose the following update to the plugin.

The plugin now can receive a two-part message, the first part is the topic (as string) and the second is the payload (the data you said PlotJuggler to expect).
Using the topic as a key to a map of parsers, it maps correctly the message to its topic. Dynamic addition of topics as they come (according to the provided filter) is supported.
The timestamp can be provided as part of the payload (as already present) or via a third part of the message. I believe this is useful if the data you are sending may not strictly contain the timestamp in the payload.

## Bug fixes

I found that the application would crash after a stop of the ZMQ plugin if it was started in bind mode, this was due a bug in the shutdown method.