### PR TITLE
fix broken parquet parsing when parquet file contains 'invalid' columns

### DIFF
--- a/plotjuggler_plugins/DataLoadParquet/dataload_parquet.cpp
+++ b/plotjuggler_plugins/DataLoadParquet/dataload_parquet.cpp
@@ -168,6 +168,7 @@ bool DataLoadParquet::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_
     {
       if (!valid_column[col])
       {
+        os.SkipColumns(1);
         continue;
       }
       auto type = column_type[col];
@@ -267,7 +268,7 @@ bool DataLoadParquet::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_
         default: {
         }
       }  // end switch
-    }    // end for column
+    }  // end for column
 
     os >> parquet::EndRow;
 


### PR DESCRIPTION
When parquet parser encounters an 'invalid' columns it should skip it in the stream.