### PR TITLE
Add Quaternion to RPY autofill for PX4

### DIFF
--- a/plotjuggler_plugins/ToolboxQuaternion/toolbox_quaternion.cpp
+++ b/plotjuggler_plugins/ToolboxQuaternion/toolbox_quaternion.cpp
@@ -118,14 +118,22 @@ bool ToolboxQuaternion::eventFilter(QObject* obj, QEvent* ev)
     {
       autoFill(_dragging_curve.left(_dragging_curve.size() - 1));
     }
+
+    // Drag & drop for PX4 quaternions (order is WXYZ with entries labeled q.0X)
+    if ((obj == ui->lineEditX && _dragging_curve.endsWith(".01")) ||
+        (obj == ui->lineEditY && _dragging_curve.endsWith(".02")) ||
+        (obj == ui->lineEditZ && _dragging_curve.endsWith(".03")) ||
+        (obj == ui->lineEditW && _dragging_curve.endsWith(".00")))
+    {
+      autoFill(_dragging_curve.left(_dragging_curve.size() - 3), { ".01", ".02", ".03", ".00" });
+    }
   }
 
   return false;
 }
 
-void ToolboxQuaternion::autoFill(QString prefix)
+void ToolboxQuaternion::autoFill(QString prefix, QStringList suffix)
 {
-  QStringList suffix = { "x", "y", "z", "w" };
   std::array<QLineEdit*, 4> lineEdits = { ui->lineEditX, ui->lineEditY, ui->lineEditZ,
                                           ui->lineEditW };
   QStringList names;

--- a/plotjuggler_plugins/ToolboxQuaternion/toolbox_quaternion.h
+++ b/plotjuggler_plugins/ToolboxQuaternion/toolbox_quaternion.h
@@ -51,7 +51,7 @@ private:
 
   QString _dragging_curve;
 
-  void autoFill(QString prefix);
+  void autoFill(QString prefix, QStringList suffix = { "x", "y", "z", "w" });
 
   PJ::PlotWidgetBase* _plot_widget = nullptr;
 


### PR DESCRIPTION
First of all, thank you for this amazing project and it's support for `.ulg` & `.mcap` files, it's truly been a game changer when debugging issues!

PX4 logs quaternions using WXYZ order with elements ending in  `.00`, `.01`, `.02` and `.03` respectively. Some examples of these quaternions in `.ulg` files are `vehicle_attitude/q.0X` and `vehicle_attitude_setpoint/q_d.0X`, matching on the `.0X` part.

This quaternion format is unfortunately not compatible with the drag & drop autofill feature of the `Quaternion to RPY` toolbox. This PR adds autofill for these quaterions, so you only need to drag one of the elements into the  tool to visualize them.