### PR TITLE
Update macOS compile instructions

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -33,9 +33,9 @@ if (NOT lua_FOUND)
         target_include_directories(lua SYSTEM PUBLIC $<BUILD_INTERFACE:${lua_SOURCE_DIR}>)
         set_property(TARGET lua PROPERTY POSITION_INDEPENDENT_CODE ON)
     endif()
- endif()
+endif()
 
-CPMAddPackage("gh:ThePhD/sol2@3.3.0")
+CPMAddPackage("gh:ThePhD/sol2@3.5.0")
 
 
 ##### data_tamer ######

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -82,9 +82,9 @@ cp -v install/bin/* AppDir/usr/bin
 docker buildx build -o . .
 ```
 
-# Compile in Mac
+# Compile in macOS
 
-On Mac, the dependencies can be installed using [brew](https://brew.sh/) with the following command:
+On macOS, the dependencies can be installed using [brew](https://brew.sh/) with the following command:
 
 ```shell
 brew install cmake qt@5 protobuf mosquitto zeromq zstd
@@ -93,8 +93,8 @@ brew install cmake qt@5 protobuf mosquitto zeromq zstd
 If a newer version of qt is installed, you may need to temporarily link to qt5
 
 ```shell
-brew link qt@5 --override
-# brew link qt --override # Run once you are done building to restore the original linking
+brew link qt@5 --overwrite
+# brew link qt --overwrite  # Run once you are done building to restore the original linking
 ```
 
 Add CMake into your env-vars to be detected by cmake
@@ -125,7 +125,7 @@ cd ~/plotjuggler_ws
 Then compile using cmake:
 
 ```shell
-cmake -S src/PlotJuggler -B build/PlotJuggler -DCMAKE_INSTALL_PREFIX=install
+cmake -S src/PlotJuggler -B build/PlotJuggler -DCMAKE_INSTALL_PREFIX=install -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 cmake --build build/PlotJuggler --config RelWithDebInfo --target install
 ```
 


### PR DESCRIPTION
Hi, @facontidavide!  😃  I was just now trying to build PlotJuggler on my MacBook Air M2 from source, and I ran into a few issues. This PR includes the changes I had to make to build it successfully.

Note: this bumps the `ThePhD/sol2` dependency from `v3.3.0` to `v3.5.0`.