### PR TITLE
Fix Issues on MacOS Compilation

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -103,7 +103,7 @@ Add CMake into your env-vars to be detected by cmake
 echo  'QT_HOME=$(brew --prefix qt@5) \
 export CPPFLAGS="-I $QT_HOME/include" \
 export PKG_CONFIG_PATH="$QT_HOME/lib/pkgconfig" \
-export LDFLAGS="$QT_HOME/lib"' >> $HOME/.zshrc
+export LDFLAGS="-L$QT_HOME/lib"' >> $HOME/.zshrc
 ```
 
 If you don't want to permanently add them into your main file, you can try by just exporting locally in the current terminal with:
@@ -112,7 +112,7 @@ If you don't want to permanently add them into your main file, you can try by ju
 QT_HOME=$(brew --prefix qt@5)
 export CPPFLAGS="-I $QT_HOME/include"
 export PKG_CONFIG_PATH="$QT_HOME/lib/pkgconfig"
-export LDFLAGS="$QT_HOME/lib"
+export LDFLAGS="-L$QT_HOME/lib"
 ```
 
 Clone the repository into **~/plotjuggler_ws**:


### PR DESCRIPTION
I followed COMPILE.md instructions when compiling on an M4 macbook pro and found that it didn't work out of the box without these change to the `LDFLAGS` option. Based on my understanding of these options, it's not clear to me how this would work without the -L?