### PR TITLE
Update compile instructions for Fedora

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -8,11 +8,11 @@ sudo apt -y install qtbase5-dev libqt5svg5-dev libqt5websockets5-dev \
       liblz4-dev libzstd-dev
 ```
 
-On Fedora:
+On Fedora (42):
 
 ```shell
-sudo dnf install qt5-qtbase-devel qt5-qtsvg-devel qt5-websockets-devel \
-      qt5-qtopendl-devel qt5-qtx11extras-devel
+sudo dnf install qt5-qtbase-devel qt5-qtsvg-devel qt5-qtwebsockets-devel \
+      qt5-qtx11extras-devel
 ```
 
 Clone the repository into **~/plotjuggler_ws**:


### PR DESCRIPTION
Hello Davide

I just tried installing deps and compiling on Fedora 42, and I had to make these changes to get it to build.

Not sure which Fedora version these instructions were written for, so I specified that this is Fedora 42.

I'm also happy to keep the current instructions, ideally with an identifier for the Fedora version, and add the updated one alongside it.