### PR TITLE
Fixed windows app icon

### DIFF
--- a/Plotjuggler.rc
+++ b/Plotjuggler.rc
@@ -1,1 +1,0 @@
-IDI_ICON1 ICON  DISCARDABLE "plotjuggler.ico"

--- a/plotjuggler_app/CMakeLists.txt
+++ b/plotjuggler_app/CMakeLists.txt
@@ -3,6 +3,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 qt5_add_resources(RES_SRC resource.qrc)
 
+if(WIN32)
+  # Adds icon to plotjuggler.exe
+  set(RES_SRC ${RES_SRC} plotjuggler.rc)
+endif()
+
 qt5_wrap_ui(
   UI_SRC
   aboutdialog.ui

--- a/plotjuggler_app/plotjuggler.rc
+++ b/plotjuggler_app/plotjuggler.rc
@@ -1,0 +1,1 @@
+IDI_ICON1 ICON  DISCARDABLE "..\plotjuggler.ico"


### PR DESCRIPTION
- App icon now complied into `plotjuggler.exe` again by including `plotjuggler.rc` (win32 resource file) on win32 builds.
- Moved the .rc file into the app sources which makes more sense instead of littering the repository root.

Resolves #681