### PR TITLE
Fix infinite streaming buffer regression

### DIFF
--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -2422,7 +2422,14 @@ void MainWindow::updateDataAndReplot(bool replot_hidden_tabs)
       _curvelist_widget->refreshColumns();
     }
 
-    _mapped_plot_data.setMaximumRangeX(ui->streamingSpinBox->value());
+    if (ui->streamingSpinBox->value() == ui->streamingSpinBox->maximum())
+    {
+      _mapped_plot_data.setMaximumRangeX(std::numeric_limits<double>::max());
+    }
+    else
+    {
+      _mapped_plot_data.setMaximumRangeX(ui->streamingSpinBox->value());
+    }
   }
 
   const bool is_streaming_active = isStreamingActive();
@@ -2473,6 +2480,18 @@ void MainWindow::updateDataAndReplot(bool replot_hidden_tabs)
 void MainWindow::on_streamingSpinBox_valueChanged(int value)
 {
   double real_value = value;
+
+  if (value == ui->streamingSpinBox->maximum())
+  {
+    real_value = std::numeric_limits<double>::max();
+    ui->streamingSpinBox->setStyleSheet("QSpinBox { color: red; }");
+    ui->streamingSpinBox->setSuffix("=inf");
+  }
+  else
+  {
+    ui->streamingSpinBox->setStyleSheet("QSpinBox { color: black; }");
+    ui->streamingSpinBox->setSuffix(" sec");
+  }
 
   if (isStreamingActive() == false)
   {


### PR DESCRIPTION
I noticed that sometime ago #174 got removed. Therefore there's no way to switch off streaming buffer limit, which is not suitable for some cases. Let's say data acquisition rate is 1Hz, then 999 seconds is less than half an hour (basically nothing in terms of long measurements). Was this removal a conscious decision or an accident? This PR reintroduces #174.

I managed to use a combination of CSV import and real-time streaming to plot long live data series, however such a configuration revealed one more issue. Namely, when "quick reload" button is pressed, X axis limits are set according to streaming buffer length, and CSV data length is ignored.

This PR also makes quick reload autoscaling respect static data length.