### PR TITLE
Fix error 127 from linuxdeploy in Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as builder
+FROM ubuntu:22.04 AS builder
 
 RUN apt-get update && \
     apt-get -y install git cmake build-essential wget file qtbase5-dev libqt5svg5-dev \


### PR DESCRIPTION
Docker builds of the AppImage failed with exit code 127 when linuxdeploy tried to query the Qt plugin. Setting `APPIMAGE_EXTRACT_AND_RUN=1` fixes this by forcing both linuxdeploy and its Qt plugin (also an AppImage) to run in extract-and-run mode, avoiding FUSE issues inside Docker.

I also fixed the warning about casing.

To reproduce:
Build with docker ` docker buildx build -o . .`
```
...
2.439 linuxdeploy version 1-alpha (git commit ID 160c700), GitHub actions build 324 built on 2025-08-12 20:25:18 UTC
2.442 terminate called after throwing an instance of 'std::logic_error'
2.442   what():  subprocess /opt/plotjuggler/build/linuxdeploy-plugin-qt-x86_64.AppImage --plugin-api-version failed with exit code 127
------

 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
Dockerfile:15
--------------------
  13 |     RUN make -j `nproc`
  14 |     RUN make install DESTDIR=AppDir
  15 | >>> RUN /opt/plotjuggler/appimage/AppImage.sh
  16 |     
  17 |     FROM scratch AS exporter
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c /opt/plotjuggler/appimage/AppImage.sh" did not complete successfully: exit code: 127
```