### PR TITLE
Fix MQTT plugin (#1006, #1008)

### DIFF
--- a/plotjuggler_plugins/DataStreamMQTT/mqtt_client.cpp
+++ b/plotjuggler_plugins/DataStreamMQTT/mqtt_client.cpp
@@ -235,7 +235,7 @@ bool MQTTClient::configureMosquitto(const MosquittoConfig& config)
   {
     QMessageBox::warning(nullptr, "MQTT Client", QString("Failed to start MQTT client"),
                          QMessageBox::Ok);
-    debug() << "MQTT start loot failed:" << mosquitto_strerror(rc);
+    debug() << "MQTT start loop failed:" << mosquitto_strerror(rc);
     return false;
   }
   return true;

--- a/plotjuggler_plugins/DataStreamMQTT/mqtt_client.h
+++ b/plotjuggler_plugins/DataStreamMQTT/mqtt_client.h
@@ -4,6 +4,7 @@
 #include "mosquitto_config.h"
 #include <string>
 #include <functional>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <mutex>
@@ -46,13 +47,14 @@ signals:
   void disconnected();
 
 private:
-  bool configureMosquitto(const MosquittoConfig &config);
+  bool configureMosquitto(const MosquittoConfig& config);
 
   mosquitto* _mosq = nullptr;
   std::unordered_map<std::string, TopicCallback> _message_callbacks;
   std::unordered_set<std::string> _topics_set;
   std::mutex _mutex;
   MosquittoConfig _config;
+  std::thread* _thread;
 };
 
 #endif  // MQTT_CLIENT_H

--- a/plotjuggler_plugins/DataStreamMQTT/mqtt_client.h
+++ b/plotjuggler_plugins/DataStreamMQTT/mqtt_client.h
@@ -46,6 +46,8 @@ signals:
   void disconnected();
 
 private:
+  bool configureMosquitto(const MosquittoConfig &config);
+
   mosquitto* _mosq = nullptr;
   std::unordered_map<std::string, TopicCallback> _message_callbacks;
   std::unordered_set<std::string> _topics_set;


### PR DESCRIPTION
This pull request fixes issues #1006 and #1008.

On Linux the MQTT plugin freezes PlotJugger see issue #1008. The program flow seems to be stuck within mosquitto_connect_bind_v5() on the second connection attempt. This is solved by starting with a fresh mosquitto instance at each connection attempt.

On Windows PlotJuggler doesn't show any topics after establishing a connection, see issue #1006. mqtt_client.cpp does not check the return code of mosquitto_loop_start(), which may return MOSQ_ERR_NOT_SUPPORTED on Windows. This causes the plugin to assume that the connection has been established, but in reality the mosquitto event loop is not processed. This causes the user to think that a connection was established but no topics are displayed. The plugin worked in the past with no recent changes to the source code, so what causes the problem?  It seems that libmosquitto has at some point dropped threaded support on Windows (see https://github.com/eclipse/mosquitto/issues/2707). Threaded support will be added again in the future (maybe 2.1?). To solve this problem mosquitto gets it's own thread if mosquitto_loop_start() fails. 

To make mqtt_client.cpp more robust all mosquitto_xxx return codes are checked. To increase the user experience some QMessageBox messages have been added.

fixes #1006 
fixes #1008 

Kind regards,
Valentin