### PR TITLE
feat: add support for plotting the last array element with [-1]

### DIFF
--- a/plotjuggler_app/curvelist_panel.cpp
+++ b/plotjuggler_app/curvelist_panel.cpp
@@ -376,7 +376,7 @@ void CurveListPanel::refreshValues()
 
 QString StringifyArray(QString str)
 {
-  static const QRegExp rx("(\\[\\d+\\])");
+  static const QRegExp rx("(\\[-?\\d+\\])");
   int pos = 0;
   std::vector<std::pair<int, int>> index_positions;
 

--- a/plotjuggler_app/nlohmann_parsers.cpp
+++ b/plotjuggler_app/nlohmann_parsers.cpp
@@ -39,6 +39,7 @@ bool NlohmannParser::parseMessageImpl(double& timestamp)
         {
           flatten(fmt::format("{}[{}]", prefix, i), value[i]);
         }
+        flatten(fmt::format("{}[-1]", prefix), value.back());
         break;
       }
 


### PR DESCRIPTION
I sometimes need to plot the last element of a dynamic-size array, but PlotJuggler only exposes fixed indices like [0], [1], … and the tree keeps showing indices up to the maximum size ever seen. So when the array shrinks/grows over time, you can’t easily know which index is actually “the last one right now” to plot.

This MR adds virtual [-1] series aliases so you can plot things like poses[-1] or poses[-1]/position/x and always get the last parsed element at each sample (including nested arrays). [-1] is grouped under [] in the tree like other indices.

Also fixes a small protobuf clamp bug (std::max → std::min) [here](https://github.com/facontidavide/PlotJuggler/pull/1299/changes#diff-d67f8d176b1f6e96575613c43f2cdae5b801bfc627940d182f296e53b748f812R118) so truncation works as intended.

#### Screenshots:
<img width="348" height="480" alt="back_alias_tree_view" src="https://github.com/user-attachments/assets/52c6481e-0c9b-486f-bafb-6ad16b1d01e8" />
<img width="686" height="929" alt="back_alias_plot" src="https://github.com/user-attachments/assets/e3cb50b3-769a-417a-a6ac-e1440ef24215" />
