### PR TITLE
Setting stretch behavior of the config panel in zcm dataloader ui

### DIFF
--- a/plotjuggler_plugins/PluginsZcm/config_zcm.ui
+++ b/plotjuggler_plugins/PluginsZcm/config_zcm.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>553</width>
-    <height>264</height>
+    <height>200</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -78,6 +78,9 @@
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QListWidget" name="listWidgetLibs">
+          <property name="sizeAdjustPolicy">
+           <enum>QAbstractScrollArea::AdjustToContents</enum>
+          </property>
           <property name="editTriggers">
            <set>QAbstractItemView::NoEditTriggers</set>
           </property>
@@ -136,12 +139,6 @@
            <spacer name="verticalSpacer">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
             </property>
            </spacer>
           </item>

--- a/plotjuggler_plugins/PluginsZcm/dataload_zcm.cpp
+++ b/plotjuggler_plugins/PluginsZcm/dataload_zcm.cpp
@@ -28,7 +28,9 @@ DataLoadZcm::DataLoadZcm()
   _ui->setupUi(_dialog);
 
   _config_widget = new ConfigZCM("DataLoadZcm", _dialog);
+  _config_widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
   _ui->mainLayout->insertWidget(0, _config_widget, 1);
+  _ui->mainLayout->setStretchFactor(_config_widget, 0);
 
   _ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
 


### PR DESCRIPTION
Changed the stretch behavior of the config panel when added to the dataloader panel