### PR TITLE
fix linking to roscpp when required

### DIFF
--- a/plotjuggler_app/CMakeLists.txt
+++ b/plotjuggler_app/CMakeLists.txt
@@ -128,7 +128,11 @@ target_link_libraries(plotjuggler
         lua::lua
     )
 
-if(COMPILING_WITH_AMENT)
+if(COMPILING_WITH_CATKIN)
+    target_link_libraries(plotjuggler PRIVATE
+        ${catkin_LIBRARIES}
+    )
+elseif(COMPILING_WITH_AMENT)
 
     target_link_libraries(plotjuggler PRIVATE
         ament_index_cpp::ament_index_cpp


### PR DESCRIPTION
At least mold complains when trying to build without explicitly linking roscpp (when required).

```
mold: error: undefined symbol: ros::removeROSArgs(int, char const* const*, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&)
>>> referenced by main.cpp
>>>               CMakeFiles/plotjuggler.dir/main.cpp.o:(main)
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

I'm not sure what you will do with this patch after you merged https://github.com/PlotJuggler/plotjuggler-ros-plugins/pull/98 recently.
It would be great if you could provide some guidance on how ROS-O should handle PlotJuggler in the future.