### PR TITLE
Bugfix/mnaveau/pal statistics several topics

### DIFF
--- a/plotjuggler_plugins/ParserROS/ros_parser.cpp
+++ b/plotjuggler_plugins/ParserROS/ros_parser.cpp
@@ -552,7 +552,8 @@ void ParserROS::parseDataTamerSnapshot(const std::string& prefix, double& timest
   DataTamerParser::ParseSnapshot(dt_schema, snapshot, callback);
 }
 
-static std::unordered_map<std::string, std::unordered_map<uint32_t, std::vector<std::string>>>
+static std::unordered_map<std::string,
+                          std::unordered_map<uint32_t, std::vector<std::string>>>
     _pal_statistics_names_per_topic;
 
 void ParserROS::parsePalStatisticsNames(const std::string& prefix, double& timestamp)
@@ -600,12 +601,14 @@ void ParserROS::parsePalStatisticsValues(const std::string& prefix, double& time
 std::string ParserROS::parsePalStatisticsPrefix(const std::string& in_prefix)
 {
   std::string prefix = in_prefix;
-  const std::vector<std::string> suffixes = {"/values", "/names"};
-  for (const auto& suffix : suffixes) {
-      if (prefix.size() >= suffix.size() &&
-          prefix.compare(prefix.size() - suffix.size(), suffix.size(), suffix) == 0) {
-          return prefix.substr(0, prefix.size() - suffix.size());
-      }
+  const std::vector<std::string> suffixes = { "/values", "/names" };
+  for (const auto& suffix : suffixes)
+  {
+    if (prefix.size() >= suffix.size() &&
+        prefix.compare(prefix.size() - suffix.size(), suffix.size(), suffix) == 0)
+    {
+      return prefix.substr(0, prefix.size() - suffix.size());
+    }
   }
   return prefix;
 }

--- a/plotjuggler_plugins/ParserROS/ros_parser.cpp
+++ b/plotjuggler_plugins/ParserROS/ros_parser.cpp
@@ -552,10 +552,12 @@ void ParserROS::parseDataTamerSnapshot(const std::string& prefix, double& timest
   DataTamerParser::ParseSnapshot(dt_schema, snapshot, callback);
 }
 
-static std::unordered_map<uint32_t, std::vector<std::string>> _pal_statistics_names;
+static std::unordered_map<std::string, std::unordered_map<uint32_t, std::vector<std::string>>>
+    _pal_statistics_names_per_topic;
 
 void ParserROS::parsePalStatisticsNames(const std::string& prefix, double& timestamp)
 {
+  auto parsed_prefix = parsePalStatisticsPrefix(prefix);
   const auto header = readHeader(timestamp);
   std::vector<std::string> names;
   const size_t vector_size = _deserializer->deserializeUInt32();
@@ -565,11 +567,12 @@ void ParserROS::parsePalStatisticsNames(const std::string& prefix, double& times
     _deserializer->deserializeString(name);
   }
   uint32_t names_version = _deserializer->deserializeUInt32();
-  _pal_statistics_names[names_version] = std::move(names);
+  _pal_statistics_names_per_topic[parsed_prefix][names_version] = std::move(names);
 }
 
 void ParserROS::parsePalStatisticsValues(const std::string& prefix, double& timestamp)
 {
+  auto parsed_prefix = parsePalStatisticsPrefix(prefix);
   const auto header = readHeader(timestamp);
   std::vector<double> values;
   const size_t vector_size = _deserializer->deserializeUInt32();
@@ -580,8 +583,9 @@ void ParserROS::parsePalStatisticsValues(const std::string& prefix, double& time
     value = _deserializer->deserialize(BuiltinType::FLOAT64).convert<double>();
   }
   uint32_t names_version = _deserializer->deserializeUInt32();
-  auto it = _pal_statistics_names.find(names_version);
-  if (it != _pal_statistics_names.end())
+  auto it = _pal_statistics_names_per_topic[parsed_prefix].find(names_version);
+  auto end_it = _pal_statistics_names_per_topic[parsed_prefix].end();
+  if (it != end_it)
   {
     const auto& names = it->second;
     const size_t N = std::min(names.size(), values.size());
@@ -591,6 +595,19 @@ void ParserROS::parsePalStatisticsValues(const std::string& prefix, double& time
       series.pushBack({ timestamp, values[i] });
     }
   }
+}
+
+std::string ParserROS::parsePalStatisticsPrefix(const std::string& in_prefix)
+{
+  std::string prefix = in_prefix;
+  const std::vector<std::string> suffixes = {"/values", "/names"};
+  for (const auto& suffix : suffixes) {
+      if (prefix.size() >= suffix.size() &&
+          prefix.compare(prefix.size() - suffix.size(), suffix.size(), suffix) == 0) {
+          return prefix.substr(0, prefix.size() - suffix.size());
+      }
+  }
+  return prefix;
 }
 
 constexpr static std::array<BuiltinType, 11> _tsl_type_order = {

--- a/plotjuggler_plugins/ParserROS/ros_parser.h
+++ b/plotjuggler_plugins/ParserROS/ros_parser.h
@@ -68,6 +68,9 @@ protected:
                           const std::vector<std::string>& definition,
                           const std::vector<double>& values);
 
+  /// @brief Remove "/values" or "/names" suffix from a topic string
+  std::string parsePalStatisticsPrefix(const std::string& in_prefix);
+
   std::function<void(const std::string& prefix, double&)> _customized_parser;
 
   bool _has_header = false;


### PR DESCRIPTION
## Introduction

This PR introduce a bugfix in the parsing of the PAL-Statistics topics.
It's the same PR as this closed one: https://github.com/facontidavide/PlotJuggler/pull/1129
@facontidavide I recreate it here as I cannot reopen the other one.
Hope it's not too much of a trouble.

## Description

In case several topic are published like for example:
- `/estimator/introspection_data/full`
- `/estimator/introspection_data/names`
- `/estimator/introspection_data/values`
- `/controller/introspection_data/full`
- `/controller/introspection_data/names`
- `/controller/introspection_data/values`
Then the behavior of the ROS parser is wrong as the static variable does not distinguish the different topics individually leading to a wrong parsing of the names versus data.

Therefore I created a map containing the prefix: `/controller/introspection_data` or `/estimator/introspection_data` where I store the topic names and versions.
Hence this map is filled up in the `parsePalStatisticsNames` and reused later depending on which topic the current message is read from.
Tried on Ubuntu22.04 humble.