### PR TITLE
Feature: Added option to merge identically named timeseries across files

### DIFF
--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -1373,7 +1373,7 @@ bool MainWindow::loadDataFromFiles(QStringList filenames)
 {
   filenames.sort();
   std::map<QString, QString> filename_prefix;
-  bool mergeFiles = false;
+  bool mergeFiles = false, clearExisting = true;
 
   if (filenames.size() > 1 || ui->checkBoxAddPrefixAndMerge->isChecked())
   {
@@ -1385,6 +1385,7 @@ bool MainWindow::loadDataFromFiles(QStringList filenames)
     }
     filename_prefix = dialog.getPrefixes();
     mergeFiles = dialog.mergeFiles;
+    clearExisting = dialog.clearExisting;
   }
 
   std::unordered_set<std::string> previous_names = _mapped_plot_data.getAllNames();
@@ -1400,7 +1401,7 @@ bool MainWindow::loadDataFromFiles(QStringList filenames)
     {
       info.prefix = filename_prefix[info.filename];
     }
-    auto added_names = loadDataFromFile(info, mergeFiles);
+    auto added_names = loadDataFromFile(info, mergeFiles && !(i == 0 && clearExisting));
     if (!added_names.empty())
     {
       loaded_filenames.push_back(filenames[i]);

--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -1373,6 +1373,7 @@ bool MainWindow::loadDataFromFiles(QStringList filenames)
 {
   filenames.sort();
   std::map<QString, QString> filename_prefix;
+  bool mergeFiles = false;
 
   if (filenames.size() > 1 || ui->checkBoxAddPrefixAndMerge->isChecked())
   {
@@ -1383,6 +1384,7 @@ bool MainWindow::loadDataFromFiles(QStringList filenames)
       return false;
     }
     filename_prefix = dialog.getPrefixes();
+    mergeFiles = dialog.mergeFiles;
   }
 
   std::unordered_set<std::string> previous_names = _mapped_plot_data.getAllNames();
@@ -1398,7 +1400,7 @@ bool MainWindow::loadDataFromFiles(QStringList filenames)
     {
       info.prefix = filename_prefix[info.filename];
     }
-    auto added_names = loadDataFromFile(info);
+    auto added_names = loadDataFromFile(info, mergeFiles);
     if (!added_names.empty())
     {
       loaded_filenames.push_back(filenames[i]);
@@ -1453,7 +1455,7 @@ bool MainWindow::loadDataFromFiles(QStringList filenames)
   return false;
 }
 
-std::unordered_set<std::string> MainWindow::loadDataFromFile(const FileLoadInfo& info)
+std::unordered_set<std::string> MainWindow::loadDataFromFile(const FileLoadInfo& info, const bool mergeFiles)
 {
   ui->buttonPlay->setChecked(false);
 
@@ -1545,7 +1547,7 @@ std::unordered_set<std::string> MainWindow::loadDataFromFile(const FileLoadInfo&
         AddPrefixToPlotData(info.prefix.toStdString(), mapped_data.strings);
 
         added_names = mapped_data.getAllNames();
-        importPlotDataMap(mapped_data, true);
+        importPlotDataMap(mapped_data, !mergeFiles);
 
         QDomElement plugin_elem = dataloader->xmlSaveState(new_info.plugin_config);
         new_info.plugin_config.appendChild(plugin_elem);

--- a/plotjuggler_app/mainwindow.h
+++ b/plotjuggler_app/mainwindow.h
@@ -46,7 +46,7 @@ public:
 
   bool loadLayoutFromFile(QString filename);
   bool loadDataFromFiles(QStringList filenames);
-  std::unordered_set<std::string> loadDataFromFile(const FileLoadInfo& info);
+  std::unordered_set<std::string> loadDataFromFile(const FileLoadInfo& info, const bool mergeFiles = false);
 
   void stopStreamingPlugin();
   void startStreamingPlugin(QString streamer_name);

--- a/plotjuggler_app/multifile_prefix.cpp
+++ b/plotjuggler_app/multifile_prefix.cpp
@@ -32,6 +32,16 @@ DialogMultifilePrefix::DialogMultifilePrefix(QStringList filenames, QWidget* par
   ui->mergeFilesCheckbox->setChecked(
       settings.value("DialogMultifilePrefix::mergeFiles", false).toBool());
 
+  ui->checkBoxClearExisting->setChecked(
+      settings.value("DialogMultifilePrefix::clearExisting", true).toBool());
+
+  ui->checkBoxClearExisting->setDisabled(!ui->mergeFilesCheckbox->isChecked());
+  connect(ui->mergeFilesCheckbox, &QCheckBox::toggled, this,
+          [this](bool checked) {
+            ui->checkBoxClearExisting->setDisabled(!checked);
+          });
+
+
   int index = 0;
   for (QString filename : filenames)
   {
@@ -60,6 +70,7 @@ DialogMultifilePrefix::DialogMultifilePrefix(QStringList filenames, QWidget* par
   }
 
   this->mergeFilesCheckbox = ui->mergeFilesCheckbox;
+  this->clearExistingCheckbox = ui->checkBoxClearExisting;
 }
 
 std::map<QString, QString> DialogMultifilePrefix::getPrefixes() const
@@ -93,9 +104,10 @@ void DialogMultifilePrefix::accept()
   }
 
   this->mergeFiles = this->mergeFilesCheckbox->isChecked();
+  this->clearExisting = this->clearExistingCheckbox->isChecked();
 
   settings.setValue("DialogMultifilePrefix::previous", prev_prefixes);
   settings.setValue("DialogMultifilePrefix::mergeFiles", this->mergeFiles);
-
+  settings.setValue("DialogMultifilePrefix::clearExisting", this->clearExisting);
   QDialog::accept();
 }

--- a/plotjuggler_app/multifile_prefix.cpp
+++ b/plotjuggler_app/multifile_prefix.cpp
@@ -29,6 +29,9 @@ DialogMultifilePrefix::DialogMultifilePrefix(QStringList filenames, QWidget* par
     _previous_prefixes.insert({ prev_prefixes[i], prev_prefixes[i + 1] });
   }
 
+  ui->mergeFilesCheckbox->setChecked(
+      settings.value("DialogMultifilePrefix::mergeFiles", false).toBool());
+
   int index = 0;
   for (QString filename : filenames)
   {
@@ -55,12 +58,15 @@ DialogMultifilePrefix::DialogMultifilePrefix(QStringList filenames, QWidget* par
     _prefixes[filename] = line_edit->text();
     _line_edits.insert({ filename, line_edit });
   }
+
+  this->mergeFilesCheckbox = ui->mergeFilesCheckbox;
 }
 
 std::map<QString, QString> DialogMultifilePrefix::getPrefixes() const
 {
   return _prefixes;
 }
+
 
 DialogMultifilePrefix::~DialogMultifilePrefix()
 {
@@ -86,7 +92,10 @@ void DialogMultifilePrefix::accept()
     prev_prefixes.push_back(prefix);
   }
 
+  this->mergeFiles = this->mergeFilesCheckbox->isChecked();
+
   settings.setValue("DialogMultifilePrefix::previous", prev_prefixes);
+  settings.setValue("DialogMultifilePrefix::mergeFiles", this->mergeFiles);
 
   QDialog::accept();
 }

--- a/plotjuggler_app/multifile_prefix.h
+++ b/plotjuggler_app/multifile_prefix.h
@@ -23,7 +23,7 @@ class DialogMultifilePrefix : public QDialog
 public:
   explicit DialogMultifilePrefix(QStringList filenames, QWidget* parent = nullptr);
 
-  bool mergeFiles;
+  bool mergeFiles, clearExisting;
   std::map<QString, QString> getPrefixes() const;
 
   ~DialogMultifilePrefix();
@@ -35,7 +35,7 @@ private:
   std::map<QString, QLineEdit*> _line_edits;
   std::map<QString, QString> _previous_prefixes;
   std::map<QString, QString> _prefixes;
-  QCheckBox *mergeFilesCheckbox;
+  QCheckBox *mergeFilesCheckbox, *clearExistingCheckbox;
 };
 
 #endif  // MULTIFILE_PREFIX_H

