### PR TITLE
Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1753694789,
+        "narHash": "sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "dc9637876d0dcc8c9e5e22986b857632effeb727",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753694789,
-        "narHash": "sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM=",
+        "lastModified": 1753939845,
+        "narHash": "sha256-K2ViRJfdVGE8tpJejs8Qpvvejks1+A4GQej/lBk5y7I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dc9637876d0dcc8c9e5e22986b857632effeb727",
+        "rev": "94def634a20494ee057c76998843c015909d6311",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,155 @@
+{
+  description = "A flake for building and running PlotJuggler";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+          config.qt5.enable = true;
+        };
+
+        data-tamer-src = pkgs.fetchzip {
+          url = "https://github.com/PickNikRobotics/data_tamer/archive/refs/tags/1.0.3.zip";
+          sha256 = "sha256-hGfoU6oK7vh39TRCBTYnlqEsvGLWCsLVRBXh3RDrmnY=";
+        };
+
+        libmcap-pkg = pkgs.stdenv.mkDerivation rec {
+          pname = "libmcap";
+          version = "1.3.0";
+
+          src = pkgs.fetchgit {
+            url = "https://github.com/foxglove/mcap.git";
+            rev = "releases/cpp/v${version}";
+            sha256 = "sha256-vGMdVNa0wsX9OD0W29Ndk2YmwFphmxPbiovCXtHxF4E=";
+          };
+
+          installPhase = ''
+            mkdir -p $out/include
+            cp -r cpp/mcap/include/mcap $out/include/
+          '';
+        };
+
+        plotjuggler-pkg = pkgs.qt5.mkDerivation {
+          pname = "plotjuggler";
+          version = "3.10.11";
+
+          src = pkgs.fetchFromGitHub {
+            owner = "facontidavide";
+            repo = "PlotJuggler";
+            rev = "3.10.11";
+            fetchSubmodules = true;
+            sha256 = "sha256-BFY4MpJHsGi3IjK9hX23YD45GxTJWcSHm/qXeQBy9u8=";
+          };
+
+          postPatch = ''
+            substituteInPlace cmake/find_or_download_data_tamer.cmake \
+              --replace "URL" "SOURCE_DIR" \
+              --replace "https://github.com/PickNikRobotics/data_tamer/archive/refs/tags/1.0.3.zip" "${data-tamer-src}"
+
+            rm cmake/find_or_download_fmt.cmake
+            rm cmake/find_or_download_fastcdr.cmake
+            rm cmake/find_or_download_zstd.cmake
+
+            substituteInPlace CMakeLists.txt \
+              --replace "include(cmake/find_or_download_fmt.cmake)" "find_package(fmt REQUIRED)" \
+              --replace "find_or_download_fmt()" ""
+
+            substituteInPlace CMakeLists.txt \
+              --replace "include(cmake/find_or_download_fastcdr.cmake)" "find_package(fastcdr REQUIRED)" \
+              --replace "find_or_download_fastcdr()" ""
+            find . -name "CMakeLists.txt" -exec sed -i 's/fastcdr::fastcdr/fastcdr/g' {} +
+
+            cat > plotjuggler_plugins/DataLoadMCAP/CMakeLists.txt << 'EOF'
+            cmake_minimum_required(VERSION 3.5)
+
+            set(CMAKE_AUTOUIC ON)
+            set(CMAKE_AUTORCC ON)
+            set(CMAKE_AUTOMOC ON)
+
+            project(DataLoadMCAP)
+
+            add_library(mcap INTERFACE)
+            find_package(zstd REQUIRED)
+            find_package(lz4 REQUIRED)
+
+            add_library(dataload_mcap MODULE dataload_mcap.cpp)
+
+            target_link_libraries(
+              dataload_mcap PUBLIC Qt5::Widgets Qt5::Xml Qt5::Concurrent plotjuggler_base mcap
+                                  zstd lz4)
+
+            if(WIN32 AND MSVC)
+              target_link_options(dataload_mcap PRIVATE /ignore:4217)
+            endif()
+
+            install(TARGETS dataload_mcap DESTINATION ''${PJ_PLUGIN_INSTALL_DIRECTORY})
+            EOF
+          '';
+
+          cmakeFlags = [
+            "-DPLJ_USE_SYSTEM_LUA=ON"
+            "-DPLJ_USE_SYSTEM_NLOHMANN_JSON=ON"
+          ];
+
+
+          nativeBuildInputs = [ pkgs.cmake pkgs.qt5.wrapQtAppsHook ];
+
+          buildInputs = [
+            pkgs.qt5.full
+            pkgs.zeromq
+            pkgs.sqlite
+            pkgs.lua
+            pkgs.nlohmann_json
+            pkgs.fmt
+            pkgs.fastcdr
+            pkgs.lz4
+            pkgs.zstd
+            libmcap-pkg
+          ];
+
+          meta = with pkgs.lib; {
+            description = "A tool to plot streaming data, fast and easy";
+            homepage = "https://github.com/facontidavide/PlotJuggler";
+            license = licenses.mpl20;
+            platforms = platforms.linux ++ platforms.darwin;
+          };
+        };
+
+      in
+      {
+        packages.default = plotjuggler-pkg;
+        packages.plotjuggler = plotjuggler-pkg;
+
+        apps.default = {
+          type = "app";
+          program = "${plotjuggler-pkg}/bin/plotjuggler";
+        };
+        apps.plotjuggler = self.apps.${system}.default;
+
+        devShells.default = pkgs.mkShell {
+          packages = [
+            plotjuggler-pkg
+            pkgs.cmake
+            pkgs.qt5.full
+            pkgs.zeromq
+            pkgs.sqlite
+            pkgs.lua
+            pkgs.nlohmann_json
+            pkgs.fmt
+            pkgs.fastcdr
+            pkgs.lz4
+            pkgs.zstd
+            libmcap-pkg
+            pkgs.codespell
+          ];
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -40,13 +40,7 @@
           pname = "plotjuggler";
           version = "3.10.11";
 
-          src = pkgs.fetchFromGitHub {
-            owner = "facontidavide";
-            repo = "PlotJuggler";
-            rev = "3.10.11";
-            fetchSubmodules = true;
-            sha256 = "sha256-BFY4MpJHsGi3IjK9hX23YD45GxTJWcSHm/qXeQBy9u8=";
-          };
+          src = ./.;
 
           postPatch = ''
             substituteInPlace cmake/find_or_download_data_tamer.cmake \
@@ -103,6 +97,9 @@
 
           buildInputs = [
             pkgs.qt5.full
+            pkgs.qt5.qtsvg
+            pkgs.qt5.qtimageformats
+            pkgs.qt5.qtdeclarative
             pkgs.zeromq
             pkgs.sqlite
             pkgs.lua
@@ -112,6 +109,12 @@
             pkgs.lz4
             pkgs.zstd
             libmcap-pkg
+            pkgs.mosquitto
+            pkgs.protobuf
+            pkgs.xorg.libX11
+            pkgs.xorg.libxcb
+            pkgs.xorg.xcbutil
+            pkgs.xorg.xcbutilkeysyms
           ];
 
           meta = with pkgs.lib; {
@@ -135,9 +138,11 @@
 
         devShells.default = pkgs.mkShell {
           packages = [
-            plotjuggler-pkg
             pkgs.cmake
             pkgs.qt5.full
+            pkgs.qt5.qtsvg
+            pkgs.qt5.qtimageformats
+            pkgs.qt5.qtdeclarative
             pkgs.zeromq
             pkgs.sqlite
             pkgs.lua
@@ -147,7 +152,13 @@
             pkgs.lz4
             pkgs.zstd
             libmcap-pkg
+            pkgs.mosquitto
+            pkgs.protobuf
             pkgs.codespell
+            pkgs.xorg.libX11
+            pkgs.xorg.libxcb
+            pkgs.xorg.xcbutil
+            pkgs.xorg.xcbutilkeysyms
           ];
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,7 @@
             pkgs.xorg.xcbutil
             pkgs.xorg.xcbutilkeysyms
           ];
+          dontWrapQtApps = true;
 
           meta = with pkgs.lib; {
             description = "A tool to plot streaming data, fast and easy";

--- a/flake.nix
+++ b/flake.nix
@@ -20,22 +20,6 @@
           sha256 = "sha256-hGfoU6oK7vh39TRCBTYnlqEsvGLWCsLVRBXh3RDrmnY=";
         };
 
-        libmcap-pkg = pkgs.stdenv.mkDerivation rec {
-          pname = "libmcap";
-          version = "1.3.0";
-
-          src = pkgs.fetchgit {
-            url = "https://github.com/foxglove/mcap.git";
-            rev = "releases/cpp/v${version}";
-            sha256 = "sha256-vGMdVNa0wsX9OD0W29Ndk2YmwFphmxPbiovCXtHxF4E=";
-          };
-
-          installPhase = ''
-            mkdir -p $out/include
-            cp -r cpp/mcap/include/mcap $out/include/
-          '';
-        };
-
         plotjuggler-pkg = pkgs.qt5.mkDerivation {
           pname = "plotjuggler";
           version = "3.10.11";
@@ -63,17 +47,18 @@
             cat > plotjuggler_plugins/DataLoadMCAP/CMakeLists.txt << 'EOF'
             cmake_minimum_required(VERSION 3.5)
 
-            set(CMAKE_AUTOUIC ON)
-            set(CMAKE_AUTORCC ON)
-            set(CMAKE_AUTOMOC ON)
+            if(mcap_vendor_FOUND)
+              set(CMAKE_AUTOUIC ON)
+              set(CMAKE_AUTORCC ON)
+              set(CMAKE_AUTOMOC ON)
 
-            project(DataLoadMCAP)
+              project(DataLoadMCAP)
 
-            add_library(mcap INTERFACE)
-            find_package(zstd REQUIRED)
-            find_package(lz4 REQUIRED)
+              add_library(mcap INTERFACE)
+              find_package(zstd REQUIRED)
+              find_package(lz4 REQUIRED)
 
-            add_library(dataload_mcap MODULE dataload_mcap.cpp)
+              add_library(dataload_mcap MODULE dataload_mcap.cpp)
 
             target_link_libraries(
               dataload_mcap PUBLIC Qt5::Widgets Qt5::Xml Qt5::Concurrent plotjuggler_base mcap
@@ -84,6 +69,7 @@
             endif()
 
             install(TARGETS dataload_mcap DESTINATION ''${PJ_PLUGIN_INSTALL_DIRECTORY})
+            endif()
             EOF
           '';
 
@@ -108,7 +94,6 @@
             pkgs.fastcdr
             pkgs.lz4
             pkgs.zstd
-            libmcap-pkg
             pkgs.mosquitto
             pkgs.protobuf
             pkgs.xorg.libX11
@@ -151,7 +136,6 @@
             pkgs.fastcdr
             pkgs.lz4
             pkgs.zstd
-            libmcap-pkg
             pkgs.mosquitto
             pkgs.protobuf
             pkgs.codespell

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
           version = "3.10.11";
 
           src = ./.;
+          patches = [ ./nix/arrow.patch ];
 
           postPatch = ''
             substituteInPlace cmake/find_or_download_data_tamer.cmake \
@@ -100,6 +101,7 @@
             pkgs.xorg.libxcb
             pkgs.xorg.xcbutil
             pkgs.xorg.xcbutilkeysyms
+            pkgs.arrow-cpp
           ];
           dontWrapQtApps = true;
 
@@ -129,6 +131,7 @@
             pkgs.qt5.qtsvg
             pkgs.qt5.qtimageformats
             pkgs.qt5.qtdeclarative
+            pkgs.arrow-cpp
             pkgs.zeromq
             pkgs.sqlite
             pkgs.lua

--- a/nix/arrow.patch
+++ b/nix/arrow.patch
@@ -1,0 +1,14 @@
+diff --git a/plotjuggler_plugins/DataLoadParquet/CMakeLists.txt b/plotjuggler_plugins/DataLoadParquet/CMakeLists.txt
+index cf101343..3368e555 100644
+--- a/plotjuggler_plugins/DataLoadParquet/CMakeLists.txt
++++ b/plotjuggler_plugins/DataLoadParquet/CMakeLists.txt
+@@ -11,8 +11,8 @@ if(Arrow_FOUND)
+   add_library(DataLoadParquet SHARED ${SRC} ${UI_SRC})
+
+   target_link_libraries(
+-    DataLoadParquet PRIVATE Qt5::Widgets Qt5::Xml Arrow::arrow_static
+-                            Parquet::parquet_static plotjuggler_base)
++    DataLoadParquet PRIVATE Qt5::Widgets Qt5::Xml Arrow::arrow_shared
++                            Parquet::parquet_shared plotjuggler_base)
+
+   target_compile_definitions(DataLoadParquet PRIVATE QT_PLUGIN)


### PR DESCRIPTION
uses  #1134 but fixes the plugin loading, adds more dependencies to enable more plugins.
libmcap is removed as the nix package did not work