### PR TITLE
Udp-socket-thread

### DIFF
--- a/plotjuggler_plugins/DataStreamUDP/udp_server.cpp
+++ b/plotjuggler_plugins/DataStreamUDP/udp_server.cpp
@@ -23,16 +23,9 @@ THE SOFTWARE.
 #include <QSettings>
 #include <QDialog>
 #include <mutex>
-#include <QWebSocket>
 #include <QIntValidator>
 #include <QMessageBox>
 #include <chrono>
-#include <QNetworkDatagram>
-#include <QNetworkInterface>
-#include <QtConcurrent/QtConcurrent>
-#include <functional>
-#include <iostream>
-#include <cstring>
 #include <arpa/inet.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Switched from QSocket to default linux sockets to implement the receive of packets in a separeted thread.

This solves an issue with high frequency data where plotjuggler would lose several packets while updating the plots. This issue only happens while livestreaming whithout pause, if you pause the window it receives normally all the data, but as soon as it is unpaused the issue returns.

I'm aware that this solution will lead to problems with windows implementation, but for now I dont have the time to implement with other OS compatibility.

Tested on Ubuntu 22.04..4 LTS