--- a/plotjuggler_app/multifile_prefix.h
+++ b/plotjuggler_app/multifile_prefix.h
@@ -9,6 +9,7 @@
 
 #include <QDialog>
 #include <QLineEdit>
+#include <QCheckBox>
 
 namespace Ui
 {
@@ -22,6 +23,7 @@ class DialogMultifilePrefix : public QDialog
 public:
   explicit DialogMultifilePrefix(QStringList filenames, QWidget* parent = nullptr);
 
+  bool mergeFiles;
   std::map<QString, QString> getPrefixes() const;
 
   ~DialogMultifilePrefix();
@@ -33,6 +35,7 @@ private:
   std::map<QString, QLineEdit*> _line_edits;
   std::map<QString, QString> _previous_prefixes;
   std::map<QString, QString> _prefixes;
+  QCheckBox *mergeFilesCheckbox;
 };
 
 #endif  // MULTIFILE_PREFIX_H

--- a/plotjuggler_app/multifile_prefix.ui
+++ b/plotjuggler_app/multifile_prefix.ui
@@ -65,6 +65,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="checkBoxClearExisting">
+       <property name="text">
+        <string>clear already present data</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/plotjuggler_app/multifile_prefix.ui
+++ b/plotjuggler_app/multifile_prefix.ui
@@ -56,14 +56,25 @@
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QCheckBox" name="mergeFilesCheckbox">
+       <property name="text">
+        <string>merge identically named timeseries</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/plotjuggler_app/utils.cpp
+++ b/plotjuggler_app/utils.cpp
@@ -92,10 +92,7 @@ MoveDataRet MoveData(PlotDataMapRef& source, PlotDataMapRef& destination,
       }
       else
       {
-        for (size_t i = 0; i < source_plot.size(); i++)
-        {
-          destination_plot.pushBack(source_plot.at(i));
-        }
+        destination_plot.mergeWith(source_plot);
         source_plot.clear();
       }
     }

