### PR TITLE
Fix atan bug in lua `quat_to_yaw` and `quat_to_roll` conversions for lua versions <5.3

### DIFF
--- a/plotjuggler_app/resources/default.snippets.xml
+++ b/plotjuggler_app/resources/default.snippets.xml
@@ -101,7 +101,7 @@ z = v3
 dcm21 = 2 * (w * x + y * z)
 dcm22 = w*w - x*x - y*y + z*z
 
-roll = math.atan(dcm21, dcm22)
+roll = math.atan2(dcm21, dcm22)
 
 return roll</function>
     <linkedSource></linkedSource>
@@ -132,7 +132,7 @@ z = v3
 dcm10 = 2 * (x * y + w * z)
 dcm00 = w*w + x*x - y*y - z*z
 
-yaw = math.atan(dcm10, dcm00)
+yaw = math.atan2(dcm10, dcm00)
 
 return yaw</function>
     <linkedSource></linkedSource>


### PR DESCRIPTION
The default `quat_to_yaw` and `quat_to_roll` custom series are using a two argument atan method, but this was only added in lua 5.3. If two arguments are provided in older versions the second argument is ignored and the regular `atan(x)` method is called, which computes the wrong value. As far as I can tell plotjuggler just uses whatever version of lua is available in the system, and so doesn't guarantee it's >=5.3 https://github.com/facontidavide/PlotJuggler/blob/e9e2e624d67cc157143f42342d916c0abe38a487/cmake/find_or_download_lua.cmake#L5

but at least the ROS humble release of this is depending on liblua5.1.0
```
matt@matt-thinkpad:~$ apt show ros-humble-plotjuggler
Package: ros-humble-plotjuggler
Version: 3.10.11-1jammy.20250727.225740
Priority: optional
Section: misc
Maintainer: Davide Faconti <davide.faconti@gmail.com>
Installed-Size: 15.9 MB
Depends: libbinutils (>= 2.38), libbinutils (<< 2.38.1), libc6 (>= 2.35), libgcc-s1 (>= 4.2), liblua5.1-0, libprotobuf23 (>= 3.12.4), libqt5core5a (>= 5.15.1), libqt5gui5 (>= 5.14.1) | libqt5gui5-gles (>= 5.14.1), libqt5network5 (>= 5.14.1), libqt5svg5 (>= 5.6.0~beta), libqt5websockets5 (>= 5.6.0), libqt5widgets5 (>= 5.14.1), libqt5x11extras5 (>= 5.6.0), libqt5xml5 (>= 5.0.2), libstdc++6 (>= 11), libxcb1, libzmq5 (>= 3.2.3+dfsg), ros-humble-fastcdr, binutils-dev, libboost-all-dev, libfmt-dev, **liblua5.1-0-dev**, liblz4-dev, libprotobuf-dev, libprotoc-dev, libqt5opengl5-dev, libqt5svg5-dev, libqt5websockets5-dev, libqt5x11extras5-dev, libzmq3-dev, libzstd-dev, nlohmann-json3-dev, protobuf-compiler, qtbase5-dev, ros-humble-ament-index-cpp, ros-humble-data-tamer-cpp, ros-humble-mcap-vendor, ros-humble-rclcpp, ros-humble-ros-workspace
Homepage: https://github.com/facontidavide/PlotJuggler
Download-Size: 8,186 kB
APT-Manual-Installed: no
APT-Sources: http://packages.ros.org/ros2/ubuntu jammy/main amd64 Packages
Description: PlotJuggler: juggle with data

```

Changing these scripts to explicitly call the two-argument atan2 method avoids this incompatibility.

A quick example:

I'm running `ros2 run tf2_ros static_transform_publisher --frame-id base_link --child-frame-id sensor --yaw 0.1 --pitch 0.2 --roll 0.3` to create a static tf, and am subscribing to this in plotjuggler.

Here is the yaw computed on main (see bottom left)
<img width="1586" height="1274" alt="image" src="https://github.com/user-attachments/assets/fa23263c-6baf-432c-92fc-7ddb63a01e26" />

and on this PR
<img width="1586" height="1274" alt="image" src="https://github.com/user-attachments/assets/4c07b394-4712-451b-91c3-7befc6c21877" />


