### PR TITLE
Fix copilot breakage

### DIFF
--- a/plotjuggler_plugins/ParserROS/rosx_introspection/include/rosx_introspection/contrib/nanocdr.hpp
+++ b/plotjuggler_plugins/ParserROS/rosx_introspection/include/rosx_introspection/contrib/nanocdr.hpp
@@ -323,7 +323,7 @@ constexpr bool is_type_defined_v()
   return is_type_defined<T>::value;
 }
 
-Endianness getCurrentEndianness()
+inline Endianness getCurrentEndianness()
 {
   union
   {


### PR DESCRIPTION
Yes, this function must not be constexpr, but it's also defined in a header included in multiple translation units, so it must be `inline` to avoid multiple implementations for the function:

> /usr/bin/ld: CMakeFiles/rosx_introspection.dir/src/serializer.cpp.o: in function `nanocdr::getCurrentEndianness()':
./.obj-x86_64-linux-gnu/plotjuggler_plugins/ParserROS/rosx_introspection/./plotjuggler_plugins/ParserROS/rosx_introspection/include/rosx_introspection/contrib/nanocdr.hpp:336: multiple definition of `nanocdr::getCurrentEndianness()'; CMakeFiles/rosx_introspection.dir/src/deserializer.cpp.o:./.obj-x86_64-linux-gnu/plotjuggler_plugins/ParserROS/rosx_introspection/./plotjuggler_plugins/ParserROS/rosx_introspection/include/rosx_introspection/contrib/nanocdr.hpp:336: first defined here
collect2: error: ld returned 1 exit status

[Seen building for [ROS-O] on bookworm.](https://raw.githubusercontent.com/v4hn/ros-o-builder/bookworm-one-unstable/repository/ros-one-plotjuggler_3.12.0-3-g7387d8d7-2025.09.18.15.23_amd64-2025-09-18T15:23:07Z.build)