### PR TITLE
Parquet loading

### DIFF
--- a/plotjuggler_plugins/DataLoadParquet/dataload_parquet.cpp
+++ b/plotjuggler_plugins/DataLoadParquet/dataload_parquet.cpp
@@ -1,4 +1,5 @@
 #include "dataload_parquet.h"
+#include <arrow/type_fwd.h>
 #include <QTextStream>
 #include <QFile>
 #include <QMessageBox>
@@ -8,6 +9,7 @@
 #include <QDateTime>
 #include <QInputDialog>
 #include <QListWidget>
+#include <QTimeZone>
 #include <cmath>
 
 DataLoadParquet::DataLoadParquet()
@@ -95,6 +97,43 @@ double get_arrow_value(const std::shared_ptr<arrow::Array>& array, int64_t index
       return get_arrow_value<arrow::FloatArray>(array, index);
     case arrow::Type::DOUBLE:
       return get_arrow_value<arrow::DoubleArray>(array, index);
+    case arrow::Type::TIMESTAMP: {
+      auto timestamp_array = std::static_pointer_cast<arrow::TimestampArray>(array);
+      if (timestamp_array->IsNull(index))
+      {
+        return std::numeric_limits<double>::quiet_NaN();
+      }
+      const auto timestamp_type =
+          std::static_pointer_cast<arrow::TimestampType>(timestamp_array->type());
+      const int64_t value = timestamp_array->Value(index);
+      double seconds = 0;
+      switch (timestamp_type->unit())
+      {
+        case arrow::TimeUnit::SECOND:
+          seconds = static_cast<double>(value);
+          break;
+        case arrow::TimeUnit::MILLI:
+          seconds = static_cast<double>(value) / 1000.0;
+          break;
+        case arrow::TimeUnit::MICRO:
+          seconds = static_cast<double>(value) / 1000000.0;
+          break;
+        case arrow::TimeUnit::NANO:
+          seconds = static_cast<double>(value) / 1000000000.0;
+          break;
+      }
+      const std::string& timezone_str = timestamp_type->timezone();
+      if (!timezone_str.empty() && timezone_str != "UTC")
+      {
+        QTimeZone tz(QByteArray::fromStdString(timezone_str));
+        if (tz.isValid())
+        {
+          QDateTime utc_dt = QDateTime::fromSecsSinceEpoch(static_cast<qint64>(seconds));
+          seconds -= tz.offsetFromUtc(utc_dt);
+        }
+      }
+      return seconds;
+    }
     default:
       break;
   }
@@ -160,7 +199,7 @@ bool DataLoadParquet::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_
          info.arrow_type == arrow::Type::INT64 || info.arrow_type == arrow::Type::UINT8 ||
          info.arrow_type == arrow::Type::UINT16 || info.arrow_type == arrow::Type::UINT32 ||
          info.arrow_type == arrow::Type::UINT64 || info.arrow_type == arrow::Type::FLOAT ||
-         info.arrow_type == arrow::Type::DOUBLE);
+         info.arrow_type == arrow::Type::TIMESTAMP || info.arrow_type == arrow::Type::DOUBLE);
 
     if (is_valid)
     {


### PR DESCRIPTION
This adds the capability to read the timestamp data type from parquet files with the correct conversion to PlotJuggler's internal time.
It also fixes a little bug, where bool columns were shown in the selector but were not displayed when pulled into the plot. Now they are plotted as 1 and 0.