### PR TITLE
Inherit legend settings when splitting plot views

### DIFF
--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -832,6 +832,17 @@ void MainWindow::onPlotAdded(PlotWidget* plot)
   plot->setDefaultStyle(ui->buttonDots->isChecked() ? PlotWidgetBase::LINES_AND_DOTS :
                                                       PlotWidgetBase::LINES);
 
+  // Inherit legend settings from current state
+  plot->activateLegend(_labels_status != LabelStatus::HIDDEN);
+  if (_labels_status == LabelStatus::LEFT)
+  {
+    plot->setLegendAlignment(Qt::AlignLeft);
+  }
+  else if (_labels_status == LabelStatus::RIGHT)
+  {
+    plot->setLegendAlignment(Qt::AlignRight);
+  }
+
   QSettings settings;
   bool swap_pan_zoom = settings.value("Preferences::swap_pan_zoom", false).toBool();
   plot->setSwapZoomPan(swap_pan_zoom);


### PR DESCRIPTION
**Summary**

Fixed an issue where newly created subplots (via split view) did not inherit the current legend settings from existing plots, causing them to always display the default legend configuration (right-aligned, visible) instead of matching the user's current preferences.

**Motivation**

When users configure their legend settings (left/right alignment, hidden/visible) and then split a view to create additional subplots, they expect the new subplot to maintain the same visual configuration as the existing plots. However, the new subplots were always created with default settings:

- Legend always positioned on the right side
- Legend always visible (even if user had hidden it)
- Pressing legend buttons would advance through modes instead of matching current state

This inconsistent behavior disrupted the user's workflow and required manual reconfiguration of each new subplot to match their preferences.

**Solution**

Enhanced the `onPlotAdded` method in `mainwindow.cpp` to inherit legend settings from the application's current state:

- New subplots now inherit legend visibility from `_labels_status` (hidden/visible)
- New subplots now inherit legend alignment from `_labels_status` (left/right positioning)
- Legend configuration is applied immediately when the subplot is created

The fix ensures that split views maintain visual consistency across all subplots, matching user expectations and improving the overall user experience.