### PR TITLE
CSV: added option to skip invalid rows

### DIFF
--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.ui
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.ui
@@ -228,6 +228,13 @@
              </attribute>
             </widget>
            </item>
+           <item>
+            <widget class="QCheckBox" name="checkBoxSkipInvalidRows">
+             <property name="text">
+              <string>Skip rows with incorrect column count</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </widget>
          <widget class="QWidget" name="tab_3">


### PR DESCRIPTION
CSV files may contain invalid rows (i.e., rows that have the wrong number of columns). In some cases, those are not expected and thus not loading the entire file (and displaying a warning) may make sense. This is what is currently done. In other cases, however, due to how the CSV files are generated, invalid rows may be expected and still being able to load such a file without having to first manually remove them would thus be helpful.

This pull request does exactly that: It adds a checkbox to just ignore rows which don't have as many values as there are columns. It is unchecked by default, preserving the current behaviour.

<img width="1219" alt="Screenshot 2024-04-01 at 16 26 57" src="https://github.com/facontidavide/PlotJuggler/assets/3756385/ad490bca-3906-4125-8c92-723de607d0f0">
