### PR TITLE
[Draft] QOL: Show currently loaded file(s) in the file label.

### DIFF
--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -1422,6 +1422,14 @@ bool MainWindow::loadDataFromFiles(QStringList filenames)
 
   ui->buttonReloadData->setEnabled(!loaded_filenames.empty());
 
+  QList<QFileInfo> loaded_fileinfos{};
+  for (const auto& file_info : loaded_filenames)
+  {
+    loaded_fileinfos.push_back(QFileInfo(file_info));
+  }
+  updateCurrentLoadedFilesLabel(loaded_fileinfos);
+
+
   if (loaded_filenames.size() > 0)
   {
     updateRecentDataMenu(loaded_filenames);
@@ -1580,6 +1588,11 @@ std::unordered_set<std::string> MainWindow::loadDataFromFile(const FileLoadInfo&
 
   updateDataAndReplot(true);
   ui->timeSlider->setRealValue(ui->timeSlider->getMinimum());
+
+  if (!added_names.empty())
+  {
+    updateCurrentLoadedFilesLabel({ QFileInfo(info.filename) });
+  }
 
   return added_names;
 }
@@ -3633,6 +3646,35 @@ void MainWindow::on_actionColorMap_Editor_triggered()
 {
   ColorMapEditor dialog;
   dialog.exec();
+}
+
+void MainWindow::updateCurrentLoadedFilesLabel(const QList<QFileInfo>& files)
+{
+  QStringList basenames{};
+  QStringList fullpaths{};
+  for (const auto& file_info : files)
+  {
+    basenames.push_back(file_info.fileName());
+    fullpaths.push_back(file_info.absoluteFilePath());
+  }
+
+  if(files.empty())
+  {
+    ui->labelCurrentLoadedFiles->setText(tr("File: "));
+    ui->labelCurrentLoadedFiles->setToolTip("");
+    return;
+  }
+
+  if(files.size() == 1)
+  {
+    ui->labelCurrentLoadedFiles->setText(tr("File: %1").arg(basenames.first()));
+    ui->labelCurrentLoadedFiles->setToolTip(fullpaths.first());
+    return;
+  }
+
+  //Multiple files loaded. Don't try and show what could be a long list of files in the label, but show them in the tooltip instead.
+  ui->labelCurrentLoadedFiles->setText(tr("Files (%1): %2 ...").arg(files.size()).arg(basenames.first()));
+  ui->labelCurrentLoadedFiles->setToolTip(fullpaths.join('\n'));
 }
 
 void MainWindow::on_buttonReloadData_clicked()

--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -1279,6 +1279,9 @@ void MainWindow::deleteAllData()
   _undo_states.clear();
   _redo_states.clear();
 
+  //No data means no files loaded.
+  updateCurrentLoadedFilesLabel(QList<QFileInfo>());
+  
   bool stopped = false;
 
   for (int idx = 0; idx < ui->layoutPublishers->count(); idx++)

--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -1280,7 +1280,7 @@ void MainWindow::deleteAllData()
   _redo_states.clear();
 
   //No data means no files loaded.
-  updateCurrentLoadedFilesLabel(QList<QFileInfo>());
+  updateCurrentLoadedFilesLabel(QList<FileLoadInfo>());
   
   bool stopped = false;
 
@@ -1367,7 +1367,7 @@ bool MainWindow::loadDataFromFiles(QStringList filenames)
 
   std::unordered_set<std::string> previous_names = _mapped_plot_data.getAllNames();
 
-  QStringList loaded_filenames;
+  QList<FileLoadInfo> loaded_fileinfos{};
   _loaded_datafiles_previous.clear();
 
   for (int i = 0; i < filenames.size(); i++)
@@ -1381,7 +1381,7 @@ bool MainWindow::loadDataFromFiles(QStringList filenames)
     auto added_names = loadDataFromFile(info, merge_data);
     if (!added_names.empty())
     {
-      loaded_filenames.push_back(filenames[i]);
+      loaded_fileinfos.push_back(info);
     }
     for (const auto& name : added_names)
     {
@@ -1416,25 +1416,25 @@ bool MainWindow::loadDataFromFiles(QStringList filenames)
   }
 
   // special case when only the last file should be remembered
-  if (loaded_filenames.size() == 1 && data_replaced_entirely &&
+  if (loaded_fileinfos.size() == 1 && data_replaced_entirely &&
       _loaded_datafiles_history.size() > 1)
   {
     std::swap(_loaded_datafiles_history.back(), _loaded_datafiles_history.front());
     _loaded_datafiles_history.resize(1);
   }
 
-  ui->buttonReloadData->setEnabled(!loaded_filenames.empty());
+  ui->buttonReloadData->setEnabled(!loaded_fileinfos.empty());
 
-  QList<QFileInfo> loaded_fileinfos{};
-  for (const auto& file_info : loaded_filenames)
-  {
-    loaded_fileinfos.push_back(QFileInfo(file_info));
-  }
   updateCurrentLoadedFilesLabel(loaded_fileinfos);
 
 
-  if (loaded_filenames.size() > 0)
+  if (loaded_fileinfos.size() > 0)
   {
+    QStringList loaded_filenames;
+    for (const auto& info : loaded_fileinfos)
+    {
+      loaded_filenames.push_back(info.filename);
+    }
     updateRecentDataMenu(loaded_filenames);
     linkedZoomOut();
     return true;
@@ -1594,7 +1594,10 @@ std::unordered_set<std::string> MainWindow::loadDataFromFile(const FileLoadInfo&
 
   if (!added_names.empty())
   {
-    updateCurrentLoadedFilesLabel({ QFileInfo(info.filename) });
+    QList<FileLoadInfo> fileinfos;
+    fileinfos.push_back(info);
+
+    updateCurrentLoadedFilesLabel(fileinfos);
   }
 
   return added_names;
@@ -3651,14 +3654,32 @@ void MainWindow::on_actionColorMap_Editor_triggered()
   dialog.exec();
 }
 
-void MainWindow::updateCurrentLoadedFilesLabel(const QList<QFileInfo>& files)
+void MainWindow::updateCurrentLoadedFilesLabel(const QList<FileLoadInfo>& files)
 {
-  QStringList basenames{};
-  QStringList fullpaths{};
-  for (const auto& file_info : files)
+  QStringList abbreviated_file_paths{}; //WITH prefix if given
+  QStringList absolute_file_paths{};
+
+  for (const auto& file_loaded_info : files)
   {
-    basenames.push_back(file_info.fileName());
-    fullpaths.push_back(file_info.absoluteFilePath());
+    QString absolute_file_path;
+    QString abbreviated_name;
+ 
+    QFileInfo file_info = QFileInfo(file_loaded_info.filename);
+
+    if(file_loaded_info.prefix.isEmpty())
+    {
+      
+      abbreviated_name = file_info.fileName();
+      absolute_file_path = file_info.absoluteFilePath();
+    }
+    else
+    {
+      abbreviated_name = QString("%1: %2").arg(file_loaded_info.prefix).arg(file_info.fileName());
+      absolute_file_path = QString("%1: %2").arg(file_loaded_info.prefix).arg(file_info.absoluteFilePath());
+    }
+
+    abbreviated_file_paths.push_back(abbreviated_name);
+    absolute_file_paths.push_back(absolute_file_path);
   }
 
   if(files.empty())
@@ -3670,14 +3691,14 @@ void MainWindow::updateCurrentLoadedFilesLabel(const QList<QFileInfo>& files)
 
   if(files.size() == 1)
   {
-    ui->labelCurrentLoadedFiles->setText(tr("File: %1").arg(basenames.first()));
-    ui->labelCurrentLoadedFiles->setToolTip(fullpaths.first());
+    ui->labelCurrentLoadedFiles->setText(tr("File: %1").arg(abbreviated_file_paths.first()));
+    ui->labelCurrentLoadedFiles->setToolTip(absolute_file_paths.first());
     return;
   }
 
   //Multiple files loaded. Don't try and show what could be a long list of files in the label, but show them in the tooltip instead.
-  ui->labelCurrentLoadedFiles->setText(tr("Files (%1): %2 ...").arg(files.size()).arg(basenames.first()));
-  ui->labelCurrentLoadedFiles->setToolTip(fullpaths.join('\n'));
+  ui->labelCurrentLoadedFiles->setText(tr("Files (%1): %2 ...").arg(files.size()).arg(abbreviated_file_paths.first()));
+  ui->labelCurrentLoadedFiles->setToolTip(absolute_file_paths.join('\n'));
 }
 
 void MainWindow::on_buttonReloadData_clicked()

--- a/plotjuggler_app/mainwindow.h
+++ b/plotjuggler_app/mainwindow.h
@@ -328,7 +328,7 @@ private slots:
 private:
   QStringList readAllCurvesFromXML(QDomElement root_node);
   void loadAllPlugins(QStringList command_line_plugin_folders);
-  void updateCurrentLoadedFilesLabel(const QList<QFileInfo>& files);
+  void updateCurrentLoadedFilesLabel(const QList<FileLoadInfo>& files);
 };
 
 class PopupMenu : public QMenu

--- a/plotjuggler_app/mainwindow.h
+++ b/plotjuggler_app/mainwindow.h
@@ -12,6 +12,7 @@
 #include <functional>
 
 #include <QCommandLineParser>
+#include <QFileInfo>
 #include <QElapsedTimer>
 #include <QMainWindow>
 #include <QSignalMapper>
@@ -327,6 +328,7 @@ private slots:
 private:
   QStringList readAllCurvesFromXML(QDomElement root_node);
   void loadAllPlugins(QStringList command_line_plugin_folders);
+  void updateCurrentLoadedFilesLabel(const QList<QFileInfo>& files);
 };
 
 class PopupMenu : public QMenu

--- a/plotjuggler_app/mainwindow.ui
+++ b/plotjuggler_app/mainwindow.ui
@@ -110,7 +110,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_5">
+            <widget class="QLabel" name="labelCurrentLoadedFiles">
              <property name="maximumSize">
               <size>
                <width>16777215</width>


### PR DESCRIPTION
## Current Behavior

When loading log files with parameters the file name is displayed in the parameter dialog. 

![ulog_parameters_dialog](https://github.com/user-attachments/assets/db81c968-eb86-4226-bdfe-ebf489b59bb7)

In the event that multiple files are loaded in at the same time, then each file is given its own root path to distinguish them. 

![time_series_directories](https://github.com/user-attachments/assets/89831203-f914-49c9-8c91-02b89ac86b88)

## Present Restrictions

CSV files do not have the parameter dialog, and as such there is no indicator to indicate which file is currently open when only a single file is loaded.

For files with many series available, the root paths are not necessarily visible. Consider these PX4 ULog files for an example, where there are multiple files loaded, but no immediately visible labels to indicate which ones.

As a result, when multiple instances of PlotJuggler is running at the same time it is unclear which instance has which file(s) loaded.

![time_series_ambiguous_series](https://github.com/user-attachments/assets/a950b5d4-847b-46a4-9163-7fc19efa3206)

The conventional way to do this in many applications is too rename the main window. However, to my understanding this would potentially interfere with skins, and may not be as practical when several files are open in the same instance.

## New QOL Feature

This PR repurposes the "File" label to show what file(s) are presently loaded in the current instance of PlotJuggler. In the event that multiple files are loaded, or the file path is too long, the label truncates the text. To cover this edge case, a tool-tip has been added to show the full list of all loaded files.

![FilesOpenLabelWithTooltip](https://github.com/user-attachments/assets/b16e3bcd-c8b5-495d-bb2f-23c201d5ad80)

### Testing
The PR has been built and tested on Windows 11 with vcpkg, as well as with Ubuntu 24.04 LTS in WSL using the docker container.

### Change Log Entry
* QOL: Show currently open file path(s) in *File* header.