### PR TITLE
Using absl library streams instead of std::file** to comply with new …

### DIFF
--- a/plotjuggler_plugins/ParserProtobuf/error_collectors.cpp
+++ b/plotjuggler_plugins/ParserProtobuf/error_collectors.cpp
@@ -2,28 +2,28 @@
 #include <QMessageBox>
 #include <QDebug>
 
-void FileErrorCollector::AddError(const std::string& filename, int line, int,
-                                  const std::string& message)
+void FileErrorCollector::RecordError(const absl::string_view filename, int line, int,
+                                  const absl::string_view message)
 {
   auto msg = QString("File: [%1] Line: [%2] Message: %3\n\n")
-                 .arg(QString::fromStdString(filename))
+                 .arg(QString::fromStdString(std::string(filename)))
                  .arg(line)
-                 .arg(QString::fromStdString(message));
+                 .arg(QString::fromStdString(std::string(message)));
 
   _errors.push_back(msg);
 }
 
-void FileErrorCollector::AddWarning(const std::string& filename, int line, int,
-                                    const std::string& message)
+void FileErrorCollector::RecordWarning(const absl::string_view filename, int line, int,
+                                    const absl::string_view message)
 {
   auto msg = QString("Warning [%1] line %2: %3")
-                 .arg(QString::fromStdString(filename))
+                 .arg(QString::fromStdString(std::string(filename)))
                  .arg(line)
-                 .arg(QString::fromStdString(message));
+                 .arg(QString::fromStdString(std::string(message)));
   qDebug() << msg;
 }
 
-void IoErrorCollector::AddError(int line, google::protobuf::io::ColumnNumber,
+void IoErrorCollector::AddError(int line, google::protobuf::io::ColumnNumber column,
                                 const std::string& message)
 {
   _errors.push_back(

--- a/plotjuggler_plugins/ParserProtobuf/error_collectors.h
+++ b/plotjuggler_plugins/ParserProtobuf/error_collectors.h
@@ -3,6 +3,7 @@
 
 #include <google/protobuf/io/tokenizer.h>
 #include <google/protobuf/compiler/importer.h>
+#include "absl/strings/string_view.h"
 
 #include <QStringList>
 
@@ -27,11 +28,11 @@ private:
 class FileErrorCollector : public google::protobuf::compiler::MultiFileErrorCollector
 {
 public:
-  void AddError(const std::string& filename, int line, int,
-                const std::string& message) override;
+  void RecordError(const absl::string_view filename, int line, int,
+                const absl::string_view message) override;
 
-  void AddWarning(const std::string& filename, int line, int,
-                  const std::string& message) override;
+  void RecordWarning(const absl::string_view filename, int line, int,
+                  const absl::string_view message) override;
 
   const QStringList& errors()
   {


### PR DESCRIPTION
New versions of google's protobuf compiler started to use abseil libraries instead of standard streams. Look at: [(src/google/protobuf/compiler/command_line_interface.cc#L402)](https://github.com/protocolbuffers/protobuf/blob/e3e56c72a9fafb64fd25853e183fffa2bd12b0b7/src/google/protobuf/compiler/command_line_interface.cc#L402)

This a small fix to comply with this change