### PR TITLE
CI: rename .deb file before uploading

### DIFF
--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -116,11 +116,14 @@ jobs:
           cp plotjuggler.svg plotjuggler_'${{ steps.define_version.outputs.version }}'_amd64/usr/share/icons/hicolor/scalable/apps/
           dpkg-deb --build ./plotjuggler_'${{ steps.define_version.outputs.version }}'_amd64
 
+      - name: Rename deb with distro suffix
+        run: mv plotjuggler_${{ steps.define_version.outputs.version }}_amd64.deb plotjuggler_${{ steps.define_version.outputs.version }}_amd64_${{ steps.dist_short.outputs.short_name }}.deb
+
       - name: Upload deb
         uses: actions/upload-artifact@v4
         with:
           name: plotjuggler_${{ steps.define_version.outputs.version }}_amd64_${{ steps.dist_short.outputs.short_name }}.deb
-          path: plotjuggler_${{ steps.define_version.outputs.version }}_amd64.deb
+          path: plotjuggler_${{ steps.define_version.outputs.version }}_amd64_${{ steps.dist_short.outputs.short_name }}.deb
 
       - name: Upload to Release
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
fixes the uploading of the artifacts, without this the file can not be found in the release upload

