### PR TITLE
Fix IPv6 multicast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ _deps
 # Clangd
 .cache
 /snap/*
+*.AppImage

--- a/plotjuggler_plugins/DataStreamUDP/udp_client.py
+++ b/plotjuggler_plugins/DataStreamUDP/udp_client.py
@@ -5,14 +5,18 @@ import socket
 import math
 import json
 from time import sleep
+from ipaddress import ip_address
 
 parser = argparse.ArgumentParser(description="Send UDP test data.")
+# For testing multicast, try IPv4 address 239.0.0.1 or IPv6 address ff02::1
 parser.add_argument("--address", default="127.0.0.1", help="UDP address")
 parser.add_argument("--port", default=9870, type=int, help="UDP port")
 args = parser.parse_args()
 
-sock = socket.socket(socket.AF_INET, # Internet
-                     socket.SOCK_DGRAM) # UDP
+addr = ip_address(args.address)
+print(f"Opening IPv{addr.version} UDP socket for address {addr} on port {args.port}...")
+family = socket.AF_INET6 if addr.version == 6 else socket.AF_INET
+sock = socket.socket(family, socket.SOCK_DGRAM) # UDP
 time = 0.0
 
 while True:


### PR DESCRIPTION
Trying IPv6 multicast, I could get nothing to work. After much trial & error, I got this solution working, including using the `udp_client.py` tool as a test data source with the documented multicast groups for both IPv4 and IPv6. I noticed the previous #858, @agoessling would you like to re-test your use-case?