### PR TITLE
Save NlohmannParser (JSON) settings

### DIFF
--- a/plotjuggler_app/nlohmann_parsers.h
+++ b/plotjuggler_app/nlohmann_parsers.h
@@ -10,6 +10,7 @@
 #include "nlohmann/json.hpp"
 #include "PlotJuggler/messageparser_base.h"
 #include <QDebug>
+#include <QSettings>
 
 using namespace PJ;
 
@@ -113,11 +114,14 @@ public:
   NlohmannParserCreator()
   {
     _checkbox_use_timestamp = new QCheckBoxClose("use field as timestamp if available");
+    loadSettings();
   }
 
   template <typename ParserT>
   MessageParserPtr createParserImpl(const std::string& topic_name, PlotDataMapRef& data)
   {
+    saveSettings();
+
     std::string timestamp_name = _checkbox_use_timestamp->lineedit->text().toStdString();
     return std::make_shared<ParserT>(
         topic_name, data, _checkbox_use_timestamp->isChecked(), timestamp_name);
@@ -125,7 +129,26 @@ public:
 
   virtual QWidget* optionsWidget()
   {
+    loadSettings();
+
     return _checkbox_use_timestamp;
+  }
+
+  virtual void loadSettings()
+  {
+    QSettings settings;
+    bool checked = settings.value("NlohmannParser.timestampEnabled", false).toBool();
+    QString field = settings.value("NlohmannParser.timestampFieldName", "").toString();
+
+    _checkbox_use_timestamp->setChecked(checked);
+    _checkbox_use_timestamp->lineedit->setText(field);
+  }
+
+  virtual void saveSettings()
+  {
+    QSettings settings;
+    settings.setValue("NlohmannParser.timestampEnabled", _checkbox_use_timestamp->isChecked());
+    settings.setValue("NlohmannParser.timestampFieldName", _checkbox_use_timestamp->lineedit->text());
   }
 
 protected:


### PR DESCRIPTION
With this change, the NlohmannParser (json/bson/cbor/msgpack parsers) options are saved to the user settings file, making especially data streaming easier where we no longer have to specify this option after each restart of the app.

This PR partially solves #839: Settings are now saved, but not as part of the layout file.

### Changes:
- Settings saved when parser is instantiated.
- Settings loaded when the options widget is accessed.

### Design reasoning:
I debated over extending the `ParserFactoryPlugin` interface with `void saveSettings()` and `void loadSettings()` to make this feature explicit and controllable by the caller, that also would improve the interface for future plugins.
In the end I opted for this simpler more contained solution not to change the architecture, but with the downside of settings being loaded multiple times and both load and save being a side-effect.

I would be happy update the PR with the interface route if you think that is a better approach.

Thanks