### PR TITLE
Feature: StringsSeries allowed

### DIFF
--- a/plotjuggler_plugins/ToolboxCSV/toolbox_csv.cpp
+++ b/plotjuggler_plugins/ToolboxCSV/toolbox_csv.cpp
@@ -50,7 +50,7 @@ ToolboxCSV::ToolboxCSV()
     updateTimeRange();
   });
 
-  // Add all topics of the data
+  // Add all topics of the data (numeric + string series).
   connect(&_ui, &ToolBoxUI::addAllRequested, this, [this]() {
     if (!_plot_data)
     {
@@ -58,9 +58,13 @@ ToolboxCSV::ToolboxCSV()
     }
 
     std::vector<std::string> topics;
-    topics.reserve(_plot_data->numeric.size());
+    topics.reserve(_plot_data->numeric.size() + _plot_data->strings.size());
 
     for (const auto& [name, _] : _plot_data->numeric)
+    {
+      topics.push_back(name);
+    }
+    for (const auto& [name, _] : _plot_data->strings)
     {
       topics.push_back(name);
     }
@@ -107,7 +111,8 @@ bool ToolboxCSV::onShowWidget()
 
 bool ToolboxCSV::serializeTable(const ExportTable& table, const QString& path, bool is_csv)
 {
-  if (path.isEmpty() || table.time.empty() || table.cols.size() != table.names.size())
+  if (path.isEmpty() || table.time.empty() || table.cols.size() != table.names.size() ||
+      table.string_cols.size() != table.string_names.size())
   {
     return false;
   }
@@ -163,19 +168,36 @@ void ToolboxCSV::onExportMultipleFiles(bool is_csv, QDir dir, QString prefix)
 
   const QString ext = is_csv ? "csv" : "parquet";
 
-  // Group selected topics by their PlotGroup name.
+  // Group selected topics by their PlotGroup name (check numeric, then string).
   std::map<std::string, std::vector<std::string>> groups;
 
   for (const auto& topic_name : selected_topics)
   {
-    auto it = _plot_data->numeric.find(topic_name);
-    if (it == _plot_data->numeric.end())
+    std::string group_name = "ungrouped";
+
+    auto it_num = _plot_data->numeric.find(topic_name);
+    if (it_num != _plot_data->numeric.end())
     {
-      continue;
+      const auto& gp = it_num->second.group();
+      if (gp)
+      {
+        group_name = gp->name();
+      }
+    }
+    else
+    {
+      auto it_str = _plot_data->strings.find(topic_name);
+      if (it_str == _plot_data->strings.end())
+      {
+        continue;  // topic not found in either map
+      }
+      const auto& gp = it_str->second.group();
+      if (gp)
+      {
+        group_name = gp->name();
+      }
     }
 
-    const auto& group_ptr = it->second.group();
-    std::string group_name = group_ptr ? group_ptr->name() : "ungrouped";
     groups[group_name].push_back(topic_name);
   }
 
@@ -190,19 +212,23 @@ void ToolboxCSV::onExportMultipleFiles(bool is_csv, QDir dir, QString prefix)
     }
 
     // Strip group prefix from column names (e.g. "/robot/imu/accel" -> "accel").
-    for (auto& col_name : table.names)
-    {
-      if (col_name.size() > group_name.size() &&
-          col_name.compare(0, group_name.size(), group_name) == 0)
+    auto strip_prefix = [&group_name](std::vector<std::string>& names) {
+      for (auto& col_name : names)
       {
-        size_t start = group_name.size();
-        if (start < col_name.size() && col_name[start] == '/')
+        if (col_name.size() > group_name.size() &&
+            col_name.compare(0, group_name.size(), group_name) == 0)
         {
-          start++;
+          size_t start = group_name.size();
+          if (start < col_name.size() && col_name[start] == '/')
+          {
+            start++;
+          }
+          col_name.erase(0, start);
         }
-        col_name.erase(0, start);
       }
-    }
+    };
+    strip_prefix(table.names);
+    strip_prefix(table.string_names);
 
     // Sanitize group name for use in filename.
     QString safe_group = QString::fromStdString(group_name);
@@ -236,30 +262,15 @@ void ToolboxCSV::onClosed()
   emit closed();
 }
 
-// Compute global [tmin, tmax] across selected numeric topics.
+// Compute global [tmin, tmax] across selected topics (numeric + string).
 bool ToolboxCSV::getTimeRange(double& tmin, double& tmax) const
 {
   bool any = false;
 
   const auto topics = _ui.getSelectedTopics();
 
-  for (const auto& name : topics)
-  {
-    auto it = _plot_data->numeric.find(name);
-    if (it == _plot_data->numeric.end())
-    {
-      continue;
-    }
-
-    const auto& plot = it->second;
-    if (plot.size() == 0)
-    {
-      continue;
-    }
-
-    const double front_time = plot.front().x;
-    const double back_time = plot.back().x;
-
+  // Helper to update bounds from a single series.
+  auto update_bounds = [&](double front_time, double back_time) {
     if (!any)
     {
       tmin = front_time;
@@ -270,6 +281,24 @@ bool ToolboxCSV::getTimeRange(double& tmin, double& tmax) const
     {
       tmin = std::min(tmin, front_time);
       tmax = std::max(tmax, back_time);
+    }
+  };
+
+  for (const auto& name : topics)
+  {
+    // Check numeric series.
+    auto it_num = _plot_data->numeric.find(name);
+    if (it_num != _plot_data->numeric.end() && it_num->second.size() > 0)
+    {
+      update_bounds(it_num->second.front().x, it_num->second.back().x);
+      continue;
+    }
+
+    // Check string series.
+    auto it_str = _plot_data->strings.find(name);
+    if (it_str != _plot_data->strings.end() && it_str->second.size() > 0)
+    {
+      update_bounds(it_str->second.front().x, it_str->second.back().x);
     }
   }
 
@@ -295,7 +324,8 @@ void ToolboxCSV::updateTimeRange()
 }
 
 // Estimate local minimum dt to derive adaptive merge tolerance.
-double ToolboxCSV::estimateMinDt(const PJ::PlotData& plot, size_t start_idx, double t_end)
+template <typename TSeries>
+double ToolboxCSV::estimateMinDt(const TSeries& plot, size_t start_idx, double t_end)
 {
   if (plot.size() < 2 || start_idx + 1 >= plot.size())
   {
@@ -327,6 +357,10 @@ double ToolboxCSV::estimateMinDt(const PJ::PlotData& plot, size_t start_idx, dou
   return min_dt;
 }
 
+template double ToolboxCSV::estimateMinDt<PJ::PlotData>(const PJ::PlotData&, size_t, double);
+template double ToolboxCSV::estimateMinDt<PJ::StringSeries>(const PJ::StringSeries&, size_t,
+                                                            double);
+
 // Merge multiple time series into a row-aligned table using adaptive tolerance.
 ToolboxCSV::ExportTable ToolboxCSV::buildExportTable(const std::vector<std::string>& topics,
                                                      double t_start, double t_end) const
@@ -341,6 +375,14 @@ ToolboxCSV::ExportTable ToolboxCSV::buildExportTable(const std::vector<std::stri
     size_t idx;
   };
 
+  struct StringSeriesRef
+  {
+    std::string name;
+    const PJ::StringSeries* plot;
+    size_t idx;
+  };
+
+  // Collect numeric series.
   std::vector<SeriesRef> series;
   series.reserve(topics.size());
 
@@ -367,16 +409,50 @@ ToolboxCSV::ExportTable ToolboxCSV::buildExportTable(const std::vector<std::stri
     series.push_back({ name, &plot, static_cast<size_t>(index) });
   }
 
-  if (series.empty())
+  // Collect string series.
+  std::vector<StringSeriesRef> str_series;
+
+  for (const auto& name : topics)
+  {
+    auto it = _plot_data->strings.find(name);
+    if (it == _plot_data->strings.end())
+    {
+      continue;
+    }
+
+    const auto& plot = it->second;
+    if (plot.size() == 0 || plot.front().x > t_end || plot.back().x < t_start)
+    {
+      continue;
+    }
+
+    int index = plot.getIndexFromX(t_start);
+    if (index < 0)
+    {
+      continue;
+    }
+
+    str_series.push_back({ name, &plot, static_cast<size_t>(index) });
+  }
+
+  if (series.empty() && str_series.empty())
   {
     return table;
   }
 
-  // Compute tolerance from the minimum observed sample period.
+  // Compute tolerance from the minimum observed sample period across both types.
   double min_dt = 0.0;
   {
     double best = std::numeric_limits<double>::max();
     for (const auto& sr : series)
+    {
+      double dt = estimateMinDt(*sr.plot, sr.idx, t_end);
+      if (dt > 0.0 && dt < best)
+      {
+        best = dt;
+      }
+    }
+    for (const auto& sr : str_series)
     {
       double dt = estimateMinDt(*sr.plot, sr.idx, t_end);
       if (dt > 0.0 && dt < best)
@@ -394,6 +470,9 @@ ToolboxCSV::ExportTable ToolboxCSV::buildExportTable(const std::vector<std::stri
   const double tol = (min_dt > 0.0) ? (0.5 * min_dt) : 0.0;
 
   const size_t N = series.size();
+  const size_t S = str_series.size();
+
+  // Initialize numeric columns.
   table.names.reserve(N);
   table.cols.assign(N, {});
   table.has_value.assign(N, {});
@@ -402,15 +481,25 @@ ToolboxCSV::ExportTable ToolboxCSV::buildExportTable(const std::vector<std::stri
     table.names.push_back(sr.name);
   }
 
+  // Initialize string columns.
+  table.string_names.reserve(S);
+  table.string_cols.assign(S, {});
+  table.string_has_value.assign(S, {});
+  for (const auto& sr : str_series)
+  {
+    table.string_names.push_back(sr.name);
+  }
+
   const auto NaN = std::numeric_limits<double>::quiet_NaN();
   std::vector<double> row_values(N, NaN);
-
-  // Track sample presence separately from numeric value (handles NaN correctly).
   std::vector<bool> row_used(N, false);
+
+  std::vector<std::string> str_row_values(S);
+  std::vector<bool> str_row_used(S, false);
 
   while (true)
   {
-    // Find next row time as the minimum current timestamp among series.
+    // Find next row time as the minimum current timestamp among all series.
     bool done = true;
     double min_time = std::numeric_limits<double>::max();
 
@@ -435,15 +524,38 @@ ToolboxCSV::ExportTable ToolboxCSV::buildExportTable(const std::vector<std::stri
       }
     }
 
+    for (size_t col = 0; col < S; col++)
+    {
+      auto& sr = str_series[col];
+      if (sr.idx >= sr.plot->size())
+      {
+        continue;
+      }
+
+      const auto& point = sr.plot->at(sr.idx);
+      if (point.x > t_end)
+      {
+        continue;
+      }
+
+      done = false;
+      if (point.x < min_time)
+      {
+        min_time = point.x;
+      }
+    }
+
     if (done || min_time > t_end)
     {
       break;
     }
 
+    // Reset row buffers.
     std::fill(row_values.begin(), row_values.end(), NaN);
     std::fill(row_used.begin(), row_used.end(), false);
+    std::fill(str_row_used.begin(), str_row_used.end(), false);
 
-    // Fill values for this row (within tolerance), then advance only the series that contributed.
+    // Fill numeric values within tolerance.
     for (size_t col = 0; col < N; col++)
     {
       auto& sr = series[col];
@@ -458,25 +570,42 @@ ToolboxCSV::ExportTable ToolboxCSV::buildExportTable(const std::vector<std::stri
         continue;
       }
 
-      if (tol == 0.0)
+      const bool match =
+          (tol == 0.0) ? (point.x == min_time) : (std::abs(point.x - min_time) <= tol);
+      if (match)
       {
-        if (point.x == min_time)
-        {
-          row_values[col] = point.y;
-          row_used[col] = true;
-        }
-      }
-      else
-      {
-        if (std::abs(point.x - min_time) <= tol)
-        {
-          row_values[col] = point.y;
-          row_used[col] = true;
-        }
+        row_values[col] = point.y;
+        row_used[col] = true;
       }
     }
 
+    // Fill string values within tolerance.
+    for (size_t col = 0; col < S; col++)
+    {
+      auto& sr = str_series[col];
+      if (sr.idx >= sr.plot->size())
+      {
+        continue;
+      }
+
+      const auto& point = sr.plot->at(sr.idx);
+      if (point.x > t_end)
+      {
+        continue;
+      }
+
+      const bool match =
+          (tol == 0.0) ? (point.x == min_time) : (std::abs(point.x - min_time) <= tol);
+      if (match)
+      {
+        str_row_values[col] = std::string(sr.plot->getString(point.y));
+        str_row_used[col] = true;
+      }
+    }
+
+    // Append row to table.
     table.time.push_back(min_time);
+
     for (size_t col = 0; col < N; col++)
     {
       table.cols[col].push_back(row_values[col]);
@@ -486,13 +615,23 @@ ToolboxCSV::ExportTable ToolboxCSV::buildExportTable(const std::vector<std::stri
         series[col].idx++;
       }
     }
+
+    for (size_t col = 0; col < S; col++)
+    {
+      table.string_cols[col].push_back(str_row_used[col] ? str_row_values[col] : std::string());
+      table.string_has_value[col].push_back(str_row_used[col] ? 1 : 0);
+      if (str_row_used[col])
+      {
+        str_series[col].idx++;
+      }
+    }
   }
 
   return table;
 }
 
 // Serialize ExportTable to a plain CSV file.
-// Layout: first column "time", followed by one column per topic.
+// Layout: first column "time", then numeric columns, then string columns.
 bool ToolboxCSV::serializeCSV(const ToolboxCSV::ExportTable& export_table, const QString& path)
 {
   QFile file(path);
@@ -504,8 +643,13 @@ bool ToolboxCSV::serializeCSV(const ToolboxCSV::ExportTable& export_table, const
   QTextStream out(&file);
   out.setCodec("UTF-8");
 
+  // Header: time, numeric columns, string columns.
   out << "time";
   for (const auto& col_name : export_table.names)
+  {
+    out << "," << QString::fromStdString(col_name);
+  }
+  for (const auto& col_name : export_table.string_names)
   {
     out << "," << QString::fromStdString(col_name);
   }
@@ -516,11 +660,13 @@ bool ToolboxCSV::serializeCSV(const ToolboxCSV::ExportTable& export_table, const
 
   const int num_rows = static_cast<int>(export_table.time.size());
   const int num_cols = static_cast<int>(export_table.names.size());
+  const int num_str_cols = static_cast<int>(export_table.string_names.size());
 
   for (int row = 0; row < num_rows; row++)
   {
     out << QString::number(export_table.time[row], 'f', time_decimals);
 
+    // Numeric columns.
     for (int col = 0; col < num_cols; col++)
     {
       out << ",";
@@ -545,6 +691,27 @@ bool ToolboxCSV::serializeCSV(const ToolboxCSV::ExportTable& export_table, const
         }
       }
     }
+
+    // String columns with RFC 4180 quoting.
+    for (int col = 0; col < num_str_cols; col++)
+    {
+      out << ",";
+      if (export_table.string_has_value[col][row] != 0)
+      {
+        const QString val = QString::fromStdString(export_table.string_cols[col][row]);
+        if (val.contains(',') || val.contains('"') || val.contains('\n') || val.contains('\r'))
+        {
+          QString escaped = val;
+          escaped.replace('"', "\"\"");
+          out << '"' << escaped << '"';
+        }
+        else
+        {
+          out << val;
+        }
+      }
+    }
+
     out << "\n";
   }
 
@@ -582,8 +749,35 @@ makeDoubleArray(const std::vector<double>& values, const std::vector<uint8_t>& p
   return arr;
 }
 
+// Build an Arrow UTF-8 string array. NULL represents missing sample.
+static arrow::Result<std::shared_ptr<arrow::Array>>
+makeStringArray(const std::vector<std::string>& values, const std::vector<uint8_t>& present)
+{
+  arrow::StringBuilder builder;
+  ARROW_RETURN_NOT_OK(builder.Reserve(static_cast<int64_t>(values.size())));
+
+  if (present.size() != values.size())
+  {
+    return arrow::Status::Invalid("size mismatch");
+  }
+
+  for (size_t idx = 0; idx < values.size(); idx++)
+  {
+    if (!present[idx])
+    {
+      ARROW_RETURN_NOT_OK(builder.AppendNull());
+      continue;
+    }
+    ARROW_RETURN_NOT_OK(builder.Append(values[idx]));
+  }
+
+  std::shared_ptr<arrow::Array> arr;
+  ARROW_RETURN_NOT_OK(builder.Finish(&arr));
+  return arr;
+}
+
 // Serialize the merged ExportTable to a Parquet file using Arrow.
-// Each column is stored as Float64.
+// Numeric columns as Float64, string columns as UTF-8.
 bool ToolboxCSV::serializeParquet(const ToolboxCSV::ExportTable& export_table, const QString& path)
 {
   std::vector<std::shared_ptr<arrow::Field>> fields;
@@ -603,6 +797,19 @@ bool ToolboxCSV::serializeParquet(const ToolboxCSV::ExportTable& export_table, c
   {
     fields.push_back(arrow::field(export_table.names[col], arrow::float64()));
     auto arr_res = makeDoubleArray(export_table.cols[col], export_table.has_value[col]);
+    if (!arr_res.ok())
+    {
+      return false;
+    }
+    arrays.push_back(*arr_res);
+  }
+
+  // String columns as UTF-8.
+  for (size_t col = 0; col < export_table.string_names.size(); col++)
+  {
+    fields.push_back(arrow::field(export_table.string_names[col], arrow::utf8()));
+    auto arr_res =
+        makeStringArray(export_table.string_cols[col], export_table.string_has_value[col]);
     if (!arr_res.ok())
     {
       return false;

--- a/plotjuggler_plugins/ToolboxCSV/toolbox_csv.h
+++ b/plotjuggler_plugins/ToolboxCSV/toolbox_csv.h
@@ -6,6 +6,7 @@
 #include <QtPlugin>
 #include "PlotJuggler/toolbox_base.h"
 #include "PlotJuggler/plotwidget_base.h"
+#include "PlotJuggler/stringseries.h"
 #include "toolbox_ui.h"
 
 // Toolbox plugin to export selected PlotJuggler topics to CSV (extensible to other formats)
@@ -55,17 +56,24 @@ private:
 
   void updateTimeRange();
 
-  // Generic table representation for exporters (time + N columns)
+  // Generic table representation for exporters (time + N numeric + S string columns)
   struct ExportTable
   {
+    // Numeric columns
     std::vector<std::string> names;               // column names
-    std::vector<double> time;                     // time axis
+    std::vector<double> time;                     // shared time axis
     std::vector<std::vector<double>> cols;        // per-topic values
-    std::vector<std::vector<uint8_t>> has_value;  // Values checker
+    std::vector<std::vector<uint8_t>> has_value;  // presence flags
+
+    // String columns (parallel structure, same time axis)
+    std::vector<std::string> string_names;
+    std::vector<std::vector<std::string>> string_cols;
+    std::vector<std::vector<uint8_t>> string_has_value;
   };
 
-  // Tolerance helper
-  static double estimateMinDt(const PJ::PlotData& plot, size_t start_idx, double t_end);
+  // Tolerance helper (works with PlotData and StringSeries — both have .size() and .at().x)
+  template <typename TSeries>
+  static double estimateMinDt(const TSeries& plot, size_t start_idx, double t_end);
 
   // Build a time-aligned export table from selected topics
   ExportTable buildExportTable(const std::vector<std::string>& topics, double t_start,


### PR DESCRIPTION
## Summary                                                      

  Extends the ToolboxCSV plugin to export string series (`_plot_data->strings`)                                                                               
  alongside numeric data.
                                                                                                                                                              
  ### Changes                                                     
  - **ExportTable** — new parallel fields: `string_names`, `string_cols`,                                                                                     
    `string_has_value` (same time axis as numeric)                                                                                                            
  - **buildExportTable()** — merge loop scans both numeric and string series for
    min-time, fills each side independently within adaptive tolerance                                                                                         
  - **estimateMinDt()** — templated to work with both `PlotData` and `StringSeries`                                                                           
  - **serializeCSV()** — string columns appended after numeric, with RFC 4180 quoting                                                                         
    (commas, quotes, newlines)                                                                                                                                
  - **serializeParquet()** — new `makeStringArray` helper using `arrow::StringBuilder`,                                                                       
    string columns as `arrow::utf8()`                                                                                                                         
  - **"Add All"** — now includes string series                    
  - **getTimeRange()** — scans both maps for time bounds                                                                                                      
  - **onExportMultipleFiles()** — group lookup falls back to `_plot_data->strings`,                                                                           
    prefix stripping applied to string column names                                                                                                           