### PR TITLE
fix(ulog): the index of the timestamp may be non-zero

### DIFF
--- a/plotjuggler_plugins/DataLoadULog/ulog_parser.h
+++ b/plotjuggler_plugins/DataLoadULog/ulog_parser.h
@@ -79,12 +79,13 @@ public:
 
   struct Format
   {
-    Format() : padding(0)
+    Format() : padding(0), timestamp_idx(-1)
     {
     }
     std::string name;
     std::vector<Field> fields;
     int padding;
+    int timestamp_idx;
   };
 
   struct MessageLog


### PR DESCRIPTION
The previous parsing assumed that the timestamp for a ulog data series was always at index 0, which is often, but not necessarily the case. The parser now store the correct index when parsing the definition.