### PR TITLE
Add GitHub actions to the dependabot configuration.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "🛠️"


### PR DESCRIPTION
## Description

* Added Dependabot configuration to monitor release versions of GitHub Actions.
