### PR TITLE
Enhance Data Retrieval Accuracy with MatchType in TimeseriesRef

### DIFF
--- a/plotjuggler_base/include/PlotJuggler/reactive_function.h
+++ b/plotjuggler_base/include/PlotJuggler/reactive_function.h
@@ -27,6 +27,8 @@ struct TimeseriesRef
 
   double atTime(double t) const;
 
+  int getRawIndexAtTime(double t) const;
+
   unsigned size() const;
 
   void clear() const;

--- a/plotjuggler_base/include/PlotJuggler/reactive_function.h
+++ b/plotjuggler_base/include/PlotJuggler/reactive_function.h
@@ -25,7 +25,7 @@ struct TimeseriesRef
 
   void set(unsigned index, double x, double y);
 
-  double atTime(double t) const;
+  double atTime(double t, MatchType match_type) const;
 
   int getRawIndexAtTime(double t) const;
 
@@ -61,6 +61,11 @@ struct CreatedSeriesTime : public CreatedSeriesBase
 struct CreatedSeriesXY : public CreatedSeriesBase
 {
   CreatedSeriesXY(PlotDataMapRef* data_map, const std::string& name);
+};
+
+enum class MatchType {
+    Exact,    // Returns an index only if the exact time is found
+    Nearest   // Returns the nearest time index (current behavior)
 };
 
 //-----------------------

--- a/plotjuggler_base/src/reactive_function.cpp
+++ b/plotjuggler_base/src/reactive_function.cpp
@@ -114,6 +114,7 @@ void ReactiveLuaFunction::prepareLua()
   _timeseries_ref["at"] = &TimeseriesRef::at;
   _timeseries_ref["set"] = &TimeseriesRef::set;
   _timeseries_ref["atTime"] = &TimeseriesRef::atTime;
+  _timeseries_ref["getRawIndexAtTime"] = &TimeseriesRef::getRawIndexAtTime;
   _timeseries_ref["clear"] = &TimeseriesRef::clear;
 
   //---------------------------------------
@@ -188,6 +189,11 @@ double TimeseriesRef::atTime(double t) const
 {
   int i = _plot_data->getIndexFromX(t);
   return _plot_data->at(i).y;
+}
+
+int TimeseriesRef::getRawIndexAtTime(double t) const
+{
+  return _plot_data->getIndexFromX(t);
 }
 
 unsigned TimeseriesRef::size() const


### PR DESCRIPTION
This MR introduces the `MatchType` enumeration to `TimeseriesRef`, providing the option to choose between exact and nearest time matching. Changes include updates to the `atTime` and `getRawIndexAtTime` methods to support this new functionality.

For a detailed problem description see: https://github.com/facontidavide/PlotJuggler/issues/968
