### PR TITLE
Windows Installer: Added ability to detect and uninstall existing installations when detected

### DIFF
--- a/installer/io.plotjuggler.application/meta/installscript.qs
+++ b/installer/io.plotjuggler.application/meta/installscript.qs
@@ -26,12 +26,12 @@
 **
 ****************************************************************************/
 
+var targetDirectoryPage = null;
+
 function Component()
 {
-    // constructor
-    component.loaded.connect(this, Component.prototype.loaded);
-    if (!installer.addWizardPage(component, "Page", QInstaller.TargetDirectory))
-        console.log("Could not add the dynamic page.");
+    installer.gainAdminRights();
+    component.loaded.connect(this, this.installerLoaded);
 }
 
 Component.prototype.isDefault = function()
@@ -56,20 +56,49 @@ Component.prototype.createOperations = function()
     }
 }
 
-Component.prototype.loaded = function ()
+
+// https://stackoverflow.com/a/46614107
+
+Component.prototype.installerLoaded = function()
 {
-    var page = gui.pageByObjectName("DynamicPage");
-    if (page != null) {
-        console.log("Connecting the dynamic page entered signal.");
-        page.entered.connect(Component.prototype.dynamicPageEntered);
-    }
+    installer.setDefaultPageVisible(QInstaller.TargetDirectory, false);
+    installer.addWizardPage(component, "TargetWidget", QInstaller.TargetDirectory);
+
+    targetDirectoryPage = gui.pageWidgetByObjectName("DynamicTargetWidget");
+    targetDirectoryPage.windowTitle = "Choose Installation Directory";
+    targetDirectoryPage.description.setText("Please select where PlotJuggler will be installed:");
+    targetDirectoryPage.targetDirectory.textChanged.connect(this, this.targetDirectoryChanged);
+    targetDirectoryPage.targetDirectory.setText(installer.value("TargetDir"));
+    targetDirectoryPage.targetChooser.released.connect(this, this.targetChooserClicked);
+
+    gui.pageById(QInstaller.ComponentSelection).entered.connect(this, this.componentSelectionPageEntered);
 }
 
-Component.prototype.dynamicPageEntered = function ()
+Component.prototype.targetChooserClicked = function()
 {
-    var pageWidget = gui.pageWidgetByObjectName("DynamicPage");
-    if (pageWidget != null) {
-        console.log("Setting the widgets label text.")
-        pageWidget.m_pageLabel.text = "This is a dynamically created page.";
+    var dir = QFileDialog.getExistingDirectory("", targetDirectoryPage.targetDirectory.text);
+    targetDirectoryPage.targetDirectory.setText(dir);
+}
+
+Component.prototype.targetDirectoryChanged = function()
+{
+    var dir = targetDirectoryPage.targetDirectory.text;
+    if (installer.fileExists(dir) && installer.fileExists(dir + "/maintenancetool.exe")) {
+        targetDirectoryPage.warning.setText("<p style=\"color: red\">Existing installation detected and will be overwritten.</p>");
+    }
+    else if (installer.fileExists(dir)) {
+        targetDirectoryPage.warning.setText("<p style=\"color: red\">Installing in existing directory. It will be wiped on uninstallation.</p>");
+    }
+    else {
+        targetDirectoryPage.warning.setText("");
+    }
+    installer.setValue("TargetDir", dir);
+}
+
+Component.prototype.componentSelectionPageEntered = function()
+{
+    var dir = installer.value("TargetDir");
+    if (installer.fileExists(dir) && installer.fileExists(dir + "/maintenancetool.exe")) {
+        installer.execute(dir + "/maintenancetool.exe", ["purge", "-c"]);
     }
 }

--- a/installer/io.plotjuggler.application/meta/package.xml
+++ b/installer/io.plotjuggler.application/meta/package.xml
@@ -10,4 +10,7 @@
     </Licenses>
     <Default>script</Default>
     <Script>installscript.qs</Script>
+    <UserInterfaces>
+        <UserInterface>targetwidget.ui</UserInterface>
+    </UserInterfaces>
 </Package>

--- a/installer/io.plotjuggler.application/meta/targetwidget.ui
+++ b/installer/io.plotjuggler.application/meta/targetwidget.ui
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TargetWidget</class>
+ <widget class="QWidget" name="TargetWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>491</width>
+    <height>190</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>491</width>
+    <height>190</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="description">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLineEdit" name="targetDirectory">
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="targetChooser">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="warning">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>TextLabel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>122</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Currently, when installing PlotJuggler, the installer simply fails when an existing installation is present. This modification to the Qt Installer Framework installer is based on StackOverflow answers by [rationalcoder](https://stackoverflow.com/a/46614107), [Skeird](https://stackoverflow.com/a/66154201), and [chipolux](https://stackoverflow.com/a/73819557) addressing this use-case of Qt Installer Framework's offline installer.

When an existing installation is detected, the installer now merely displays a message stating "Existing installation detected and will be overwritten". By calling the `maintenancetool.exe`, the installation is not merely overwritten, but the previous installation is properly uninstalled, too.

![image](https://github.com/user-attachments/assets/5f01b774-4549-4948-bfbd-739b8ff32667)
