### PR TITLE
DataLoadMCAP: add support to mcap logTime

### DIFF
--- a/plotjuggler_plugins/DataLoadMCAP/dataload_mcap.cpp
+++ b/plotjuggler_plugins/DataLoadMCAP/dataload_mcap.cpp
@@ -37,6 +37,7 @@ bool DataLoadMCAP::xmlSaveState(QDomDocument& doc, QDomElement& parent_element) 
   QDomElement elem = doc.createElement("parameters");
   const auto& params = *_dialog_parameters;
   elem.setAttribute("use_timestamp", int(params.use_timestamp));
+  elem.setAttribute("use_mcap_log_time", int(params.use_mcap_log_time));
   elem.setAttribute("clamp_large_arrays", int(params.clamp_large_arrays));
   elem.setAttribute("max_array_size", params.max_array_size);
   elem.setAttribute("selected_topics", params.selected_topics.join(';'));
@@ -55,6 +56,7 @@ bool DataLoadMCAP::xmlLoadState(const QDomElement& parent_element)
   }
   mcap::LoadParams params;
   params.use_timestamp = bool(elem.attribute("use_timestamp").toInt());
+  params.use_mcap_log_time = bool(elem.attribute("use_mcap_log_time").toInt());
   params.clamp_large_arrays = bool(elem.attribute("clamp_large_arrays").toInt());
   params.max_array_size = elem.attribute("max_array_size").toInt();
   params.selected_topics = elem.attribute("selected_topics").split(';');
@@ -227,6 +229,10 @@ bool DataLoadMCAP::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_dat
 
     // MCAP always represents publishTime in nanoseconds
     double timestamp_sec = double(msg_view.message.publishTime) * 1e-9;
+    if (_dialog_parameters->use_mcap_log_time)
+    {
+      timestamp_sec = double(msg_view.message.logTime) * 1e-9;
+    }
     auto parser_it = parsers_by_channel.find(msg_view.channel->id);
     if (parser_it == parsers_by_channel.end())
     {

--- a/plotjuggler_plugins/DataLoadMCAP/dataload_params.h
+++ b/plotjuggler_plugins/DataLoadMCAP/dataload_params.h
@@ -11,6 +11,7 @@ struct LoadParams
   unsigned max_array_size;
   bool clamp_large_arrays;
   bool use_timestamp = false;
+  bool use_mcap_log_time;
 };
 
 }  // namespace mcap

--- a/plotjuggler_plugins/DataLoadMCAP/dialog_mcap.cpp
+++ b/plotjuggler_plugins/DataLoadMCAP/dialog_mcap.cpp
@@ -34,6 +34,8 @@ DialogMCAP::DialogMCAP(const std::unordered_map<int, mcap::ChannelPtr>& channels
     params.clamp_large_arrays = settings.value(prefix + "clamp", true).toBool();
     params.max_array_size = settings.value(prefix + "max_array", 500).toInt();
     params.use_timestamp = settings.value(prefix + "use_timestamp", false).toBool();
+    params.use_mcap_log_time =
+        settings.value(prefix + "use_mcap_log_time", false).toBool();
   }
   else
   {
@@ -50,6 +52,14 @@ DialogMCAP::DialogMCAP(const std::unordered_map<int, mcap::ChannelPtr>& channels
   }
   ui->spinBox->setValue(params.max_array_size);
   ui->checkBoxUseTimestamp->setChecked(params.use_timestamp);
+  if (params.use_mcap_log_time)
+  {
+    ui->radioLogTime->setChecked(true);
+  }
+  else
+  {
+    ui->radioPubTime->setChecked(true);
+  }
 
   int row = 0;
   for (const auto& [id, channel] : channels)
@@ -83,6 +93,7 @@ mcap::LoadParams DialogMCAP::getParams() const
   params.max_array_size = ui->spinBox->value();
   params.clamp_large_arrays = ui->radioClamp->isChecked();
   params.use_timestamp = ui->checkBoxUseTimestamp->isChecked();
+  params.use_mcap_log_time = ui->radioLogTime->isChecked();
 
   QItemSelectionModel* select = ui->tableWidget->selectionModel();
   QStringList selected_topics;
@@ -107,10 +118,12 @@ void DialogMCAP::accept()
   bool clamp_checked = ui->radioClamp->isChecked();
   int max_array = ui->spinBox->value();
   bool use_timestamp = ui->checkBoxUseTimestamp->isChecked();
+  bool use_mcap_log_time = ui->radioLogTime->isChecked();
 
   settings.setValue(prefix + "clamp", clamp_checked);
   settings.setValue(prefix + "max_array", max_array);
   settings.setValue(prefix + "use_timestamp", use_timestamp);
+  settings.setValue(prefix + "use_mcap_log_time", use_mcap_log_time);
 
   QItemSelectionModel* select = ui->tableWidget->selectionModel();
   QStringList selected_topics;

--- a/plotjuggler_plugins/DataLoadMCAP/dialog_mcap.ui
+++ b/plotjuggler_plugins/DataLoadMCAP/dialog_mcap.ui
@@ -73,6 +73,40 @@
     </widget>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_1">
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Select the MCAP timestamping mode:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="radioPubTime">
+       <property name="text">
+        <string>publish time</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="radioLogTime">
+       <property name="text">
+        <string>log time</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="Line" name="line">
      <property name="frameShadow">
       <enum>QFrame::Plain</enum>
@@ -178,4 +212,7 @@
    </hints>
   </connection>
  </connections>
+ <buttongroups>
+  <buttongroup name="buttonGroup"/>
+ </buttongroups>
 </ui>


### PR DESCRIPTION
The DataLoadMCAP plugin support only the publishTime of the mcap message. Add a radio button in the load dialog to select the logTime or publishTime.