### PR TITLE
Allow saving a whole tab

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,8 @@ set(PLOTJUGGLER_BASE_SRC
     plotjuggler_base/src/plotlegend.cpp
     plotjuggler_base/src/plotpanner.cpp
     plotjuggler_base/src/timeseries_qwt.cpp
-    plotjuggler_base/src/reactive_function.cpp)
+    plotjuggler_base/src/reactive_function.cpp
+    plotjuggler_base/src/save_plot.cpp)
 
 qt5_wrap_cpp(
   PLOTJUGGLER_BASE_MOCS

--- a/plotjuggler_app/plot_docker.cpp
+++ b/plotjuggler_app/plot_docker.cpp
@@ -279,12 +279,12 @@ void PlotDocker::on_stylesheetChanged(QString theme)
   }
 }
 
-QRect PlotDocker::plotRelativeFootprint(int index) const
+QRect PlotDocker::plotRelativeFootprint(int index, QSize plot_size) const
 {
-  const auto factor_x = static_cast<float>(default_document_dimentions.width()) /
-                        static_cast<float>(rect().width());
-  const auto factor_y = static_cast<float>(default_document_dimentions.height()) /
-                        static_cast<float>(rect().height());
+  const auto factor_x =
+      static_cast<float>(plot_size.width()) / static_cast<float>(rect().width());
+  const auto factor_y =
+      static_cast<float>(plot_size.height()) / static_cast<float>(rect().height());
 
   const auto* dock_area = dockArea(index);
   const auto plot_pos = mapFromGlobal(
@@ -306,13 +306,14 @@ QRect PlotDocker::plotRelativeFootprint(int index) const
 
 void PlotDocker::savePlotsToFile()
 {
-  PlotSaveHelper save_plots_helper(default_document_dimentions, this);
+  const auto plot_size = plotSize();
+  PlotSaveHelper save_plots_helper(plot_size, this);
 
   for (int index = 0; index < plotCount(); index++)
   {
     const auto* dock_area = dockArea(index);
 
-    const auto plot_footprint = plotRelativeFootprint(index);
+    const auto plot_footprint = plotRelativeFootprint(index, plot_size);
     auto* plot_at = plotAt(index);
     plot_at->plotOn(save_plots_helper, plot_footprint);
 

--- a/plotjuggler_app/plot_docker.h
+++ b/plotjuggler_app/plot_docker.h
@@ -26,6 +26,8 @@ public:
 
   DockToolbar* toolBar();
 
+  QString name() const;
+
 public slots:
   DockWidget* splitHorizontal();
 
@@ -73,8 +75,12 @@ public slots:
 
   void on_stylesheetChanged(QString theme);
 
+  void savePlotsToFile();
+
 private:
   void restoreSplitter(QDomElement elem, DockWidget* widget);
+
+  QRect plotRelativeFootprint(int index) const;
 
   QString _name;
 

--- a/plotjuggler_app/plot_docker.h
+++ b/plotjuggler_app/plot_docker.h
@@ -80,7 +80,7 @@ public slots:
 private:
   void restoreSplitter(QDomElement elem, DockWidget* widget);
 
-  QRect plotRelativeFootprint(int index) const;
+  QRect plotRelativeFootprint(int index, QSize plot_size) const;
 
   QString _name;
 

--- a/plotjuggler_app/plotwidget.cpp
+++ b/plotjuggler_app/plotwidget.cpp
@@ -1394,6 +1394,13 @@ void PlotWidget::updateAvailableTransformers()
 
 void PlotWidget::on_savePlotToFile()
 {
+  PlotSaveHelper save_plots_helper(default_document_dimentions, this);
+  plotOn(save_plots_helper, { 0, 0, default_document_dimentions.width(),
+                              default_document_dimentions.height() });
+}
+
+void PlotWidget::plotOn(const PlotSaveHelper& plot_save_helper, QRect paint_at)
+{
   bool tracker_enabled = _tracker->isEnabled();
   if (tracker_enabled)
   {
@@ -1401,7 +1408,7 @@ void PlotWidget::on_savePlotToFile()
     replot();
   }
 
-  savePlotToFile(default_document_dimentions, qwtPlot(), this);
+  plot_save_helper.paint(qwtPlot(), paint_at);
 
   if (tracker_enabled)
   {

--- a/plotjuggler_app/plotwidget.cpp
+++ b/plotjuggler_app/plotwidget.cpp
@@ -1394,9 +1394,9 @@ void PlotWidget::updateAvailableTransformers()
 
 void PlotWidget::on_savePlotToFile()
 {
-  PlotSaveHelper save_plots_helper(default_document_dimentions, this);
-  plotOn(save_plots_helper, { 0, 0, default_document_dimentions.width(),
-                              default_document_dimentions.height() });
+  const auto plot_size = plotSize();
+  PlotSaveHelper save_plots_helper(plot_size, this);
+  plotOn(save_plots_helper, { 0, 0, plot_size.width(), plot_size.height() });
 }
 
 void PlotWidget::plotOn(const PlotSaveHelper& plot_save_helper, QRect paint_at)

--- a/plotjuggler_app/plotwidget.h
+++ b/plotjuggler_app/plotwidget.h
@@ -25,6 +25,7 @@
 #include "qwt_plot_legenditem.h"
 
 #include "PlotJuggler/plotwidget_base.h"
+#include "PlotJuggler/save_plot.h"
 #include "customtracker.h"
 #include "colormap_editor.h"
 
@@ -141,6 +142,8 @@ public slots:
   void onBackgroundColorRequest(QString name);
 
   void onShowDataStatistics();
+
+  void plotOn(const PlotSaveHelper& plot_save_helper, QRect paint_at);
 
 private slots:
 

--- a/plotjuggler_app/preferences_dialog.cpp
+++ b/plotjuggler_app/preferences_dialog.cpp
@@ -9,6 +9,7 @@
 #include <QSettings>
 #include <QDir>
 #include <QFileDialog>
+#include "PlotJuggler/save_plot.h"
 #include "PlotJuggler/svg_util.h"
 
 PreferencesDialog::PreferencesDialog(QWidget* parent)
@@ -61,6 +62,12 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
   bool truncation_check = settings.value("Preferences::truncation_check", true).toBool();
   ui->checkBoxTruncation->setChecked(truncation_check);
 
+  QSize export_plot =
+      settings.value("Preferences::export_plot_size", default_document_dimentions)
+          .toSize();
+  ui->spinBoxExportX->setValue(export_plot.width());
+  ui->spinBoxExportY->setValue(export_plot.height());
+
   //---------------
   auto custom_plugin_folders =
       settings.value("Preferences::plugin_folders", true).toStringList();
@@ -108,6 +115,8 @@ void PreferencesDialog::on_buttonBox_accepted()
   settings.setValue("Preferences::autozoom_filter_applied",
                     ui->checkBoxAutoZoomFilter->isChecked());
   settings.setValue("Preferences::truncation_check", ui->checkBoxTruncation->isChecked());
+  settings.setValue("Preferences::export_plot_size",
+                    QSize{ ui->spinBoxExportX->value(), ui->spinBoxExportY->value() });
 
   QStringList plugin_folders;
   for (int row = 0; row < ui->listWidgetCustom->count(); row++)

--- a/plotjuggler_app/preferences_dialog.ui
+++ b/plotjuggler_app/preferences_dialog.ui
@@ -374,6 +374,49 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="gridGroupBox">
+         <property name="title">
+          <string>Export Plots:</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelExportY">
+            <property name="text">
+             <string>Height</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelExportX">
+            <property name="text">
+             <string>Width</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="spinBoxExportX">
+            <property name="maximum">
+             <number>10000</number>
+            </property>
+            <property name="value">
+             <number>1200</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="spinBoxExportY">
+            <property name="maximum">
+             <number>10000</number>
+            </property>
+            <property name="value">
+             <number>900</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="groupBox_2">
          <property name="title">
           <string>Parsing</string>

--- a/plotjuggler_app/tabbedplotwidget.cpp
+++ b/plotjuggler_app/tabbedplotwidget.cpp
@@ -68,14 +68,19 @@ TabbedPlotWidget::TabbedPlotWidget(QString name, QMainWindow* mainwindow,
 
   tabWidget()->tabBar()->installEventFilter(this);
 
-  // TODO _action_savePlots = new QAction(tr("&Save plots to file"), this);
-  // TODO connect(_action_savePlots, &QAction::triggered, this,
-  // &TabbedPlotWidget::on_savePlotsToFile);
+  _action_savePlots = new QAction(tr("&Save plots to file"), this);
+  connect(_action_savePlots, &QAction::triggered, this,
+          &TabbedPlotWidget::on_savePlotsToFile);
 
-  //  _tab_menu = new QMenu(this);
-  //  _tab_menu->addSeparator();
-  //  //_tab_menu->addAction(_action_savePlots);
-  //  _tab_menu->addSeparator();
+  _tab_menu = new QMenu(this);
+  _tab_menu->addSeparator();
+  _tab_menu->addAction(_action_savePlots);
+  _tab_menu->addSeparator();
+
+  QSettings settings;
+  QString theme = settings.value("StyleSheet::theme", "light").toString();
+
+  _action_savePlots->setIcon(LoadSvg(":/resources/svg/save.svg", theme));
 
   connect(this, &TabbedPlotWidget::destroyed, main_window,
           &MainWindow::on_tabbedAreaDestroyed);
@@ -257,6 +262,11 @@ void TabbedPlotWidget::on_renameCurrentTab()
   }
 }
 
+void TabbedPlotWidget::on_savePlotsToFile()
+{
+  currentTab()->savePlotsToFile();
+}
+
 void TabbedPlotWidget::on_stylesheetChanged(QString theme)
 {
   _buttonAddTab->setIcon(LoadSvg(":/resources/svg/add_tab.svg", theme));
@@ -366,6 +376,8 @@ bool TabbedPlotWidget::eventFilter(QObject* obj, QEvent* event)
 
       if (mouse_event->button() == Qt::RightButton)
       {
+        _tab_menu->exec(mouse_event->globalPos());
+
         // QMenu* submenu = new QMenu("Move tab to...");
         // _tab_menu->addMenu(submenu);
 
@@ -394,15 +406,10 @@ bool TabbedPlotWidget::eventFilter(QObject* obj, QEvent* event)
         //        SLOT(on_requestTabMovement(QString)));
 
         //        //-------------------------------
-        ////        QIcon iconSave;
-        ////        iconSave.addFile(tr(":/%1/save.png").arg(theme), QSize(26, 26));
-        ////        _action_savePlots->setIcon(iconSave);
-
         ////        QIcon iconNewWin;
         ////        iconNewWin.addFile(tr(":/%1/stacks.png").arg(theme), QSize(16, 16));
         ////        action_new_window->setIcon(iconNewWin);
 
-        //        _tab_menu->exec(mouse_event->globalPos());
         //        //-------------------------------
         //        submenu->deleteLater();
       }

--- a/plotjuggler_app/tabbedplotwidget.h
+++ b/plotjuggler_app/tabbedplotwidget.h
@@ -62,7 +62,7 @@ private slots:
 
   void on_renameCurrentTab();
 
-  // void on_savePlotsToFile();
+  void on_savePlotsToFile();
 
   void on_addTabButton_pressed();
 
@@ -87,9 +87,9 @@ private:
   QPushButton* _buttonLegend;
   QPushButton* _buttonAddTab;
 
-  // TODO QAction* _action_savePlots;
+  QAction* _action_savePlots;
 
-  // QMenu* _tab_menu;
+  QMenu* _tab_menu;
 
   const QString _name;
 

--- a/plotjuggler_base/include/PlotJuggler/save_plot.h
+++ b/plotjuggler_base/include/PlotJuggler/save_plot.h
@@ -13,6 +13,7 @@
 #include <QPaintDevice>
 #include <QPainter>
 #include <QRect>
+#include <QSettings>
 #include <QSize>
 #include <QString>
 #include <QWidget>
@@ -22,6 +23,16 @@
 const static QSize default_document_dimentions{ 1200, 900 };
 
 void savePlotToFile(QSize dims, QwtPlot* plot, QWidget* parent);
+
+inline auto plotSize()
+{
+  QSettings settings;
+  QSize result =
+      settings.value("Preferences::export_plot_size", default_document_dimentions)
+          .toSize();
+
+  return result;
+}
 
 class PlotSaveHelper
 {

--- a/plotjuggler_base/include/PlotJuggler/save_plot.h
+++ b/plotjuggler_base/include/PlotJuggler/save_plot.h
@@ -8,12 +8,35 @@
 #define PJ_SAVE_PLOT_H
 
 #include <qwt_plot.h>
+#include <qwt_plot_renderer.h>
 
+#include <QPaintDevice>
+#include <QPainter>
+#include <QRect>
 #include <QSize>
+#include <QString>
 #include <QWidget>
+
+#include <memory>
 
 const static QSize default_document_dimentions{ 1200, 900 };
 
 void savePlotToFile(QSize dims, QwtPlot* plot, QWidget* parent);
+
+class PlotSaveHelper
+{
+public:
+  PlotSaveHelper(QSize dims, QWidget* parent);
+  ~PlotSaveHelper();
+
+  void paint(QwtPlot* plot, QRect paint_at) const;
+  void paintTitle(const QString& title, QRectF paint_at, QWidget* parent) const;
+
+private:
+  std::unique_ptr<QwtPlotRenderer> _renderer;
+  std::unique_ptr<QPaintDevice> _paint_device;
+  std::unique_ptr<QPainter> _painter;
+  QString _save_filename;
+};
 
 #endif  // PJ_SAVE_PLOT_H

--- a/plotjuggler_base/include/PlotJuggler/save_plot.h
+++ b/plotjuggler_base/include/PlotJuggler/save_plot.h
@@ -1,0 +1,19 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef PJ_SAVE_PLOT_H
+#define PJ_SAVE_PLOT_H
+
+#include <qwt_plot.h>
+
+#include <QSize>
+#include <QWidget>
+
+const static QSize default_document_dimentions{ 1200, 900 };
+
+void savePlotToFile(QSize dims, QwtPlot* plot, QWidget* parent);
+
+#endif  // PJ_SAVE_PLOT_H

--- a/plotjuggler_base/src/save_plot.cpp
+++ b/plotjuggler_base/src/save_plot.cpp
@@ -1,0 +1,61 @@
+#include "PlotJuggler/save_plot.h"
+
+#include <qwt_plot.h>
+#include <qwt_plot_renderer.h>
+
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QPainter>
+#include <QRect>
+#include <QSize>
+#include <QString>
+#include <QSvgGenerator>
+
+auto toExtension(const QString& filter)
+{
+  return filter.split(" ").front().prepend('.');
+}
+
+void savePlotToFile(QSize dims, QwtPlot* plot, QWidget* parent)
+{
+  QFileDialog save_dialog(parent);
+  save_dialog.setAcceptMode(QFileDialog::AcceptSave);
+
+  QStringList filters;
+  filters << "png (*.png)"
+          << "jpg (*.jpg *.jpeg)"
+          << "svg (*.svg)";
+
+  QString selected_filter;
+  auto save_filename = save_dialog.getSaveFileName(parent, "Save plot", "",
+                                                   filters.join(";;"), &selected_filter);
+
+  if (save_filename.isEmpty())
+    return;
+
+  if (QFileInfo(save_filename).suffix().isEmpty())
+  {
+    save_filename.append(toExtension(selected_filter));
+  }
+  auto is_svg = save_filename.endsWith(".svg");
+
+  QwtPlotRenderer renderer;
+
+  const auto rect = QRect{0, 0, dims.width(), dims.height()};
+  if (is_svg)
+  {
+    QSvgGenerator generator;
+    generator.setFileName(save_filename);
+    generator.setResolution(80);
+    generator.setViewBox(rect);
+    QPainter painter(&generator);
+    renderer.render(plot, &painter, rect);
+  }
+  else
+  {
+    QPixmap pixmap(dims.width(), dims.height());
+    QPainter painter(&pixmap);
+    renderer.render(plot, &painter, rect);
+    pixmap.save(save_filename);
+  }
+}

--- a/plotjuggler_base/src/save_plot.cpp
+++ b/plotjuggler_base/src/save_plot.cpp
@@ -1,22 +1,29 @@
 #include "PlotJuggler/save_plot.h"
 
+#include <qwt_painter.h>
 #include <qwt_plot.h>
 #include <qwt_plot_renderer.h>
 
 #include <QFileDialog>
 #include <QFileInfo>
+#include <QFont>
+#include <QPaintDevice>
 #include <QPainter>
 #include <QRect>
 #include <QSize>
 #include <QString>
 #include <QSvgGenerator>
+#include <QTextOption>
+
+#include <memory>
 
 auto toExtension(const QString& filter)
 {
   return filter.split(" ").front().prepend('.');
 }
 
-void savePlotToFile(QSize dims, QwtPlot* plot, QWidget* parent)
+PlotSaveHelper::PlotSaveHelper(QSize dims, QWidget* parent)
+  : _renderer{ std::make_unique<QwtPlotRenderer>(parent) }
 {
   QFileDialog save_dialog(parent);
   save_dialog.setAcceptMode(QFileDialog::AcceptSave);
@@ -27,35 +34,74 @@ void savePlotToFile(QSize dims, QwtPlot* plot, QWidget* parent)
           << "svg (*.svg)";
 
   QString selected_filter;
-  auto save_filename = save_dialog.getSaveFileName(parent, "Save plot", "",
-                                                   filters.join(";;"), &selected_filter);
-
-  if (save_filename.isEmpty())
+  _save_filename = save_dialog.getSaveFileName(parent, "Save plot", "",
+                                               filters.join(";;"), &selected_filter);
+  if (_save_filename.isEmpty())
     return;
 
-  if (QFileInfo(save_filename).suffix().isEmpty())
+  if (QFileInfo(_save_filename).suffix().isEmpty())
   {
-    save_filename.append(toExtension(selected_filter));
+    _save_filename.append(toExtension(selected_filter));
   }
-  auto is_svg = save_filename.endsWith(".svg");
+  auto is_svg = _save_filename.endsWith(".svg");
 
-  QwtPlotRenderer renderer;
-
-  const auto rect = QRect{0, 0, dims.width(), dims.height()};
+  const auto rect = QRect(0, 0, dims.width(), dims.height());
   if (is_svg)
   {
-    QSvgGenerator generator;
-    generator.setFileName(save_filename);
-    generator.setResolution(80);
-    generator.setViewBox(rect);
-    QPainter painter(&generator);
-    renderer.render(plot, &painter, rect);
+    auto* generator = new QSvgGenerator();
+    generator->setFileName(_save_filename);
+    generator->setResolution(80);
+    generator->setViewBox(rect);
+
+    _paint_device = std::unique_ptr<QPaintDevice>(generator);
   }
   else
   {
-    QPixmap pixmap(dims.width(), dims.height());
-    QPainter painter(&pixmap);
-    renderer.render(plot, &painter, rect);
-    pixmap.save(save_filename);
+    auto* pixmap = new QPixmap(dims.width(), dims.height());
+    _paint_device = std::unique_ptr<QPaintDevice>(pixmap);
   }
+  _painter = std::make_unique<QPainter>(_paint_device.get());
+
+  _painter->fillRect(rect, parent->palette().window());
+}
+
+PlotSaveHelper::~PlotSaveHelper()
+{
+  if (const auto* pixmap = dynamic_cast<QPixmap*>(_paint_device.get()); pixmap)
+  {
+    pixmap->save(_save_filename);
+  }
+}
+
+void PlotSaveHelper::paint(QwtPlot* plot, QRect paint_at) const
+{
+  static const auto margin = 5;
+  if (_save_filename.isEmpty())
+    return;
+
+  paint_at.adjust(margin, margin, -margin, -margin);
+  _renderer->render(plot, _painter.get(), paint_at);
+}
+
+void PlotSaveHelper::paintTitle(const QString& title, QRectF paint_at,
+                                QWidget* parent) const
+{
+  if (_save_filename.isEmpty())
+    return;
+
+  QFont font;
+  _painter->setFont(parent->font());
+  _painter->setPen(parent->palette().windowText().color());
+
+  QTextOption text_options;
+  text_options.setAlignment(Qt::AlignCenter);
+
+  _painter->drawText(paint_at, title, text_options);
+}
+
+void savePlotToFile(QSize dims, QwtPlot* plot, QWidget* parent)
+{
+  PlotSaveHelper save_plots_helper(dims, parent);
+  const auto rect = QRect(0, 0, dims.width(), dims.height());
+  save_plots_helper.paint(plot, rect);
 }


### PR DESCRIPTION
Hi, here is an MR to allow exporting multiple plots at once.

This resolves https://github.com/facontidavide/PlotJuggler/issues/362

- Add back an action to export a whole tab to a file
- Add a parameter to set the exported plot size (in px)

Example: 

| plotj | export |
| ------ | ---------- |
| <img width="1540" height="889" alt="2025-07-11T00:56:16,812870897+02:00" src="https://github.com/user-attachments/assets/463107d4-0a7d-446b-9f81-3cfb0a69b962" /> | <img width="1200" height="900" alt="exported" src="https://github.com/user-attachments/assets/f0232854-dfa5-4940-8142-ec91b35d8a70" /> |
