### PR TITLE
Build improvements

### DIFF
--- a/plotjuggler_app/CMakeLists.txt
+++ b/plotjuggler_app/CMakeLists.txt
@@ -1,3 +1,4 @@
+option(EXE_STATIC "Link the PlotJuggler binary statically" OFF)
 
 set (CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -119,7 +120,8 @@ target_link_libraries(plotjuggler
     plotjuggler_base
     plotjuggler_qwt
     QCodeEditor
-    )
+    $<$<BOOL:${EXE_STATIC}>:-static-libgcc -static-libstdc++ -static>
+)
 
 if(COMPILING_WITH_CATKIN)
 

--- a/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/CMakeLists.txt
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/3rdparty/Fast-CDR/src/cpp/CMakeLists.txt
@@ -32,7 +32,7 @@ set(${PROJECT_NAME}_source_files
     exceptions/Exception.cpp
     exceptions/LockedExternalAccessException.cpp
     exceptions/NotEnoughMemoryException.cpp
-    FastCdr.rc
+    $<$<STREQUAL:$<TARGET_PROPERTY:${PROJECT_NAME},TYPE>,SHARED_LIBRARY>:FastCdr.rc>
     )
 
 configure_file(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/config.h.in


### PR DESCRIPTION
The first commit fixes a problem that I have reported upstream as well (https://github.com/eProsima/Fast-CDR/pull/259). With this change it is possible to cross-compile PJ with mingw for windows.

The second patch allows for building PJ statically. It's meant as a base for discussion. The resulting binary is naturally huge but easy to distribute.