### PR TITLE
Fix compilation with recent protobuf

### DIFF
--- a/plotjuggler_plugins/ParserProtobuf/error_collectors.cpp
+++ b/plotjuggler_plugins/ParserProtobuf/error_collectors.cpp
@@ -2,38 +2,76 @@
 #include <QMessageBox>
 #include <QDebug>
 
+namespace
+{
+// Helper function to convert string parameter to QString, handling both std::string and
+// absl::string_view
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+QString protobufStringToQString(absl::string_view str)
+{
+  return QString::fromStdString(std::string(str));
+}
+#else
+QString protobufStringToQString(const std::string& str)
+{
+  return QString::fromStdString(str);
+}
+#endif
+}  // anonymous namespace
+
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+void FileErrorCollector::RecordError(absl::string_view filename, int line, int,
+                                     absl::string_view message)
+#else
 void FileErrorCollector::AddError(const std::string& filename, int line, int,
                                   const std::string& message)
+#endif
 {
   auto msg = QString("File: [%1] Line: [%2] Message: %3\n\n")
-                 .arg(QString::fromStdString(filename))
+                 .arg(protobufStringToQString(filename))
                  .arg(line)
-                 .arg(QString::fromStdString(message));
+                 .arg(protobufStringToQString(message));
 
   _errors.push_back(msg);
 }
 
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+void FileErrorCollector::RecordWarning(absl::string_view filename, int line, int,
+                                       absl::string_view message)
+#else
 void FileErrorCollector::AddWarning(const std::string& filename, int line, int,
                                     const std::string& message)
+#endif
 {
   auto msg = QString("Warning [%1] line %2: %3")
-                 .arg(QString::fromStdString(filename))
+                 .arg(protobufStringToQString(filename))
                  .arg(line)
-                 .arg(QString::fromStdString(message));
+                 .arg(protobufStringToQString(message));
   qDebug() << msg;
 }
 
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+void IoErrorCollector::RecordError(int line, google::protobuf::io::ColumnNumber,
+                                   absl::string_view message)
+#else
 void IoErrorCollector::AddError(int line, google::protobuf::io::ColumnNumber,
                                 const std::string& message)
+#endif
 {
-  _errors.push_back(
-      QString("Line: [%1] Message: %2\n").arg(line).arg(QString::fromStdString(message)));
+  _errors.push_back(QString("Line: [%1] Message: %2\n")
+                        .arg(line)
+                        .arg(protobufStringToQString(message)));
 }
 
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+void IoErrorCollector::RecordWarning(int line, google::protobuf::io::ColumnNumber column,
+                                     absl::string_view message)
+#else
 void IoErrorCollector::AddWarning(int line, google::protobuf::io::ColumnNumber column,
                                   const std::string& message)
+#endif
 {
   qDebug() << QString("Line: [%1] Message: %2\n")
                   .arg(line)
-                  .arg(QString::fromStdString(message));
+                  .arg(protobufStringToQString(message));
 }

--- a/plotjuggler_plugins/ParserProtobuf/error_collectors.h
+++ b/plotjuggler_plugins/ParserProtobuf/error_collectors.h
@@ -3,17 +3,26 @@
 
 #include <google/protobuf/io/tokenizer.h>
 #include <google/protobuf/compiler/importer.h>
+#include <google/protobuf/port_def.inc>
 
 #include <QStringList>
 
 class IoErrorCollector : public google::protobuf::io::ErrorCollector
 {
 public:
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+  void RecordError(int line, google::protobuf::io::ColumnNumber column,
+                   absl::string_view message) override;
+
+  void RecordWarning(int line, google::protobuf::io::ColumnNumber column,
+                     absl::string_view message) override;
+#else
   void AddError(int line, google::protobuf::io::ColumnNumber column,
-                const std::string& message);
+                const std::string& message) override;
 
   void AddWarning(int line, google::protobuf::io::ColumnNumber column,
-                  const std::string& message);
+                  const std::string& message) override;
+#endif
 
   const QStringList& errors()
   {
@@ -27,11 +36,19 @@ private:
 class FileErrorCollector : public google::protobuf::compiler::MultiFileErrorCollector
 {
 public:
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+  void RecordError(absl::string_view filename, int line, int,
+                   absl::string_view message) override;
+
+  void RecordWarning(absl::string_view filename, int line, int,
+                     absl::string_view message) override;
+#else
   void AddError(const std::string& filename, int line, int,
                 const std::string& message) override;
 
   void AddWarning(const std::string& filename, int line, int,
                   const std::string& message) override;
+#endif
 
   const QStringList& errors()
   {


### PR DESCRIPTION
This PR fixes the compilation with recent protobuf version, while keeping compatibility with older protobuf versions.

Fix https://github.com/facontidavide/PlotJuggler/issues/1004 .
Fix https://github.com/facontidavide/PlotJuggler/pull/1097 .
Fix https://github.com/facontidavide/PlotJuggler/pull/1106 .

Related to https://github.com/facontidavide/PlotJuggler/issues/1090#issuecomment-3025267144 .