### PR TITLE
Fixes issue #1015: UDP server crash

### DIFF
--- a/plotjuggler_plugins/DataStreamUDP/udp_server.cpp
+++ b/plotjuggler_plugins/DataStreamUDP/udp_server.cpp
@@ -118,7 +118,20 @@ bool UDP_Server::start(QStringList*)
         prev_widget->setVisible(false);
       }
     }
-    parser_creator = parserFactories()->at(selected_protocol);
+    // Safe lookup with fallback
+    auto it = parserFactories()->find(selected_protocol);
+    if (it != parserFactories()->end())
+    {
+      parser_creator = it->second;
+    }
+    else
+    {
+      // Fallback to first available parser
+      if (!parserFactories()->empty()) 
+      {
+        parser_creator = parserFactories()->begin()->second;
+      }
+    }
 
     if (auto widget = parser_creator->optionsWidget())
     {


### PR DESCRIPTION
### Summary
Fixes issue #1015  where PlotJuggler crashes when trying to start a UDP server.
- Was not able to recreate the exact scenario that reporter experienced but the stack trace in the video shows that the error was an std::out_of_range exception within UDP::start().
- The only possible location that can happen is when the at() function is called on the parserFactories()

### Changes
- Replaced the  call to at() with a safer lookup by calling find() inside the lambda for onComboChanged()
- Provided a fallback in case the selected_protocol does not exist


### Testing
- Built in docker container
- Manually tested UDP streaming