### PR TITLE
fix(snap_core22): ros-humble-dataspeed-dbw-msgs has been removed

### DIFF
--- a/snap_core22/snapcraft.yaml
+++ b/snap_core22/snapcraft.yaml
@@ -99,7 +99,6 @@ parts:
       - ros-humble-control-msgs
       - ros-humble-controller-manager-msgs
       - ros-humble-create-msgs
-      - ros-humble-dataspeed-dbw-msgs
       - ros-humble-dataspeed-ulc-msgs
       - ros-humble-dbw-fca-msgs
       - ros-humble-dbw-ford-msgs


### PR DESCRIPTION
The msg `ros-humble-dataspeed-dbw-msgs` got removed.
Trying to install this message in the core22 snap will fail.

https://discourse.ros.org/t/new-packages-and-patch-release-for-humble-hawksbill-2024-05-23/37872#removed-packages-4-4