### PR TITLE
[Feature] Add topic filtering into the mcap dialog

### DIFF
--- a/plotjuggler_plugins/DataLoadMCAP/dialog_mcap.cpp
+++ b/plotjuggler_plugins/DataLoadMCAP/dialog_mcap.cpp
@@ -124,6 +124,9 @@ DialogMCAP::DialogMCAP(const std::unordered_map<int, mcap::ChannelPtr>& channels
                                                               Qt::SortOrder::AscendingOrder;
   auto sort_count = params.sorted_column % columns_count;
   ui->tableWidget->sortByColumn(sort_count, sort_order);
+
+  // Connect topic filter QLineEdit to filtering logic
+  connect(ui->lineEditFilter, &QLineEdit::textChanged, this, &DialogMCAP::on_lineEditFilter_textChanged);
 }
 
 DialogMCAP::~DialogMCAP()
@@ -183,4 +186,24 @@ void DialogMCAP::accept()
   settings.setValue(prefix + "selected", selected_topics);
 
   QDialog::accept();
+}
+
+void DialogMCAP::on_lineEditFilter_textChanged(const QString& search_string)
+{
+  QStringList spaced_items = search_string.split(' ');
+  for (int row = 0; row < ui->tableWidget->rowCount(); row++)
+  {
+    auto item = ui->tableWidget->item(row, 0);
+    QString name = item ? item->text() : "";
+    bool toHide = false;
+    for (const auto& filter : spaced_items)
+    {
+      if (!name.contains(filter))
+      {
+        toHide = true;
+        break;
+      }
+    }
+    ui->tableWidget->setRowHidden(row, toHide);
+  }
 }

--- a/plotjuggler_plugins/DataLoadMCAP/dialog_mcap.cpp
+++ b/plotjuggler_plugins/DataLoadMCAP/dialog_mcap.cpp
@@ -126,7 +126,8 @@ DialogMCAP::DialogMCAP(const std::unordered_map<int, mcap::ChannelPtr>& channels
   ui->tableWidget->sortByColumn(sort_count, sort_order);
 
   // Connect topic filter QLineEdit to filtering logic
-  connect(ui->lineEditFilter, &QLineEdit::textChanged, this, &DialogMCAP::on_lineEditFilter_textChanged);
+  connect(ui->lineEditFilter, &QLineEdit::textChanged, this,
+          &DialogMCAP::on_lineEditFilter_textChanged);
 }
 
 DialogMCAP::~DialogMCAP()

--- a/plotjuggler_plugins/DataLoadMCAP/dialog_mcap.h
+++ b/plotjuggler_plugins/DataLoadMCAP/dialog_mcap.h
@@ -39,6 +39,7 @@ public:
 private slots:
   void on_tableWidget_itemSelectionChanged();
   void accept() override;
+  void on_lineEditFilter_textChanged(const QString& search_string);
 
 private:
   Ui::dialog_mcap* ui;

--- a/plotjuggler_plugins/DataLoadMCAP/dialog_mcap.ui
+++ b/plotjuggler_plugins/DataLoadMCAP/dialog_mcap.ui
@@ -238,7 +238,7 @@
    </item>
   </layout>
  </widget>
- <resources />
+ <resources/>
  <connections>
   <connection>
    <sender>buttonBox</sender>
@@ -274,6 +274,6 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="buttonGroup" />
+  <buttongroup name="buttonGroup"/>
  </buttongroups>
 </ui>

--- a/plotjuggler_plugins/DataLoadMCAP/dialog_mcap.ui
+++ b/plotjuggler_plugins/DataLoadMCAP/dialog_mcap.ui
@@ -117,24 +117,72 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="label">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Select the channels that you want to load:</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Press &lt;span style=&quot; font-weight:600;&quot;&gt;Ctrl+A&lt;/span&gt; to select all the topics and &lt;span style=&quot; font-weight:600;&quot;&gt;Ctrl+Shift+A&lt;/span&gt; to deselect all&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Select the channels that you want to load</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelUsageHint">
+         <property name="font">
+          <font>
+           <pointsize>9</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Press
+           &lt;span style=&quot;
+           font-weight:600;&quot;&gt;Ctrl+A&lt;/span&gt; to select
+           all the topics and &lt;span style=&quot;
+           font-weight:600;&quot;&gt;Ctrl+Shift+A&lt;/span&gt; to
+           deselect all&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QLabel" name="labelFilter">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Filter Topic Names: </string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="lineEditFilter">
+         <property name="maximumSize">
+          <size>
+           <width>400</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="clearButtonEnabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QTableWidget" name="tableWidget">
@@ -190,7 +238,7 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources />
  <connections>
   <connection>
    <sender>buttonBox</sender>
@@ -226,6 +274,6 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="buttonGroup"/>
+  <buttongroup name="buttonGroup" />
  </buttongroups>
 </ui>


### PR DESCRIPTION
This PR adds the possibility to filter for topics shown in the mcap dialog, very similar to how it is already possible inside the DataLoad ROS Plugin for a while now.
This is very handy when handling very big rosbags with hundreds of signals

Here is an image of the updated UI (notice the filter element on the right):

<img width="1054" height="331" alt="image" src="https://github.com/user-attachments/assets/a9650f71-1337-4b07-a3ab-d7193bc49274" />
