### PR TITLE
CSV: Allowing to parse date as extended ISO 8601

### DIFF
--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
@@ -530,9 +530,9 @@ bool DataLoadCSV::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_data
       static QLocale locale_with_comma(QLocale::German);
       val = locale_with_comma.toDouble(str_trimmed, &is_number);
     }
-    if (!is_number && parse_date_format && !format_string.isEmpty())
+    if (!is_number && parse_date_format)
     {
-      QDateTime ts = QDateTime::fromString(str_trimmed, format_string);
+      QDateTime ts = !format_string.isEmpty() ? QDateTime::fromString(str_trimmed, format_string) : QDateTime::fromString(str_trimmed, Qt::ISODateWithMs);
       is_number = ts.isValid();
       if (is_number)
       {


### PR DESCRIPTION
When working with data from different sources, one may encounter a various number of different date formats.

Examples include:
- yyyy-MM-dd hh:mm:ss
- yyyy-MM-dd hh:mm:ss.zzz
- yyyy-MM-dd hh:mm:ss.zzzzzz (not even supported with format strings)
- yyyy/MM/dd hh:mm:ss
- yyyy/MM/dd hh:mm:ss.zzz
- yyyy/MM/dd hh:mm:ss.zzzzzz (not even supported with format strings)

These are all supported by Qt's `Qt::ISODateWithMs`, which thus allows for instantly loading different csv's without having to adjust the date format every time. This pull request suggests using ISO8601 parsing when no format string has been entered. 