### PR TITLE
Fix protobuf parser

### DIFF
--- a/plotjuggler_plugins/ParserProtobuf/error_collectors.cpp
+++ b/plotjuggler_plugins/ParserProtobuf/error_collectors.cpp
@@ -2,24 +2,24 @@
 #include <QMessageBox>
 #include <QDebug>
 
-void FileErrorCollector::AddError(const std::string& filename, int line, int,
-                                  const std::string& message)
+void FileErrorCollector::RecordError(absl::string_view filename, int line, int,
+                                     absl::string_view message)
 {
   auto msg = QString("File: [%1] Line: [%2] Message: %3\n\n")
-                 .arg(QString::fromStdString(filename))
+                 .arg(QString::fromStdString(std::string(filename)))
                  .arg(line)
-                 .arg(QString::fromStdString(message));
+                 .arg(QString::fromStdString(std::string(message)));
 
   _errors.push_back(msg);
 }
 
-void FileErrorCollector::AddWarning(const std::string& filename, int line, int,
-                                    const std::string& message)
+void FileErrorCollector::RecordWarning(absl::string_view filename, int line, int,
+                                       absl::string_view message)
 {
   auto msg = QString("Warning [%1] line %2: %3")
-                 .arg(QString::fromStdString(filename))
+                 .arg(QString::fromStdString(std::string(filename)))
                  .arg(line)
-                 .arg(QString::fromStdString(message));
+                 .arg(QString::fromStdString(std::string(message)));
   qDebug() << msg;
 }
 

--- a/plotjuggler_plugins/ParserProtobuf/error_collectors.h
+++ b/plotjuggler_plugins/ParserProtobuf/error_collectors.h
@@ -27,11 +27,11 @@ private:
 class FileErrorCollector : public google::protobuf::compiler::MultiFileErrorCollector
 {
 public:
-  void AddError(const std::string& filename, int line, int,
-                const std::string& message) override;
+  void RecordError(absl::string_view filename, int line, int,
+                   absl::string_view message) override;
 
-  void AddWarning(const std::string& filename, int line, int,
-                  const std::string& message) override;
+  void RecordWarning(absl::string_view filename, int line, int,
+                     absl::string_view message) override;
 
   const QStringList& errors()
   {


### PR DESCRIPTION
The protobuf API changed in v30.0

Partially addresses #1090

https://protobuf.dev/news/2024-10-02/#descriptor-apis