### PR TITLE
[ROS-O] drop broken test hook from Fast-CDR import

### DIFF
--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/CMakeLists.txt
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/CMakeLists.txt
@@ -126,20 +126,6 @@ set(LICENSE_INSTALL_DIR ${DATA_INSTALL_DIR}/${PROJECT_NAME} CACHE PATH "Installa
 add_subdirectory(src/cpp)
 
 ###############################################################################
-# Testing
-###############################################################################
-enable_testing()
-include(CTest)
-
-if (BUILD_TESTING)
-    if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.22)
-        add_subdirectory(test)
-    else()
-        message(INFO "Tests are disabled because the version of CMake is less than 3.22")
-    endif()
-endif()
-
-###############################################################################
 # Documentation
 ###############################################################################
 # Add an option to toggle the generation of the API documentation.


### PR DESCRIPTION
The tests were not imported but still referenced in the cmake depending on the system cmake version.

My build (Debian testing, ROS-O)  just got stuck on:

```
CMake Error at plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/CMakeLists.txt:136 (add_subdirectory):
  add_subdirectory given source "test" which is not an existing directory.
```

It looks like you imported the library without its tests, but did not remove the cmake reference.