### PR TITLE
Added another common statistics metrics, rms, mav, stddev, peak to peak

### DIFF
--- a/plotjuggler_app/statistics_dialog.cpp
+++ b/plotjuggler_app/statistics_dialog.cpp
@@ -7,6 +7,7 @@
 #include "statistics_dialog.h"
 #include "ui_statistics_dialog.h"
 #include <QTableWidgetItem>
+#include <cmath>
 #include "qwt_text.h"
 
 StatisticsDialog::StatisticsDialog(PlotWidget* parent)
@@ -79,8 +80,15 @@ void StatisticsDialog::update(PJ::Range range)
         stat.max = std::max(stat.max, p.y());
       }
       stat.mean_tot += p.y();
+      stat.square_tot += p.y() * p.y();
+      stat.abs_tot += std::fabs(p.y());
     }
-    stat.mean_interval = (end_time - start_time) / double(stat.count);
+
+    if (stat.count > 0)
+    {
+      stat.mean_interval = (end_time - start_time) / double(stat.count - 1);
+    }
+
     statistics[info.curve->title().text()] = stat;
   }
 
@@ -90,14 +98,32 @@ void StatisticsDialog::update(PJ::Range range)
   {
     const auto& stat = it.second;
 
-    std::array<QString, 6> row_values;
+    std::array<QString, 10> row_values;
     row_values[0] = it.first;
     row_values[1] = QString::number(stat.count);
     row_values[2] = QString::number(stat.min, 'f');
     row_values[3] = QString::number(stat.max, 'f');
-    double mean = stat.mean_tot / double(stat.count);
-    row_values[4] = QString::number(mean, 'f');
-    row_values[5] = QString::number(stat.mean_interval, 'f');
+    const double peak_to_peak = (stat.count > 0) ? (stat.max - stat.min) : 0.0;
+    double mean = 0;
+    double rms = 0;
+    double stddev = 0;
+    double mean_abs_value = 0;
+    if (stat.count > 0)
+    {
+      const double count = double(stat.count);
+      mean = stat.mean_tot / count;
+      rms = std::sqrt(stat.square_tot / count);
+      mean_abs_value = stat.abs_tot / count;
+      const double variance = std::max(0.0, (stat.square_tot / count) - (mean * mean));
+      stddev = std::sqrt(variance);
+    }
+
+    row_values[4] = QString::number(peak_to_peak, 'f');
+    row_values[5] = QString::number(mean, 'f');
+    row_values[6] = QString::number(rms, 'f');
+    row_values[7] = QString::number(stddev, 'f');
+    row_values[8] = QString::number(mean_abs_value, 'f');
+    row_values[9] = QString::number(stat.mean_interval, 'f');
 
     for (size_t col = 0; col < row_values.size(); col++)
     {

--- a/plotjuggler_app/statistics_dialog.h
+++ b/plotjuggler_app/statistics_dialog.h
@@ -23,6 +23,8 @@ struct Statistics
   double min = 0;
   double max = 0;
   double mean_tot = 0;
+  double square_tot = 0;
+  double abs_tot = 0;
   double mean_interval = 0;
 };
 

--- a/plotjuggler_app/statistics_dialog.ui
+++ b/plotjuggler_app/statistics_dialog.ui
@@ -45,11 +45,31 @@
        <string>Maximum</string>
       </property>
      </column>
+    <column>
+     <property name="text">
+      <string>Peak to Peak</string>
+     </property>
+    </column>
      <column>
       <property name="text">
        <string>Average</string>
       </property>
      </column>
+    <column>
+     <property name="text">
+      <string>RMS</string>
+     </property>
+    </column>
+    <column>
+     <property name="text">
+      <string>Std Dev</string>
+     </property>
+    </column>
+    <column>
+     <property name="text">
+      <string>Mean Abs Value</string>
+     </property>
+    </column>
      <column>
       <property name="text">
        <string>Avg Interval</string>


### PR DESCRIPTION
This PR adds additional statistical metrics to PlotJuggler, including:
- Mean
- Standard Deviation
- RMS (Root Mean Square)
- Peak-to-Peak
- MAV (Mean Absolute Value)

While working with data visualization in PlotJuggler, I found myself needing more built-in statistical indicators directly within the plotting interface. These metrics are commonly used for signal analysis and quick diagnostics, and having them readily available improves workflow efficiency without requiring external tools.

Oh and another bugfix
Average interval is now computed using sample intervals instead of sample count:
Average Interval = (end_time - start_time) / (count - 1)

This is mathematically correct because N samples contain N-1 intervals.
Example: 3 samples at 1-second spacing span 2 seconds, so average interval is 2 / (3 - 1) = 1 second.

<img width="2200" height="1402" alt="Screenshot_20260318_122056" src="https://github.com/user-attachments/assets/2ea9318a-5b60-4a28-8e70-aaba2b6c7472" />
