### PR TITLE
#983 & #984 Add option for custom line widths

### DIFF
--- a/plotjuggler_app/plotwidget.cpp
+++ b/plotjuggler_app/plotwidget.cpp
@@ -682,6 +682,8 @@ QDomElement PlotWidget::xmlSaveState(QDomDocument& doc) const
     plot_el.setAttribute("style", "StepsInv");
   }
 
+  plot_el.setAttribute("curve_width", QString::number(curvesWidth()));
+
   for (auto& it : curveList())
   {
     auto& name = it.src_name;
@@ -888,6 +890,17 @@ bool PlotWidget::xmlLoadState(QDomElement& plot_widget, bool autozoom)
     {
       changeCurvesStyle(PlotWidgetBase::STEPSINV);
     }
+  }
+
+  if (plot_widget.hasAttribute("curve_width"))
+  {
+    double curve_width = plot_widget.attribute("curve_width").toDouble();
+    if (curve_width <= 0.0)
+    {
+      curve_width = 1.3;
+    }
+
+    changeCurvesWidth(curve_width);
   }
 
   QString bg_data = plot_widget.attribute("background_data");

--- a/plotjuggler_app/plotwidget_editor.cpp
+++ b/plotjuggler_app/plotwidget_editor.cpp
@@ -104,6 +104,10 @@ PlotwidgetEditor::PlotwidgetEditor(PlotWidget* plotwidget, QWidget* parent)
     ui->lineLimitMax->setText(QString::number(suggested_limits.max));
   }
 
+  ui->widthSpinBox->setValue(_plotwidget->curvesWidth());
+  connect(ui->widthSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+         this, &PlotwidgetEditor::on_widthSpinBox_changed);
+
   // ui->listWidget->widget_background_disabled("QListView::item:selected { background:
   // #ddeeff; }");
 
@@ -205,6 +209,7 @@ void PlotwidgetEditor::disableWidgets()
 
   ui->frameLimits->setEnabled(false);
   ui->frameStyle->setEnabled(false);
+  ui->frameWidth->setEnabled(false);
 }
 
 void PlotwidgetEditor::setupTable()
@@ -454,6 +459,7 @@ void PlotwidgetEditor::on_listWidget_itemSelectionChanged()
   }
 
   ui->widgetColor->setEnabled(true);
+  ui->widthSpinBox->setValue(_plotwidget->curvesWidth());
 
   if (selected.size() != 1)
   {
@@ -466,4 +472,9 @@ void PlotwidgetEditor::on_listWidget_itemSelectionChanged()
   {
     ui->editColotText->setText(row_widget->color().name());
   }
+}
+
+void PlotwidgetEditor::on_widthSpinBox_changed(double width)
+{
+    _plotwidget->changeCurvesWidth(width);
 }

--- a/plotjuggler_app/plotwidget_editor.h
+++ b/plotjuggler_app/plotwidget_editor.h
@@ -104,6 +104,7 @@ private:
   void updateLimits();
   void onDeleteRow(QWidget* w);
   void disableWidgets();
+  void on_widthSpinBox_changed(double width);
 
   std::unordered_map<std::string, std::shared_ptr<TransformFunction>> _transforms;
 };

--- a/plotjuggler_app/plotwidget_editor.ui
+++ b/plotjuggler_app/plotwidget_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>955</width>
-    <height>657</height>
+    <height>777</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -242,22 +242,7 @@
           <height>16777215</height>
          </size>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_4">
-         <property name="spacing">
-          <number>10</number>
-         </property>
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
          <item>
           <widget class="QLabel" name="label">
            <property name="font">
@@ -341,7 +326,7 @@
               </property>
              </widget>
             </item>
-             <item>
+            <item>
              <widget class="QRadioButton" name="radioSteps">
               <property name="text">
                <string>Steps (pre)</string>
