### PR TITLE
Fix Usability of MCAP Dialog

### DIFF
--- a/plotjuggler_plugins/DataLoadMCAP/dialog_mcap.cpp
+++ b/plotjuggler_plugins/DataLoadMCAP/dialog_mcap.cpp
@@ -77,6 +77,7 @@ DialogMCAP::DialogMCAP(const std::unordered_map<int, mcap::ChannelPtr>& channels
     ui->radioSkip->setChecked(true);
   }
   ui->spinBox->setValue(params.max_array_size);
+  ui->spinBox->setFocusPolicy(Qt::ClickFocus);
   ui->checkBoxUseTimestamp->setChecked(params.use_timestamp);
   if (params.use_mcap_log_time)
   {


### PR DESCRIPTION
If you currently load an MCAP, you get a dialog window where you can select the number when arrays should be truncated.
However, per default this spinbox for selecting the cursor is in focus (has a cursor in it).

This leads to the behavior that CTRL+A selects all the text inside the spin box instead of all topics in the bag.

<img width="1039" height="745" alt="image" src="https://github.com/user-attachments/assets/810b85ef-7be8-4eef-acfa-5631e8c9c3a6" />


This can be fixed by setting the spin box to click focus. 
This way, the number can still be edited by clicking into the spin box, but by default Ctrl+A selects all topics instead of the text inside the spin box.