### PR TITLE
Add 'Export Data to CSV' option to plot context menu

### DIFF
--- a/plotjuggler_app/plotwidget.h
+++ b/plotjuggler_app/plotwidget.h
@@ -149,6 +149,8 @@ public slots:
 
   void onShowDataStatistics();
 
+  void onExportDataToCSV();
+
   void plotOn(const PlotSaveHelper& plot_save_helper, QRect paint_at);
 
 private slots:
@@ -188,6 +190,7 @@ private:
   QAction* _action_copy;
   QAction* _action_paste;
   QAction* _action_image_to_clipboard;
+  QAction* _action_exportDataToCSV;
 
   QAction* _flip_x;
   QAction* _flip_y;


### PR DESCRIPTION
## Summary
- Adds right-click context menu option "Export Data to CSV" to plots
- Exports only data within the visible/zoomed time range
- Supports multiple curves merged by timestamp

## Motivation
Addresses the feature request for per-plot CSV export respecting zoom level (see issue #1218).

Currently users must use the global CSV Publisher to export data all loaded data. This adds a quick way to export just the visible portion of a specific plot.