### PR TITLE
fix: guard undo/redo from firing during active popups (fixes #1095)

### DIFF
--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -401,6 +401,9 @@ void MainWindow::onUndoableChange()
 
 void MainWindow::onRedoInvoked()
 {
+  if (QApplication::activePopupWidget() || QApplication::activeModalWidget())
+    return;
+
   _disable_undo_logging = true;
   if (_redo_states.size() > 0)
   {
@@ -418,6 +421,9 @@ void MainWindow::onRedoInvoked()
 
 void MainWindow::onUndoInvoked()
 {
+  if (QApplication::activePopupWidget() || QApplication::activeModalWidget())
+    return;
+
   _disable_undo_logging = true;
   if (_undo_states.size() > 1)
   {


### PR DESCRIPTION

  - Fix application freeze/crash when pressing Ctrl+Z or Ctrl+Shift+Z while a context menu or modal dialog is open
  - Add re-entrancy guard to `onUndoInvoked()` and `onRedoInvoked()` using `QApplication::activePopupWidget()` and `QApplication::activeModalWidget()`

  Fixes #1095

  ## Root Cause

  The undo/redo shortcuts use `Qt::ApplicationShortcut` context, which means they fire globally — even inside nested event loops created by `QMenu::exec()` or
  `QDialog::exec()`.

  When undo runs `xmlLoadState()` during such a nested loop, it destroys/rebuilds widgets (via `deleteLater()`) that own the active popup. This causes either:
  - **Application hang** ("not responding")
  - **`double free or corruption`** crash

  ### Reproduction
  1. Load data and drag a curve onto a plot
  2. Perform any undoable action (drag another curve, add a tab, zoom out)
  3. Right-click on the plot (context menu opens)
  4. Press Ctrl+Z while the menu is still open
  5. App freezes or crashes

  ## Fix

  Guard both handlers to skip the operation if any popup or modal dialog is currently active. The user can press Ctrl+Z again after dismissing the popup.

  ```cpp
  if (QApplication::activePopupWidget() || QApplication::activeModalWidget())
      return;
   ```
  This covers all exec() call sites app-wide (context menus, edit dialogs, formula editor, colormap picker, etc.) with a single 2-line guard per handler.

  Test plan

  - Right-click plot → Ctrl+Z → menu stays open, no crash
  - Close menu → Ctrl+Z → undo works normally
  - Open "Edit curves..." dialog → Ctrl+Z → dialog stays open, no crash
  - Normal undo/redo without popups → works unchanged
