### PR TITLE
udp_server: fix crash when dialog opens for the first time

### DIFF
--- a/plotjuggler_plugins/DataStreamUDP/udp_server.cpp
+++ b/plotjuggler_plugins/DataStreamUDP/udp_server.cpp
@@ -97,9 +97,13 @@ bool UDP_Server::start(QStringList*)
 
   // load previous values
   QSettings settings;
-  QString protocol = settings.value("UDP_Server::protocol", "JSON").toString();
   QString address_str = settings.value("UDP_Server::address", "127.0.0.1").toString();
   int port = settings.value("UDP_Server::port", 9870).toInt();
+  QString protocol = settings.value("UDP_Server::protocol").toString();
+  if (parserFactories()->find(protocol) == parserFactories()->end())
+  {
+    protocol = "json";
+  }
 
   dialog.ui->lineEditAddress->setText(address_str);
   dialog.ui->lineEditPort->setText(QString::number(port));


### PR DESCRIPTION
UDP server dialogue crashes when theres no protocol stored in settings, as the default is wrongly "JSON", but it should be "json".

This patch uses default "json" even when there is wrong protocol in settings to prevent further crashes.

Fixes #992 