### PR TITLE
Added a script to remove orphaned link upon uninstall on debian

### DIFF
--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -98,6 +98,7 @@ jobs:
           cp -rp DEBIAN plotjuggler_'${{ steps.define_version.outputs.version }}'_amd64/
           chmod ogu+x plotjuggler_'${{ steps.define_version.outputs.version }}'_amd64/DEBIAN/postinst
           chmod ogu+x plotjuggler_'${{ steps.define_version.outputs.version }}'_amd64/DEBIAN/preinst
+          chmod ogu+x plotjuggler_'${{ steps.define_version.outputs.version }}'_amd64/DEBIAN/postrm
           mv plotjuggler_'${{ steps.define_version.outputs.version }}'_amd64/DEBIAN/_control.'${{ steps.dist_short.outputs.short_name }}' plotjuggler_'${{ steps.define_version.outputs.version }}'_amd64/DEBIAN/control
           rm plotjuggler_'${{ steps.define_version.outputs.version }}'_amd64/DEBIAN/_*
 

--- a/DEBIAN/postrm
+++ b/DEBIAN/postrm
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Remove the symbolic link to the plotjuggler binary if it exists
+if [ -L /usr/bin/plotjuggler ]; then
+    rm /usr/bin/plotjuggler
+fi


### PR DESCRIPTION
The symbolic link `/usr/bin/plotjuggler`  gets created on postinst, but is left behind upon package removal.
This was also causing reinstallation to display an error stating that the link already exists (i.e. returns non-zero).

This change adds a postrm script to the Debian package to remove the orphaned symbolic link.