--- a/plotjuggler_base/include/PlotJuggler/plotdatabase.h
+++ b/plotjuggler_base/include/PlotJuggler/plotdatabase.h
@@ -372,6 +372,60 @@ public:
     _points.insert(it, p);
   }
 
+
+  void mergeWith(PlotDataBase<TypeX, Value>& other) {
+    if (other._points.empty())
+      return;
+
+    if (this->_points.empty()) {
+      this->_points.swap(other._points);
+      this->_range_x_dirty = other._range_x_dirty;
+      this->_range_y_dirty = other._range_y_dirty;
+
+      if constexpr (std::is_arithmetic_v<TypeX>) {
+        this->_range_x.max = other._range_x.max;
+        this->_range_x.min = other._range_x.min;
+      }
+
+      if constexpr (std::is_arithmetic_v<Value>) {
+        this->_range_y.min = other._range_y.min;
+        this->_range_y.max = other._range_y.max;
+      }
+      return;
+
+    }
+
+    if constexpr (std::is_arithmetic_v<TypeX>) {
+
+      // new points are all after this->_points
+      if (other._points.front().x > this->_points.back().x) {
+        std::move(other._points.begin(), other._points.end(), std::back_inserter(this->_points));
+
+                // new points are all before this->_points
+      } else if (other._points.back().x < this->_points.front().x) {
+        std::move(this->_points.begin(), this->_points.end(), std::back_inserter(other._points));
+        this->_points.swap(other._points);
+      } else {
+        // Fallback to standard merging with move where possible
+        std::deque<Point> result;
+        std::merge(std::make_move_iterator(this->_points.begin()), std::make_move_iterator(this->_points.end()),
+                   std::make_move_iterator(other._points.begin()), std::make_move_iterator(other._points.end()),
+                   std::back_inserter(result),
+                   [](const Point& a, const Point& b) { return a.x < b.x; });
+        this->_points.swap(result);
+      }
+      this->_range_x.max = std::max(this->_range_x.max, other._range_x.max);
+      this->_range_x.min = std::min(this->_range_x.min, other._range_x.min);
+    } else {
+      std::move(other._points.begin(), other._points.end(), std::back_inserter(this->_points));
+    }
+
+    if constexpr (std::is_arithmetic_v<Value>) {
+      this->_range_y.max = std::max(this->_range_y.max, other._range_y.max);
+      this->_range_y.min = std::min(this->_range_y.min, other._range_y.min);
+    }
+  }
+
   virtual void popFront()
   {
     const auto& p = _points.front();


### PR DESCRIPTION
_Note: If any part of this pull-request is not up to the expected standards, preventing it from being merged, I would appreciate any feedback so that I can iterate on it until it is!_


## Background
Depending on the software used to collect data during experiments, the resulting logs can be fragmented. If that is the case, one can, currently, visualize them all at the same time in PlotJuggler by just giving them different prefixed.

This approach has one main drawback, however: Every timeseries is present as often as the number of log fragments one is dealing with. As a result, layouts don't work and custom series are cumbersome (need to be created for every <prefix>/timeseries).

## Changes
This pull request adds an option in the 'multifile prefix' dialog, that, when ticked, merges timeseries of the same name of all files loaded. In the use-case described before, this can be used in two ways: (1) By setting all prefixes to empty strings, the resulting timeseries in PlotJuggler behave as if coming from one individual file. (2) By grouping the timeseries into different prefixes, multiple fragmented datasets can be visualized simultaneously.

Additionally, this pull requests adds a 'clear already present data' checkbox, that is only active when 'merge identically named timeseries' is, too, and does as the name suggests. When not ticked, newly loaded timeseries are merged with the ones already present in PlotJuggler. When ticked, all points in existing timeseries are clearer before importing the new data.

## Examples and Screenshots
For example, this configuration:
![image](https://github.com/user-attachments/assets/ece53178-51f7-4f8f-bfc2-db76e606d7e9)

where the files all contain overlapping timeseries would merge the content of those.

Unchecking the box results in the current behaviour, where the last file loaded is the one whose timeseries with clashing names survive.
![image](https://github.com/user-attachments/assets/537eba9a-5d86-4f8b-96db-2bd6338b76a5)