### PR TITLE
fix(ulog_parser): allow messages without timestamp field

### DIFF
--- a/plotjuggler_plugins/DataLoadULog/dataload_ulog.cpp
+++ b/plotjuggler_plugins/DataLoadULog/dataload_ulog.cpp
@@ -58,7 +58,8 @@ bool DataLoadULog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
 
       for (size_t i = 0; i < data.second.size(); i++)
       {
-        double msg_time = static_cast<double>(timeseries.timestamps[i]) * 0.000001;
+        const uint64_t timestamp = timeseries.timestamps[i].value_or(static_cast<uint64_t>(i));
+        double msg_time = static_cast<double>(timestamp) * 0.000001;
         min_msg_time = std::min(min_msg_time, msg_time);
         PlotData::Point point(msg_time, data.second[i]);
         series->second.pushBack(point);

--- a/plotjuggler_plugins/DataLoadULog/ulog_parser.cpp
+++ b/plotjuggler_plugins/DataLoadULog/ulog_parser.cpp
@@ -172,7 +172,12 @@ char* ULogParser::parseSimpleDataMessage(Timeseries& timeseries, const Format* f
     bool timestamp_done = false;
     for (int array_pos = 0; array_pos < field.array_size; array_pos++)
     {
-      if (*index == format->timestamp_idx && !timestamp_done)
+      if (format->timestamp_idx < 0)
+      {
+        // No timestamps defined in this message
+        timeseries.timestamps.push_back(std::nullopt);
+      }
+      else if (*index == format->timestamp_idx && !timestamp_done)
       {
         timestamp_done = true;
         uint64_t time_val = *reinterpret_cast<uint64_t*>(message);
@@ -627,12 +632,6 @@ bool ULogParser::readFormat(DataStream& datastream, uint16_t msg_size)
       field.field_name = field_name.to_string();
       format.fields.push_back(field);
     }
-  }
-
-  if (format.timestamp_idx < 0)
-  {
-    // Required timestamp is not found in definition
-    return false;
   }
 
   format.name = name;

--- a/plotjuggler_plugins/DataLoadULog/ulog_parser.h
+++ b/plotjuggler_plugins/DataLoadULog/ulog_parser.h
@@ -6,6 +6,7 @@
 #include <set>
 #include <string.h>
 #include <cstdint>
+#include <optional>
 
 #include "string_view.hpp"
 
@@ -109,7 +110,7 @@ public:
 
   struct Timeseries
   {
-    std::vector<uint64_t> timestamps;
+    std::vector<std::optional<uint64_t>> timestamps;
     std::vector<std::pair<std::string, std::vector<double>>> data;
   };
 


### PR DESCRIPTION
fixes: https://github.com/facontidavide/PlotJuggler/issues/1136

The timestamp field is [optional](https://github.com/facontidavide/PlotJuggler/issues/1136#issuecomment-3191710284), so in case there is no timestamp, just a fixed increment.