@@ -352,6 +337,62 @@
              <widget class="QRadioButton" name="radioStepsInv">
               <property name="text">
                <string>Step (post)</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_3">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Line Width:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="frameWidth">
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>25</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>200</height>
+            </size>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Plain</enum>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_4">
+            <item>
+             <widget class="QDoubleSpinBox" name="widthSpinBox">
+              <property name="decimals">
+               <number>1</number>
+              </property>
+              <property name="minimum">
+               <double>0.100000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>10.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
+              <property name="value">
+               <double>1.300000000000000</double>
               </property>
              </widget>
             </item>
@@ -481,19 +522,6 @@
             </item>
            </layout>
           </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
          </item>
         </layout>
        </widget>

--- a/plotjuggler_base/include/PlotJuggler/plotwidget_base.h
+++ b/plotjuggler_base/include/PlotJuggler/plotwidget_base.h
@@ -85,6 +85,8 @@ public:
 
   void changeCurvesStyle(CurveStyle style);
 
+  void changeCurvesWidth(double width);
+
   bool isXYPlot() const;
 
   QRectF currentBoundingRect() const;
@@ -92,6 +94,8 @@ public:
   QRectF maxZoomRect() const;
 
   CurveStyle curveStyle() const;
+
+  double curvesWidth() const;
 
   bool keepRatioXY() const;
 
@@ -125,6 +129,7 @@ protected:
   QwtPlotPimpl* p = nullptr;
 
   static void setStyle(QwtPlotCurve* curve, CurveStyle style);
+  static void setWidth(QwtPlotCurve* curve, double width);
 
   QwtPlot* qwtPlot();
   const QwtPlot* qwtPlot() const;

--- a/plotjuggler_base/src/plotwidget_base.cpp
+++ b/plotjuggler_base/src/plotwidget_base.cpp
@@ -141,6 +141,7 @@ public:
   std::list<CurveInfo> curve_list;
 
   CurveStyle curve_style = LINES;
+  double curve_width = 1.3;
 
   bool zoom_enabled = true;
 
@@ -430,6 +431,7 @@ PlotWidgetBase::CurveInfo* PlotWidgetBase::addCurve(const std::string& name,
 
   curve->setPen(color);
   setStyle(curve, p->curve_style);
+  setWidth(curve, p->curve_width);
 
   curve->setRenderHint(QwtPlotItem::RenderAntialiased, true);
 
@@ -499,6 +501,11 @@ QwtSeriesWrapper* PlotWidgetBase::createTimeSeries(const PlotData* data,
 PlotWidgetBase::CurveStyle PlotWidgetBase::curveStyle() const
 {
   return p->curve_style;
+}
+
+double PlotWidgetBase::curvesWidth() const
+{
+  return p->curve_width;
 }
 
 bool PlotWidgetBase::keepRatioXY() const
@@ -697,8 +704,6 @@ std::map<QString, QColor> PlotWidgetBase::getCurveColors() const
 
 void PlotWidgetBase::setStyle(QwtPlotCurve* curve, CurveStyle style)
 {
-  curve->setPen(curve->pen().color(), (style == DOTS) ? 4.0 : 1.3);
-
   switch (style)
   {
     case LINES:
@@ -724,12 +729,27 @@ void PlotWidgetBase::setStyle(QwtPlotCurve* curve, CurveStyle style)
   }
 }
 
+void PlotWidgetBase::setWidth(QwtPlotCurve* curve, double width)
+{
+  curve->setPen(curve->pen().color(), width);
+}
+
 void PlotWidgetBase::changeCurvesStyle(CurveStyle style)
 {
   p->curve_style = style;
   for (auto& it : p->curve_list)
   {
     setStyle(it.curve, style);
+  }
+  replot();
+}
+
+void PlotWidgetBase::changeCurvesWidth(double width)
+{
+  p->curve_width = width;
+  for (auto& it : p->curve_list)
+  {
+    setWidth(it.curve, width);
   }
   replot();
 }


### PR DESCRIPTION
I'm no Qt designer expert, you might have to mess with the .ui file.
<img width="945" alt="pj_chonky_lines" src="https://github.com/facontidavide/PlotJuggler/assets/172684/ce15fc43-3446-4a21-a162-ecea947ee1e4">
