### PR TITLE
[Bugfix] Add Tab Button being placed outside plot widget

### DIFF
--- a/plotjuggler_app/tabbedplotwidget.cpp
+++ b/plotjuggler_app/tabbedplotwidget.cpp
@@ -17,6 +17,7 @@
 #include <QTabWidget>
 #include <QPushButton>
 #include <QHBoxLayout>
+#include <algorithm>
 #include "qwt_plot_renderer.h"
 #include "mainwindow.h"
 #include "tabbedplotwidget.h"
@@ -101,9 +102,12 @@ TabbedPlotWidget::TabbedPlotWidget(QString name, QMainWindow* mainwindow,
 void TabbedPlotWidget::paintEvent(QPaintEvent* event)
 {
   QWidget::paintEvent(event);
-
-  auto size = tabWidget()->tabBar()->size();
-  _buttonAddTab->move(QPoint(size.width() + 5, 0));
+  const int margin = 5;
+  int width_tabbar = tabWidget()->tabBar()->width();
+  int max_width_tabbar = std::max(0, width() - _buttonAddTab->width() - margin);
+  int button_pos = std::min(width_tabbar + margin, max_width_tabbar);
+  tabWidget()->tabBar()->setMaximumWidth(max_width_tabbar);
+  _buttonAddTab->move(QPoint(button_pos, 0));
 }
 
 PlotDocker* TabbedPlotWidget::currentTab()


### PR DESCRIPTION
If you create a lot of tabs, the button to add a new one moves further and further to the right.
However, if you reach the width of the tabbed_plot_widget, the button just "falls" over the edge
of the widget to the right.
<img width="398" height="295" alt="image" src="https://github.com/user-attachments/assets/86dc4c09-7978-48a7-b1e2-23a4cccad8b2" />

This PR fixes this by limiting the tab bar width to a maximum size, so button always remains there.

<img width="398" height="295" alt="image" src="https://github.com/user-attachments/assets/bbfb3df0-2946-4ee0-9c88-ad3fe2aed944" />
