### PR TITLE
Added support for empty messages

### DIFF
--- a/plotjuggler_plugins/PluginsZcm/dataload_zcm.cpp
+++ b/plotjuggler_plugins/PluginsZcm/dataload_zcm.cpp
@@ -275,6 +275,14 @@ bool DataLoadZcm::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_data
       return;
     }
 
+    if (evt->datalen == 0) {
+      auto itr = plot_data.numeric.find(evt->channel);
+      if (itr == plot_data.numeric.end())
+        itr = plot_data.addNumeric(evt->channel);
+      itr->second.pushBack({ (double)evt->timestamp / 1e6, 0 });
+      return;
+    }
+
     zcm::Introspection::processEncodedType(evt->channel, evt->data, evt->datalen, "/",
                                            types, processData, &usr);
     for (auto& n : usr.numerics)

--- a/plotjuggler_plugins/PluginsZcm/dataload_zcm.cpp
+++ b/plotjuggler_plugins/PluginsZcm/dataload_zcm.cpp
@@ -275,7 +275,8 @@ bool DataLoadZcm::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_data
       return;
     }
 
-    if (evt->datalen == 0) {
+    if (evt->datalen == 0)
+    {
       auto itr = plot_data.numeric.find(evt->channel);
       if (itr == plot_data.numeric.end())
         itr = plot_data.addNumeric(evt->channel);


### PR DESCRIPTION
This commit adds support for zcm messages that are empty. Before the messages would just be dropped and not displayed in PlotJuggler. Now they will show up at the correct timestamp with no contents and a numeric value of 0 for each message that exists