### PR TITLE
Do not convert log extensions to lowercase

### DIFF
--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -3015,7 +3015,7 @@ void MainWindow::on_buttonLoadDatafile_clicked()
     DataLoaderPtr loader = it.second;
     for (QString extension : loader->compatibleFileExtensions())
     {
-      extensions.insert(extension.toLower());
+      extensions.insert(extension);
     }
   }
 


### PR DESCRIPTION
The log files in ArduPilot have an extension of uppercase BIN. 
I want to make decisions based on the string set in the extension.

ArduPilot PLUGIN
https://github.com/ArduPilot/plotjuggler-apbin-plugins