### PR TITLE
Fix detection of system-provided liblz4 and zstd

### DIFF
--- a/cmake/FindLZ4.cmake
+++ b/cmake/FindLZ4.cmake
@@ -22,7 +22,7 @@
 
 if(UNIX)
   find_package(PkgConfig QUIET)
-  pkg_search_module(PC_LZ4 lz4)
+  pkg_search_module(PC_LZ4 lz4 liblz4)
 endif()
 
 find_path(LZ4_INCLUDE_DIR
@@ -55,7 +55,7 @@ find_package_handle_standard_args(LZ4
   LZ4_STATIC_LIBRARY
 )
 
-if(LZ4_FOUND)
+if(PC_LZ4_FOUND)
   message(STATUS "Found LZ4: shared=${LZ4_SHARED_LIBRARY}, static=${LZ4_STATIC_LIBRARY}")
 else()
   message(WARNING "LZ4 not found")

--- a/cmake/FindZSTD.cmake
+++ b/cmake/FindZSTD.cmake
@@ -50,7 +50,7 @@ find_package_handle_standard_args(ZSTD
   ZSTD_STATIC_LIBRARY
 )
 
-if(ZSTD_FOUND)
+if(PC_ZSTD_FOUND)
   message(STATUS "Found Zstd: shared=${ZSTD_SHARED_LIBRARY}, static=${ZSTD_STATIC_LIBRARY}")
 endif()
 


### PR DESCRIPTION
Without this, cmake tries to download lz4 and zstd from the internet even if they are available in the system. This is a problem with Nix package manager which compiles packages without network access.

Related to #1188 and #1190. 