### PR TITLE
Adjust color of cursor text to adhere to current theme

### DIFF
--- a/plotjuggler_app/customtracker.cpp
+++ b/plotjuggler_app/customtracker.cpp
@@ -193,15 +193,16 @@ void CurveTracker::setPosition(const QPointF& tracker_position)
   QString text_marker_info;
 
   const QString time_str = QString::number(tracker_position.x(), 'f', prec);
+  QColor text_color = _plot->palette().color(QPalette::WindowText);
   if (_reference_pos)
   {
     auto delta_time = tracker_position.x() - _reference_pos->x();
     auto delta_str = QString::number(delta_time, 'f', prec);
-    text_marker_info = QString("time : %1 (Δ %2)<br>").arg(time_str).arg(delta_str);
+    text_marker_info = QString("<font color=%1>time : %2 (Δ %3)</font><br>").arg(text_color.name()).arg(time_str).arg(delta_str);
   }
   else
   {
-    text_marker_info = QString("time : %1<br>").arg(time_str);
+    text_marker_info = QString("<font color=%1>time : %2</font><br>").arg(text_color.name()).arg(time_str);
   }
 
   if (_param != LINE_ONLY)


### PR DESCRIPTION
At the moment, the color of the time: displayed with the new cursor it hardcoded to black.
This makes it hard to read when dark mode is enabled.

This PR changes this to that the text uses the Qt::WindowText Color instead of black.

<img width="242" height="134" alt="image" src="https://github.com/user-attachments/assets/f0b35337-e0a1-4708-a7a4-313f7c6605e0" />
