### PR TITLE
refactor: extract testable CSV parsing layer from DataLoadCSV plugin

### DIFF
--- a/plotjuggler_plugins/DataLoadCSV/CMakeLists.txt
+++ b/plotjuggler_plugins/DataLoadCSV/CMakeLists.txt
@@ -7,7 +7,7 @@ qt5_wrap_ui(UI_SRC dataload_csv.ui datetimehelp.ui)
 
 # Pure parsing library (no Qt Widgets dependency)
 add_library(csv_parser_lib STATIC csv_parser.cpp timestamp_parsing.cpp)
-target_link_libraries(csv_parser_lib PUBLIC Qt5::Core)
+target_link_libraries(csv_parser_lib PRIVATE Qt5::Core)
 target_include_directories(csv_parser_lib PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/3rdparty/date-3.0.4/include)

--- a/plotjuggler_plugins/DataLoadCSV/csv_parser.cpp
+++ b/plotjuggler_plugins/DataLoadCSV/csv_parser.cpp
@@ -316,9 +316,9 @@ CsvParseResult ParseCsvData(std::istream& input, const CsvParseConfig& config,
   int linenumber = config.skip_rows + 1;  // header was this line
   int samplecount = 0;
 
-  // Optionally count total lines for progress (scan ahead if seekable)
-  int total_lines = 0;
-  if (progress)
+  // Use caller-provided total_lines for progress, or count internally
+  int total_lines = config.total_lines;
+  if (progress && total_lines <= 0)
   {
     auto pos = input.tellg();
     if (pos != std::istream::pos_type(-1))

--- a/plotjuggler_plugins/DataLoadCSV/csv_parser.h
+++ b/plotjuggler_plugins/DataLoadCSV/csv_parser.h
@@ -62,6 +62,7 @@ struct CsvParseConfig
   int time_column_index = -1;      // -1 = use row number as time
   std::string custom_time_format;  // empty = auto-detect
   int skip_rows = 0;               // lines to skip before header
+  int total_lines = 0;             // 0 = count internally if progress callback set
 };
 
 struct CsvColumnData

--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
@@ -16,7 +16,6 @@
 
 #include <array>
 #include <set>
-#include <sstream>
 
 #include <QStandardItemModel>
 
@@ -341,14 +340,13 @@ bool DataLoadCSV::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_data
   }
 
   //--- Count lines for progress ---
-  int tot_lines = 0;
   {
     file.open(QFile::ReadOnly);
     QTextStream in(&file);
     while (!in.atEnd())
     {
       in.readLine();
-      tot_lines++;
+      config.total_lines++;
     }
     file.close();
   }
@@ -357,7 +355,7 @@ bool DataLoadCSV::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_data
   progress_dialog.setWindowTitle("Loading the CSV file");
   progress_dialog.setLabelText("Loading... please wait");
   progress_dialog.setWindowModality(Qt::ApplicationModal);
-  progress_dialog.setRange(0, tot_lines);
+  progress_dialog.setRange(0, config.total_lines);
   progress_dialog.setAutoClose(true);
   progress_dialog.setAutoReset(true);
   progress_dialog.show();
@@ -370,9 +368,8 @@ bool DataLoadCSV::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_data
   file.close();
 
   std::string file_str(file_data.constData(), file_data.size());
-  std::istringstream stream(file_str);
 
-  auto result = PJ::CSV::ParseCsvData(stream, config, [&](int current, int) -> bool {
+  auto result = PJ::CSV::ParseCsvData(file_str, config, [&](int current, int) -> bool {
     progress_dialog.setValue(current);
     QApplication::processEvents();
     if (progress_dialog.wasCanceled())

--- a/plotjuggler_plugins/DataLoadCSV/tests/test_csv_parser.cpp
+++ b/plotjuggler_plugins/DataLoadCSV/tests/test_csv_parser.cpp
@@ -543,3 +543,23 @@ TEST(ParseCsvData, HeaderOnly)
   EXPECT_EQ(result.column_names.size(), 3u);
   EXPECT_EQ(result.lines_processed, 0);
 }
+
+TEST(ParseCsvData, ScientificNotation)  // PR #1280
+{
+  std::string csv = "val\n1.5e3\n2.0E-4\n-3e2\n1e10\n";
+  CsvParseConfig config;
+  config.delimiter = ',';
+  config.time_column_index = -1;
+
+  auto result = ParseCsvData(csv, config);
+  ASSERT_TRUE(result.success);
+  ASSERT_EQ(result.columns.size(), 1u);
+
+  // All values should be parsed as numeric, not string
+  EXPECT_EQ(result.columns[0].string_points.size(), 0u);
+  ASSERT_EQ(result.columns[0].numeric_points.size(), 4u);
+  EXPECT_DOUBLE_EQ(result.columns[0].numeric_points[0].second, 1500.0);
+  EXPECT_DOUBLE_EQ(result.columns[0].numeric_points[1].second, 0.0002);
+  EXPECT_DOUBLE_EQ(result.columns[0].numeric_points[2].second, -300.0);
+  EXPECT_DOUBLE_EQ(result.columns[0].numeric_points[3].second, 1e10);
+}


### PR DESCRIPTION
Extract pure C++ parsing functions (DetectDelimiter, SplitLine, ParseHeaderLine, ParseCsvData) into csv_parser.h/cpp so the CSV plugin's core logic can be unit-tested without launching the GUI. dataload_csv.cpp becomes a thin wrapper that builds config from UI state, calls ParseCsvData, and converts results to PlotData.

Adds csv_parser_lib static library target and 39 gtest regression tests covering delimiter detection, quoted fields, duplicate columns, timestamp parsing, hex values, European decimal separators, skip rows, non-monotonic time, and more.