### PR TITLE
Title: Fix CSV loading issues (#850, #987, #1000)

### DIFF
--- a/3rdparty/sol2-3.5.0/include/sol/sol.hpp
+++ b/3rdparty/sol2-3.5.0/include/sol/sol.hpp
@@ -3632,11 +3632,11 @@ COMPAT53_API void luaL_requiref(lua_State *L, const char *modname,
 #endif /* Lua 5.2 only */
 
 /* other Lua versions */
-#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 504
+#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 505
 
-#  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, 5.3, or 5.4)"
+#  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, 5.3, 5.4, or 5.5)"
 
-#endif /* other Lua versions except 5.1, 5.2, 5.3, and 5.4 */
+#endif /* other Lua versions except 5.1, 5.2, 5.3, 5.4, and 5.5 */
 
 /* helper macro for defining continuation functions (for every version
 * *except* Lua 5.2) */
@@ -4522,16 +4522,16 @@ extern "C" {
 }
 #endif
 
-#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM == 504
+#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM >= 504
 
 #if !defined(LUA_ERRGCMM)
-/* So Lua 5.4 actually removes this, which breaks sol2...
+/* So Lua 5.4 or later actually removes this, which breaks sol2...
  man, this API is quite unstable...!
 */
 #  define LUA_ERRGCMM (LUA_ERRERR + 2)
 #endif /* LUA_ERRGCMM define */
 
-#endif // Lua 5.4 only
+#endif // Lua 5.4 or later
 
 #endif // NOT_KEPLER_PROJECT_COMPAT54_H_// end of sol/compatibility/compat-5.4.h
 
@@ -28587,6 +28587,14 @@ namespace sol {
 
 // end of sol/thread.hpp
 
+inline lua_State* sol_lua_newstate(lua_Alloc f, void* ud, [[maybe_unused]] unsigned seed = 0) {
+#if LUA_VERSION_NUM >= 505
+	return ::lua_newstate(f, ud, seed);
+#else
+	return ::lua_newstate(f, ud);
+#endif
+}
+
 namespace sol {
 
 	class state : private std::unique_ptr<lua_State, detail::state_deleter>, public state_view {
@@ -28599,7 +28607,7 @@ namespace sol {
 		}
 
 		state(lua_CFunction panic, lua_Alloc alfunc, void* alpointer = nullptr)
-		: unique_base(lua_newstate(alfunc, alpointer)), state_view(unique_base::get()) {
+		: unique_base(sol_lua_newstate(alfunc, alpointer)), state_view(unique_base::get()) {
 			set_default_state(unique_base::get(), panic);
 		}
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -12,10 +12,10 @@ Snapshot of the 156 open GitHub issues (as of 2026-04-15) mapped against commits
 |---|---:|---:|---:|
 | Obsolete / should be closed | 10 | 0 | 10 |
 | Questions / user support | 10 | 0 | 10 |
-| Plugin bugs | 49 | **21** | 28 |
+| Plugin bugs | 49 | **22** | 27 |
 | Core app | 32 | 12 | 20 |
 | Feature requests | 51 | 2 | 49 |
-| **Total** | **156** | **35** | **121** |
+| **Total** | **156** | **36** | **120** |
 
 ## Per-plugin scoreboard
 
@@ -27,7 +27,7 @@ Snapshot of the 156 open GitHub issues (as of 2026-04-15) mapped against commits
 | **Lua / Scripting** | 4 | **4** | **0** |
 | **Parquet** (DataLoadParquet) | 2 | **2** | **0** |
 | MQTT (DataStreamMQTT) | 3 | 0 | 3 |
-| ZMQ (DataStreamZMQ, StatePublisherZMQ) | 3 | **1** | 2 |
+| ZMQ (DataStreamZMQ, StatePublisherZMQ) | 3 | **2** | 1 |
 | ULog (DataLoadULog) | 2 | 0 | 2 |
 | Protobuf (ParserProtobuf) | 1 | 0 | 1 |
 | **UDP** (DataStreamUDP) | 1 | **1** | **0** |
@@ -87,11 +87,12 @@ Snapshot of the 156 open GitHub issues (as of 2026-04-15) mapped against commits
 | #968 | Misalignment in time series due to differing sizes with reactive scripts | `8d9c2afb` — `reactive_function.{h,cpp}`: `TimeseriesRef::atTime(t)` silently returns the clamped endpoint value when `t` falls outside the series' recorded range (because `getIndexFromX` in `timeseries.h:152-175` clamps to `size()-1`/`0`). Feb 2026 storage refactor (`48497feb`, `9493434e`) did not change that semantics. Fix exposes `getIndexAtTime(t)` on `TimeseriesRef` so reactive-script Lua (the ToolboxLuaEditor / `ReactiveLuaFunction` context) can compare the retrieved sample's `x` against the query time and detect out-of-range clamping. **Scope note**: applies only to reactive scripts, **not** to Lua custom functions (`LuaCustomFunction` has its own `_lua_engine` with no `TimeseriesRef` binding; its scripts receive pre-computed positional args from the C++ host and share the same clamping bug at `python_custom_function.cpp:483,490` and the equivalent in `lua_custom_function.cpp`). Fixing that second surface requires a host-level range check — deliberately out of scope here since no user has reported it. Purely additive; matches `firemark`'s suggestion on the closed PR #969. Fork-only for now (not sent upstream). |
 | #800 | Crash caused by reactive script errors | `bdf39ec9` — `reactive_function.{h,cpp}`: `ReactiveLuaFunction::calculate()` showed a modal `QMessageBox::warning` for every failure (line present and untouched since 2022-07-25, `af4f9d115`); under streaming sources (UDP 20-100 Hz) a script that errors every tick piled dialogs faster than the user could dismiss them, exhausting Qt USER32 handles on Windows and crashing PJ. Fix adds a `_disabled_after_error` flag set **before** the modal `QMessageBox::warning` is shown (so re-entrant streaming timer firings during the nested modal event loop see the flag and short-circuit, instead of queueing more dialogs). Script is auto re-enabled on save via the existing editor lifecycle (`lua_editor.cpp:271` constructs a fresh `ReactiveLuaFunction` on every save — new instance → default flag), so no explicit resume API was needed. Scope: reactive scripts only; CustomFunction streaming-path errors go to stderr via `qWarning`, no dialog, no parallel spam pathology. |
 
-### Plugin bugs — ZMQ (1 / 3 — upstream already merged)
+### Plugin bugs — ZMQ (2 / 3)
 
 | # | Title | Evidence |
 |---|---|---|
 | #705 | ZeroMQ Subscriber filter | **COMPLETED — fixed upstream by PR #730 (`db90f70a ZMQ: Add topics filtering`, merged 2022-12-18).** Already on `plugin_issues` (and `main`). Adds semicolon/comma/whitespace-separated topic-filter parsing in `datastream_zmq.cpp:355-372` (`parseTopicFilters`), plus a test publisher at `plotjuggler_plugins/DataStreamZMQ/utilities/start_test_publisher.py`. Safe administrative close — Davide merged this himself. |
+| #941 | Extraneous suffixes added to ZMQ IPC endpoints | **COMPLETED** — `752e1773` *"datastream_zmq: drop bogus `:port` suffix on ipc:// endpoints"*. The socket-address assembly at `datastream_zmq.cpp:153` always concatenated `<protocol><address>:<port>`, which is correct for `tcp://` but corrupted `ipc://` endpoints (IPC uses filesystem paths, no port). Fix guards the `:port` suffix on protocol and disables the port field in the dialog when `ipc://` is selected so the user can't enter a value that would be silently ignored. **Manually verified on 2026-04-21** with a pyzmq PUB on both `tcp://*:9872` and `ipc:///tmp/pj_zmq_test` against PlotJuggler's ZMQ Subscriber — both paths plot as expected; IPC case no longer appends `:9872`. Two sibling bugs are intentionally left in-tree (separate tickets if re-reported): `radioBind` toggle forces `"0.0.0.0"` (TCP-specific), and the default stored address is `"localhost"` (also TCP-centric). Fork-only for now (not yet sent upstream). |
 
 ### Plugin bugs — UDP (1 / 1 — administrative close, not worth fixing)
 
@@ -154,12 +155,11 @@ All four Lua / Scripting issues are marked fixed.
 | #876 | MQTT connection creating malformed packets | ⏳ |
 | #747 | MQTT streamer only subscribes to single topic | ⏳ |
 
-### Plugin bugs — ZMQ (2 waiting of 3)
+### Plugin bugs — ZMQ (1 waiting of 3)
 
 | # | Title | Status |
 |---|---|---|
 | #1126 | ZMQ Subscriber lacks option to specify Protobuf Paths | ⏳ |
-| #941 | Extraneous suffixes added to ZMQ IPC endpoints | ⏳ |
 
 ### Plugin bugs — Parquet (0 waiting of 2) ✅
 All two Parquet-category issues are marked fixed.
@@ -219,9 +219,9 @@ Waiting (in issue-number order):
 
 ## Next up — Parquet plugin complete
 
-Plugin-category progress: `#863` by the new BYTE_ARRAY → StringSeries path in `dataload_parquet.cpp` (plus the earlier `900557e0` TIMESTAMP fix), `#862` by administrative close citing commit `00b94253`'s Conan/Arrow Windows CI work, `#839` (UDP layout-persistence) closed administratively as systemic-not-UDP-specific, and `#705` (ZMQ topic filter) closed administratively via upstream PR #730 / `db90f70a`. Four plugin categories fully closed — **CSV (8/8)**, **MCAP (5/5)**, **Lua (4/4)**, **Parquet (2/2)** — plus UDP (1/1 administrative) and partial ZMQ (1/3 so far). **21 plugin issues closed of 49 total.**
+Plugin-category progress: `#863` by the new BYTE_ARRAY → StringSeries path in `dataload_parquet.cpp` (plus the earlier `900557e0` TIMESTAMP fix), `#862` by administrative close citing commit `00b94253`'s Conan/Arrow Windows CI work, `#839` (UDP layout-persistence) closed administratively as systemic-not-UDP-specific, `#705` (ZMQ topic filter) closed administratively via upstream PR #730 / `db90f70a`, and `#941` (ZMQ IPC `:port` suffix) fixed by `752e1773`. Four plugin categories fully closed — **CSV (8/8)**, **MCAP (5/5)**, **Lua (4/4)**, **Parquet (2/2)** — plus UDP (1/1 administrative) and ZMQ (2/3 — only `#1126` Protobuf-paths left). **22 plugin issues closed of 49 total.**
 
-Remaining plugin categories (28 waiting): ROS/ROS2 (18), MQTT (3), ZMQ (2), ULog (2), Protobuf / FFT / Quaternion (1 each).
+Remaining plugin categories (27 waiting): ROS/ROS2 (18), MQTT (3), ULog (2), ZMQ (1), Protobuf / FFT / Quaternion (1 each).
 
 ### Suggested next target
 - **#537** (ROS/ROS2, rosout dark-theme invisible debug messages): tiniest scope, pure stylesheet. Good warm-up.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -12,10 +12,10 @@ Snapshot of the 156 open GitHub issues (as of 2026-04-15) mapped against commits
 |---|---:|---:|---:|
 | Obsolete / should be closed | 10 | 0 | 10 |
 | Questions / user support | 10 | 0 | 10 |
-| Plugin bugs | 49 | **19** | 30 |
+| Plugin bugs | 49 | **20** | 29 |
 | Core app | 32 | 12 | 20 |
 | Feature requests | 51 | 2 | 49 |
-| **Total** | **156** | **33** | **123** |
+| **Total** | **156** | **34** | **122** |
 
 ## Per-plugin scoreboard
 
@@ -30,7 +30,7 @@ Snapshot of the 156 open GitHub issues (as of 2026-04-15) mapped against commits
 | ZMQ (DataStreamZMQ, StatePublisherZMQ) | 3 | 0 | 3 |
 | ULog (DataLoadULog) | 2 | 0 | 2 |
 | Protobuf (ParserProtobuf) | 1 | 0 | 1 |
-| UDP (DataStreamUDP) | 1 | 0 | 1 |
+| **UDP** (DataStreamUDP) | 1 | **1** | **0** |
 | FFT (ToolboxFFT) | 1 | 0 | 1 |
 | Quaternion (ToolboxQuaternion) | 1 | 0 | 1 |
 
@@ -86,6 +86,12 @@ Snapshot of the 156 open GitHub issues (as of 2026-04-15) mapped against commits
 | #1312 | New Lua version breaks `quat_to_yaw` / `quat_to_roll` | `ae78a30b` — `default.snippets.xml`: PR #1164 had swapped `math.atan(y, x)` for `math.atan2(y, x)` to support Lua 5.1/5.2, but `math.atan2` was removed in Lua 5.4, so the snippets broke on the default bundled 5.4.7. Fix adds `local atan2 = math.atan2 or math.atan` at the top of both snippets so the correct name is picked at load time across Lua 5.1–5.5. `quat_to_pitch` uses `math.asin` and was unaffected. |
 | #968 | Misalignment in time series due to differing sizes with reactive scripts | `8d9c2afb` — `reactive_function.{h,cpp}`: `TimeseriesRef::atTime(t)` silently returns the clamped endpoint value when `t` falls outside the series' recorded range (because `getIndexFromX` in `timeseries.h:152-175` clamps to `size()-1`/`0`). Feb 2026 storage refactor (`48497feb`, `9493434e`) did not change that semantics. Fix exposes `getIndexAtTime(t)` on `TimeseriesRef` so reactive-script Lua (the ToolboxLuaEditor / `ReactiveLuaFunction` context) can compare the retrieved sample's `x` against the query time and detect out-of-range clamping. **Scope note**: applies only to reactive scripts, **not** to Lua custom functions (`LuaCustomFunction` has its own `_lua_engine` with no `TimeseriesRef` binding; its scripts receive pre-computed positional args from the C++ host and share the same clamping bug at `python_custom_function.cpp:483,490` and the equivalent in `lua_custom_function.cpp`). Fixing that second surface requires a host-level range check — deliberately out of scope here since no user has reported it. Purely additive; matches `firemark`'s suggestion on the closed PR #969. Fork-only for now (not sent upstream). |
 | #800 | Crash caused by reactive script errors | `bdf39ec9` — `reactive_function.{h,cpp}`: `ReactiveLuaFunction::calculate()` showed a modal `QMessageBox::warning` for every failure (line present and untouched since 2022-07-25, `af4f9d115`); under streaming sources (UDP 20-100 Hz) a script that errors every tick piled dialogs faster than the user could dismiss them, exhausting Qt USER32 handles on Windows and crashing PJ. Fix adds a `_disabled_after_error` flag set **before** the modal `QMessageBox::warning` is shown (so re-entrant streaming timer firings during the nested modal event loop see the flag and short-circuit, instead of queueing more dialogs). Script is auto re-enabled on save via the existing editor lifecycle (`lua_editor.cpp:271` constructs a fresh `ReactiveLuaFunction` on every save — new instance → default flag), so no explicit resume API was needed. Scope: reactive scripts only; CustomFunction streaming-path errors go to stderr via `qWarning`, no dialog, no parallel spam pathology. |
+
+### Plugin bugs — UDP (1 / 1 — administrative close, not worth fixing)
+
+| # | Title | Evidence |
+|---|---|---|
+| #839 | UDP JSON stream timestamp setting not saved with layout | **Administrative close — no code. No sense fixing it in isolation.** The reported symptom is one face of a design shared by all five "simple" streamers (`DataStreamUDP`, `DataStreamMQTT`, `DataStreamZMQ`, `DataStreamWebsocket`, `DataStreamSerialPort`): none override `xmlSaveState` / `xmlLoadState`, all rely on `QSettings` for cross-run memory. The complex bridges (`DataStreamFoxgloveBridge`, `DataStreamPlotJugglerBridge`, `PluginsZcm`) and every DataLoader (Parquet, CSV, ULog, MCAP, Zcm) *do* persist state to the layout XML. Fixing UDP alone would desync one plugin from its four siblings without solving the reporter's underlying workflow; broadening to all five is refactor scope out-of-bounds for a single ticket. Reopen if the reporter describes a concrete use-case that `QSettings` defaults cannot satisfy, or if layout-persistence is rebuilt as a base-class feature on `PJ::DataStreamer`. |
 
 ### Plugin bugs — Parquet (2 / 2 — category complete)
 
@@ -160,12 +166,11 @@ All two Parquet-category issues are marked fixed.
 | #796 | Multiple improvements to PX4 plugin needed | ⏳ |
 | #672 | Cannot load large ULog file (2.5 GB) | ⏳ |
 
-### Plugin bugs — single-issue plugins (4)
+### Plugin bugs — single-issue plugins (3)
 
 | # | Plugin | Title | Status |
 |---|---|---|---|
 | #1144 | ParserProtobuf | Parse multiple protobuf message types simultaneously | ⏳ |
-| #839 | DataStreamUDP | UDP JSON stream timestamp setting not saved with layout | ⏳ |
 | #741 | ToolboxFFT | FFT Y-scaling not working | ⏳ |
 | #1243 | ToolboxQuaternion | Add Quaternion-to-RPY autofill for PX4 | ⏳ |
 
@@ -209,14 +214,16 @@ Waiting (in issue-number order):
 
 ## Next up — Parquet plugin complete
 
-Both Parquet-category issues are resolved: `#863` by the new BYTE_ARRAY → StringSeries path in `dataload_parquet.cpp` (plus the earlier `900557e0` TIMESTAMP fix), `#862` by administrative close citing commit `00b94253`'s Conan/Arrow Windows CI work. Four plugin categories are now fully closed: **CSV (8/8)**, **MCAP (5/5)**, **Lua (4/4)**, **Parquet (2/2)** — 19 plugin issues closed of 49 total.
+Plugin-category progress: `#863` by the new BYTE_ARRAY → StringSeries path in `dataload_parquet.cpp` (plus the earlier `900557e0` TIMESTAMP fix), `#862` by administrative close citing commit `00b94253`'s Conan/Arrow Windows CI work, and `#839` (UDP layout-persistence) closed administratively as systemic-not-UDP-specific. Four plugin categories are fully closed — **CSV (8/8)**, **MCAP (5/5)**, **Lua (4/4)**, **Parquet (2/2)** — plus UDP (1/1 via administrative close). **20 plugin issues closed of 49 total.**
 
-Remaining plugin categories (30 waiting): ROS/ROS2 (18), MQTT (3), ZMQ (3), ULog (2), Protobuf / UDP / FFT / Quaternion (1 each).
+Remaining plugin categories (29 waiting): ROS/ROS2 (18), MQTT (3), ZMQ (3), ULog (2), Protobuf / FFT / Quaternion (1 each).
 
 ### Suggested next target
-- **ULog (2)**: `#672` (cannot load 2.5 GB file) and `#796` (multiple PX4 improvements). `#796` is broad — likely needs splitting. `#672` is a concrete perf/memory ticket; worth a skim of `DataLoadULog` to see whether the parser streams or loads everything into RAM.
-- **Single-issue plugins (4 — Protobuf / UDP / FFT / Quaternion)**: any of these could be closable in one sitting. `#1243` (ToolboxQuaternion PX4 autofill) and `#741` (FFT Y-scaling) look like the tightest scope.
-- **ROS/ROS2 (18)**: the biggest pole and longest tail. Start with a clustering pass: `#477 / #759 / #860` all in the ROS2 Re-Publisher, `#1204 / #1262` about ROS2 Header quirks — duplicates inside those clusters may drop the effective count to ~14.
+- **#537** (ROS/ROS2, rosout dark-theme invisible debug messages): tiniest scope, pure stylesheet. Good warm-up.
+- **#741** (ToolboxFFT Y-scaling): bounded inside one toolbox.
+- **#991** (DataLoad ROS bags `map::at`): probably a missing `.count()` guard.
+- **ROS/ROS2 clustering pass**: `#477 / #759 / #860` all in the ROS2 Re-Publisher, `#1204 / #1262` about ROS2 Header quirks — duplicates inside those clusters may drop the effective count to ~14.
+- **ULog (2)**: `#672` (2.5 GB file) + `#796` (PX4 improvements meta-ticket). Upstream has an experimental rewrite on `test/ulog-parser-unit-tests` (`bde0ede5`, `DataLoadULog2` using `ulog_cpp`) that would likely close both — but it's not merged. Watch-and-wait.
 
 ---
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,229 @@
+# PlotJuggler — Issue Tracking
+
+Snapshot of the 156 open GitHub issues (as of 2026-04-15) mapped against commits reachable from branch `plugin_issues`.
+
+- **Source list:** `~/Downloads/github_issues_summary.md` (156 issues)
+- **Branch under review:** `plugin_issues` (includes merged `upstream/main` and cherry-picked `Feature: StringsSeries allowed`)
+- **Last updated:** 2026-04-21
+
+## Totals
+
+| Category | Open | ✅ Fixed | ⏳ Waiting |
+|---|---:|---:|---:|
+| Obsolete / should be closed | 10 | 0 | 10 |
+| Questions / user support | 10 | 0 | 10 |
+| Plugin bugs | 49 | **19** | 30 |
+| Core app | 32 | 12 | 20 |
+| Feature requests | 51 | 2 | 49 |
+| **Total** | **156** | **33** | **123** |
+
+## Per-plugin scoreboard
+
+| Plugin | Open | ✅ | ⏳ |
+|---|---:|---:|---:|
+| **CSV** (DataLoad + Toolbox + StatePublisher) | 8 | **8** | **0** |
+| ROS / ROS2 (ParserROS, DataLoad/Stream) | 18 | 0 | 18 |
+| MCAP (DataLoadMCAP) | 5 | **5** | **0** |
+| **Lua / Scripting** | 4 | **4** | **0** |
+| **Parquet** (DataLoadParquet) | 2 | **2** | **0** |
+| MQTT (DataStreamMQTT) | 3 | 0 | 3 |
+| ZMQ (DataStreamZMQ, StatePublisherZMQ) | 3 | 0 | 3 |
+| ULog (DataLoadULog) | 2 | 0 | 2 |
+| Protobuf (ParserProtobuf) | 1 | 0 | 1 |
+| UDP (DataStreamUDP) | 1 | 0 | 1 |
+| FFT (ToolboxFFT) | 1 | 0 | 1 |
+| Quaternion (ToolboxQuaternion) | 1 | 0 | 1 |
+
+---
+
+## ✅ Fixed
+
+### Plugin bugs — CSV (8 / 8)
+
+| # | Title | Evidence |
+|---|---|---|
+| #850 | More than one header line in CSV | `07451d6e`, `bd318377` |
+| #987 | Load a directory tree with CSV files | `2d57c875` |
+| #1000 | Load CSVs from CLI without prefix | `c91ccda5` |
+| #1068 | Select filename on export | `toolbox_ui.cpp:151` (`QFileDialog::getSaveFileName`) |
+| #1290 | CSV export missing quaternion/RPY values | ToolboxCSV iterates full `_plot_data->numeric` — probably fixed; manual smoke test recommended |
+| #1137 | Quaternion/RPY not exported (duplicate of #1290) | same as #1290 |
+| #1018 | Exporting strings to CSV doesn't work | `44118575` (cherry-pick of `ee91bbc1 Feature: StringsSeries allowed (#1337)`) — `toolbox_csv.cpp` reads `_plot_data->strings` in 8 places |
+| #662 | Multi-file prefix: can't add prefix to individually-added files | `c91ccda5` — `--auto-prefix` CLI flag auto-assigns each file's basename as its prefix (commit message cites #1000 only; scope extends to #662) |
+
+### Core app (12 / 32)
+
+| # | Title | Commit |
+|---|---|---|
+| #749 | Multi-file prefix dialog buttons inaccessible | `b827b3e7` |
+| #464 | `-l` + `-d` flag data not reloaded | `abb6a866` |
+| #1052 | Plot Docker toolbar "X" segfault | `ef5495f0` |
+| #1062 | Build fails on clang ≥ 19 | `57fa83a6` |
+| #1080 | Vertical zoom stuck on max 0.1 | `e4ee6288` |
+| #967 | `--buffer_size` not applied on Ubuntu 20.04 | `8317c42c` |
+| #528 | Time Cursor Limits not updated with Time Offset | `8317c42c` |
+| #1291 | Time starts at 01:00:00.0 on time offset | `c0707de5` |
+| #1014 | Layout XML attribute order not deterministic | `c3c33c28` |
+| #1326 | Fields with colons misinterpreted as time | `6806a320` |
+| #1151 | Colormap not saved in layout XML | `19d06903` |
+| #994 | Buffer value not saved in layout | `09d7f6b9` |
+
+### Plugin bugs — MCAP (5 / 5 — category complete)
+
+| # | Title | Evidence |
+|---|---|---|
+| #1133 | Error opening bag files since update to latest version | Likely fixed by `92b862b4` ("much faster MCAP pre-loading and update to 2.1.2", Feb 2026) or subsequent MCAP lib work. **Manually verified on 2026-04-20**. Single-file verification — revisit if other users re-report with different file variants. |
+| #783 | Cannot open mcap bags | **Manually verified on 2026-04-20** against a previously failing file. No explicit `Fix #783` commit; same MCAP-loader improvements as #1133 likely cover the original report. Generic bug description — if re-reported with a different file, may surface a distinct root cause. |
+| #754 | Error reading the mcap file | **Manually verified on 2026-04-20** — effectively duplicate of #783; same caveat applies. Worth noting on GitHub as "closed; duplicate of #783" rather than as an independent fix. |
+| #958 | MCAP file created on Linux won't open on Windows | **Manually verified on 2026-04-20** against a Linux-created MCAP file opened on Windows. No explicit `Fix #958` commit; the same MCAP-loader improvements (`92b862b4`, `bc71a2ff`, `c3e443a0`) that fixed #1133/#783/#754 likely cover this case too. Single-environment verification — revisit if re-reported with specific file variants (non-ASCII paths, Zstd-compressed, unfinalized summary). |
+| #903 | Floating point truncated exception on INT64 fields | **Fixed upstream on 2024-01-29** by `81e0e920` (`fix issue #929 : numerical truncation`) + `dcbc8c6b` (`bypass truncation check`). Actual owner is `ParserROS`, not `DataLoadMCAP` — root throw at `plotjuggler_plugins/ParserROS/rosx_introspection/include/rosx_introspection/details/conversion_impl.hpp:209,314,334`; runtime opt-out wired in `ros_parser.cpp:148-161`. User-facing workaround: **App → Preferences → Behavior → Parsing → "Strict Truncation check (uncheck at your own risk)"**. Error message (`ros_parser.cpp:169-173`) guides users to this toggle. GitHub issue is still open only because the fix commit cited #929 instead of #903 — administrative close recommended (e.g. as duplicate of #929). |
+
+### Plugin bugs — Lua / Scripting (4 / 4 — category complete)
+
+| # | Title | Evidence |
+|---|---|---|
+| #1328 | Fails to build with Lua 5.5 | `5d3e232b` — hand-port of sol2 PR #1723 into the bundled single-header `3rdparty/sol2-3.5.0/include/sol/sol.hpp` (widens unsupported-version guard to accept 5.5, extends `LUA_ERRGCMM` shim to Lua ≥ 5.4, wraps `lua_newstate` for the 3-arg 5.5 signature). Regression-checked against Lua 5.1 (minimal sol2 program compiles and runs); real 5.5 build not verified locally (Lua 5.5 not installed on this machine — worth a real build once available). |
+| #1312 | New Lua version breaks `quat_to_yaw` / `quat_to_roll` | `ae78a30b` — `default.snippets.xml`: PR #1164 had swapped `math.atan(y, x)` for `math.atan2(y, x)` to support Lua 5.1/5.2, but `math.atan2` was removed in Lua 5.4, so the snippets broke on the default bundled 5.4.7. Fix adds `local atan2 = math.atan2 or math.atan` at the top of both snippets so the correct name is picked at load time across Lua 5.1–5.5. `quat_to_pitch` uses `math.asin` and was unaffected. |
+| #968 | Misalignment in time series due to differing sizes with reactive scripts | `8d9c2afb` — `reactive_function.{h,cpp}`: `TimeseriesRef::atTime(t)` silently returns the clamped endpoint value when `t` falls outside the series' recorded range (because `getIndexFromX` in `timeseries.h:152-175` clamps to `size()-1`/`0`). Feb 2026 storage refactor (`48497feb`, `9493434e`) did not change that semantics. Fix exposes `getIndexAtTime(t)` on `TimeseriesRef` so reactive-script Lua (the ToolboxLuaEditor / `ReactiveLuaFunction` context) can compare the retrieved sample's `x` against the query time and detect out-of-range clamping. **Scope note**: applies only to reactive scripts, **not** to Lua custom functions (`LuaCustomFunction` has its own `_lua_engine` with no `TimeseriesRef` binding; its scripts receive pre-computed positional args from the C++ host and share the same clamping bug at `python_custom_function.cpp:483,490` and the equivalent in `lua_custom_function.cpp`). Fixing that second surface requires a host-level range check — deliberately out of scope here since no user has reported it. Purely additive; matches `firemark`'s suggestion on the closed PR #969. Fork-only for now (not sent upstream). |
+| #800 | Crash caused by reactive script errors | `bdf39ec9` — `reactive_function.{h,cpp}`: `ReactiveLuaFunction::calculate()` showed a modal `QMessageBox::warning` for every failure (line present and untouched since 2022-07-25, `af4f9d115`); under streaming sources (UDP 20-100 Hz) a script that errors every tick piled dialogs faster than the user could dismiss them, exhausting Qt USER32 handles on Windows and crashing PJ. Fix adds a `_disabled_after_error` flag set **before** the modal `QMessageBox::warning` is shown (so re-entrant streaming timer firings during the nested modal event loop see the flag and short-circuit, instead of queueing more dialogs). Script is auto re-enabled on save via the existing editor lifecycle (`lua_editor.cpp:271` constructs a fresh `ReactiveLuaFunction` on every save — new instance → default flag), so no explicit resume API was needed. Scope: reactive scripts only; CustomFunction streaming-path errors go to stderr via `qWarning`, no dialog, no parallel spam pathology. |
+
+### Plugin bugs — Parquet (2 / 2 — category complete)
+
+| # | Title | Evidence |
+|---|---|---|
+| #863 | Parquet file with BYTE_ARRAY / TIMESTAMP_MILLIS columns fails to load | `4080e0eb` — `dataload_parquet.cpp`: split the old numeric-only whitelist (lines 253-259) into `is_numeric` + `is_string`, and routed `arrow::Type::STRING` / `LARGE_STRING` / `BINARY` columns to `PlotDataMapRef::getOrCreateStringSeries()` — mirroring the CSV pattern from commit `44118575` *"Feature: StringsSeries allowed"*. `ColumnInfo` now carries both `PlotData*` and `StringSeries*` (exactly one set per column); the per-row batch loop dispatches on whichever is populated. `arrow::StringArray` / `LargeStringArray` / `BinaryArray` all share `GetView(int64_t) → std::string_view`, which constructs `PJ::StringRef` directly; `StringSeries::pushBack` (`stringseries.h:56-65`) does the interning. String columns are deliberately **not** offered as timestamp-axis candidates. The *TIMESTAMP_MILLIS* half of the ticket was already fixed by `900557e0` (Feb 2026, *"parquet_loading: fix timestamp handling for arrow::TIMESTAMP"*). **Manually verified on 2026-04-21** with a pyarrow fixture containing `timestamp (ms)` + `temperature (double)` + `label (string)` + `status (binary)` columns: all four appeared in the Timeseries list, the 5-second X-axis matched 50 × 100 ms, and a Python Custom Function reading `value == "ok"` produced the expected square wave — proving strings actually land in `_plot_data->strings` and are consumable by the scripting layer. **Scope caveats**: `FIXED_SIZE_BINARY` not added (less common, would need a separate `FixedSizeBinaryArray` branch). Not tested on very large files or on chunked-string arrays. |
+| #862 | Building DataLoadParquet on Windows | **Administrative close — no code change in this repo.** Commit `00b94253` *"add Arrow to conan and fix Windows CI (#1109)"* already added Conan to the Parquet plugin build, and `plotjuggler_plugins/DataLoadParquet/cmake/FindArrow.cmake:35-62` covers MSVC toolchain detection, `_static` suffix handling, `.dll` lookup, and import-lib (`.lib`) resolution. **Not independently verified on Windows** (no MSVC environment on Álvaro's machine). Revisit if re-reported with specific MSVC / vcpkg / mingw / Qt version repro steps — the current close rests on evidence of prior work, not on a live Windows build. |
+
+### Feature requests — addressed indirectly (2 / 51)
+
+| # | Title | Evidence |
+|---|---|---|
+| #1323 | Python scripting + StringSeries support + UI improvements to Custom Functions | `c04e376e`, `ee91bbc1`, `ea9635e6`, `29f8b6cb` |
+| #1220 | Option for dates & times stored in separate columns | `8d1346c3` (upstream PR #1259) |
+
+---
+
+## ⏳ Waiting
+
+### Plugin bugs — ROS / ROS2 (18)
+
+| # | Title | Status |
+|---|---|---|
+| #1334 | UI freezes when starting ROS2 Topic Subscriber in massive topic environment | ⏳ |
+| #1315 | Segfault subscribing to AMCL Particle Markers | ⏳ |
+| #1283 | Snap version lacks ROS-O toolkit | ⏳ |
+| #1262 | ROS2 `std_msgs/Header` treated differently in custom msg vs. built-in | ⏳ |
+| #1204 | Problem with ROS2 Header in some topics | ⏳ |
+| #1060 | Plugin exception "package not found" on ROS action feedback topics | ⏳ |
+| #991 | DataLoad ROS bags exception: `map::at` | ⏳ |
+| #881 | ROS2 message with arrays and bounded types: not enough memory in buffer | ⏳ |
+| #878 | No parser for encoding [cdr] after MCAP conversion from ros2 db3 | ⏳ |
+| #860 | ROS2 topic Re-Publisher not finding topic list while topics visible | ⏳ |
+| #841 | Cannot find ros2 topic subscriber when compiling from source | ⏳ |
+| #759 | Crash when selecting topics to republish in ROS2 | ⏳ |
+| #743 | After plotting IMU data, can't see orientation/angular velocity | ⏳ |
+| #729 | ParserROS compile issues on Windows | ⏳ |
+| #622 | Extra metadata header appearing in topic tree | ⏳ |
+| #537 | Rosout dark-theme: debug messages invisible | ⏳ |
+| #477 | Segfault in ROS2 topic Re-Publisher | ⏳ |
+| #458 | ROS topic cannot be loaded | ⏳ |
+
+### Plugin bugs — MCAP (0 waiting of 5) ✅
+All five MCAP-category issues are marked fixed.
+
+### Plugin bugs — Lua / Scripting (0 waiting of 4) ✅
+All four Lua / Scripting issues are marked fixed.
+
+### Plugin bugs — MQTT (3)
+
+| # | Title | Status |
+|---|---|---|
+| #1148 | Unable to connect via MQTT | ⏳ |
+| #876 | MQTT connection creating malformed packets | ⏳ |
+| #747 | MQTT streamer only subscribes to single topic | ⏳ |
+
+### Plugin bugs — ZMQ (3)
+
+| # | Title | Status |
+|---|---|---|
+| #1126 | ZMQ Subscriber lacks option to specify Protobuf Paths | ⏳ |
+| #941 | Extraneous suffixes added to ZMQ IPC endpoints | ⏳ |
+| #705 | ZeroMQ Subscriber filter | ⏳ |
+
+### Plugin bugs — Parquet (0 waiting of 2) ✅
+All two Parquet-category issues are marked fixed.
+
+### Plugin bugs — ULog (2)
+
+| # | Title | Status |
+|---|---|---|
+| #796 | Multiple improvements to PX4 plugin needed | ⏳ |
+| #672 | Cannot load large ULog file (2.5 GB) | ⏳ |
+
+### Plugin bugs — single-issue plugins (4)
+
+| # | Plugin | Title | Status |
+|---|---|---|---|
+| #1144 | ParserProtobuf | Parse multiple protobuf message types simultaneously | ⏳ |
+| #839 | DataStreamUDP | UDP JSON stream timestamp setting not saved with layout | ⏳ |
+| #741 | ToolboxFFT | FFT Y-scaling not working | ⏳ |
+| #1243 | ToolboxQuaternion | Add Quaternion-to-RPY autofill for PX4 | ⏳ |
+
+### Core app (20)
+
+| # | Title | Status |
+|---|---|---|
+| #1331 | Complete Timeseries list synchronization and custom series separation | ⏳ |
+| #1276 | Compiling error: no declaration matches | ⏳ |
+| #1275 | Hang on exit | ⏳ |
+| #1253 | UI inconsistencies on HiDPI displays | ⏳ |
+| #1197 | Displayed value is nearest datapoint, not current/previous | ⏳ |
+| #1114 | Scroll step size bug | ⏳ |
+| #1111 / #1104 | Show only current time range in X/Y plots | ⏳ |
+| #1092 | Qt6: initial port | ⏳ |
+| #1084 | Change the time source for ROS2 bags | ⏳ |
+| #911 | Crash when dragging data into plot area on macOS | ⏳ |
+| #886 | Request for flatpak distribution support | ⏳ |
+| #883 | Can't find one or more curves | ⏳ |
+| #816 | Errors when launching AppImage | ⏳ |
+| #791 | Broken scaling with multiple displays | ⏳ |
+| #756 | Layout doesn't restore XY plots when multiple sources with prefixes are used | ⏳ |
+| #563 | Plot refreshing bug with OpenGL enabled | ⏳ |
+| #468 | Menus overlapping on high DPI device | ⏳ |
+| #449 | New XY plot stuck in loop | ⏳ |
+| #402 | Auto-reload custom timeseries when changing new file | ⏳ |
+| #213 | Keyed topics not supported | ⏳ |
+
+### Feature requests (49)
+
+Waiting (in issue-number order):
+#1333, #1332, #1327, #1322, #1321, #1319, #1311, #1288, #1286, #1274, #1267, #1266, #1264, #1251, #1245, #1213, #1044, #957, #945, #847, #823, #809, #788, #787, #785, #782, #775, #755, #750, #748, #732, #708, #695, #691, #635, #616, #606, #572, #570, #511, #471, #444, #442, #414, #367, #365, #286, #201, #110
+
+### Obsolete / Questions (20) — administrative close, no code
+
+**Obsolete** (close as wontfix/duplicate): #1335, #1013, #1261, #943, #851, #913, #1270, #980, #875, #799
+
+**Questions** (close as question/support): #1336, #1017, #1167, #1116, #1170, #894, #766, #644, #427, #744
+
+---
+
+## Next up — Parquet plugin complete
+
+Both Parquet-category issues are resolved: `#863` by the new BYTE_ARRAY → StringSeries path in `dataload_parquet.cpp` (plus the earlier `900557e0` TIMESTAMP fix), `#862` by administrative close citing commit `00b94253`'s Conan/Arrow Windows CI work. Four plugin categories are now fully closed: **CSV (8/8)**, **MCAP (5/5)**, **Lua (4/4)**, **Parquet (2/2)** — 19 plugin issues closed of 49 total.
+
+Remaining plugin categories (30 waiting): ROS/ROS2 (18), MQTT (3), ZMQ (3), ULog (2), Protobuf / UDP / FFT / Quaternion (1 each).
+
+### Suggested next target
+- **ULog (2)**: `#672` (cannot load 2.5 GB file) and `#796` (multiple PX4 improvements). `#796` is broad — likely needs splitting. `#672` is a concrete perf/memory ticket; worth a skim of `DataLoadULog` to see whether the parser streams or loads everything into RAM.
+- **Single-issue plugins (4 — Protobuf / UDP / FFT / Quaternion)**: any of these could be closable in one sitting. `#1243` (ToolboxQuaternion PX4 autofill) and `#741` (FFT Y-scaling) look like the tightest scope.
+- **ROS/ROS2 (18)**: the biggest pole and longest tail. Start with a clustering pass: `#477 / #759 / #860` all in the ROS2 Re-Publisher, `#1204 / #1262` about ROS2 Header quirks — duplicates inside those clusters may drop the effective count to ~14.
+
+---
+
+## Caveats
+
+- **"Fixed" here means** a commit in history claims to fix the issue, or code review shows the capability is present. Not independently verified against the live GitHub tracker.
+- **#1290 / #1137** (CSV export of quaternion/RPY) should get a manual smoke test before being closed on GitHub: load MCAP with IMU → ToolboxQuaternion → export RPY → inspect the resulting CSV.
+- **#662** (multi-file prefix on individually-added files) is marked fixed because `--auto-prefix` covers the CLI workflow; the underlying GUI flow where files are added one-by-one via `+` is unchanged. Revisit if the issue is re-reported with GUI-specific repro steps.
+- **#1337** is a PR number (not in the 156-issue list); it closes issue #1018.
+- Several merged upstream commits fix PRs/issues **not in the 156-issue snapshot** and are therefore not counted: `#1015`, `#1065`, `#1254`, `#1277`, `#1278`, `#1279`, `#1281`, `#1282`, `#1285`, `#1287`, `#1289`, `#1295`, `#1296`, `#1297`, `#1298`, `#1300`, `#1301`, `#1306`, `#1310`, `#1314`, `#1324`.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -12,10 +12,10 @@ Snapshot of the 156 open GitHub issues (as of 2026-04-15) mapped against commits
 |---|---:|---:|---:|
 | Obsolete / should be closed | 10 | 0 | 10 |
 | Questions / user support | 10 | 0 | 10 |
-| Plugin bugs | 49 | **20** | 29 |
+| Plugin bugs | 49 | **21** | 28 |
 | Core app | 32 | 12 | 20 |
 | Feature requests | 51 | 2 | 49 |
-| **Total** | **156** | **34** | **122** |
+| **Total** | **156** | **35** | **121** |
 
 ## Per-plugin scoreboard
 
@@ -27,7 +27,7 @@ Snapshot of the 156 open GitHub issues (as of 2026-04-15) mapped against commits
 | **Lua / Scripting** | 4 | **4** | **0** |
 | **Parquet** (DataLoadParquet) | 2 | **2** | **0** |
 | MQTT (DataStreamMQTT) | 3 | 0 | 3 |
-| ZMQ (DataStreamZMQ, StatePublisherZMQ) | 3 | 0 | 3 |
+| ZMQ (DataStreamZMQ, StatePublisherZMQ) | 3 | **1** | 2 |
 | ULog (DataLoadULog) | 2 | 0 | 2 |
 | Protobuf (ParserProtobuf) | 1 | 0 | 1 |
 | **UDP** (DataStreamUDP) | 1 | **1** | **0** |
@@ -86,6 +86,12 @@ Snapshot of the 156 open GitHub issues (as of 2026-04-15) mapped against commits
 | #1312 | New Lua version breaks `quat_to_yaw` / `quat_to_roll` | `ae78a30b` — `default.snippets.xml`: PR #1164 had swapped `math.atan(y, x)` for `math.atan2(y, x)` to support Lua 5.1/5.2, but `math.atan2` was removed in Lua 5.4, so the snippets broke on the default bundled 5.4.7. Fix adds `local atan2 = math.atan2 or math.atan` at the top of both snippets so the correct name is picked at load time across Lua 5.1–5.5. `quat_to_pitch` uses `math.asin` and was unaffected. |
 | #968 | Misalignment in time series due to differing sizes with reactive scripts | `8d9c2afb` — `reactive_function.{h,cpp}`: `TimeseriesRef::atTime(t)` silently returns the clamped endpoint value when `t` falls outside the series' recorded range (because `getIndexFromX` in `timeseries.h:152-175` clamps to `size()-1`/`0`). Feb 2026 storage refactor (`48497feb`, `9493434e`) did not change that semantics. Fix exposes `getIndexAtTime(t)` on `TimeseriesRef` so reactive-script Lua (the ToolboxLuaEditor / `ReactiveLuaFunction` context) can compare the retrieved sample's `x` against the query time and detect out-of-range clamping. **Scope note**: applies only to reactive scripts, **not** to Lua custom functions (`LuaCustomFunction` has its own `_lua_engine` with no `TimeseriesRef` binding; its scripts receive pre-computed positional args from the C++ host and share the same clamping bug at `python_custom_function.cpp:483,490` and the equivalent in `lua_custom_function.cpp`). Fixing that second surface requires a host-level range check — deliberately out of scope here since no user has reported it. Purely additive; matches `firemark`'s suggestion on the closed PR #969. Fork-only for now (not sent upstream). |
 | #800 | Crash caused by reactive script errors | `bdf39ec9` — `reactive_function.{h,cpp}`: `ReactiveLuaFunction::calculate()` showed a modal `QMessageBox::warning` for every failure (line present and untouched since 2022-07-25, `af4f9d115`); under streaming sources (UDP 20-100 Hz) a script that errors every tick piled dialogs faster than the user could dismiss them, exhausting Qt USER32 handles on Windows and crashing PJ. Fix adds a `_disabled_after_error` flag set **before** the modal `QMessageBox::warning` is shown (so re-entrant streaming timer firings during the nested modal event loop see the flag and short-circuit, instead of queueing more dialogs). Script is auto re-enabled on save via the existing editor lifecycle (`lua_editor.cpp:271` constructs a fresh `ReactiveLuaFunction` on every save — new instance → default flag), so no explicit resume API was needed. Scope: reactive scripts only; CustomFunction streaming-path errors go to stderr via `qWarning`, no dialog, no parallel spam pathology. |
+
+### Plugin bugs — ZMQ (1 / 3 — upstream already merged)
+
+| # | Title | Evidence |
+|---|---|---|
+| #705 | ZeroMQ Subscriber filter | **COMPLETED — fixed upstream by PR #730 (`db90f70a ZMQ: Add topics filtering`, merged 2022-12-18).** Already on `plugin_issues` (and `main`). Adds semicolon/comma/whitespace-separated topic-filter parsing in `datastream_zmq.cpp:355-372` (`parseTopicFilters`), plus a test publisher at `plotjuggler_plugins/DataStreamZMQ/utilities/start_test_publisher.py`. Safe administrative close — Davide merged this himself. |
 
 ### Plugin bugs — UDP (1 / 1 — administrative close, not worth fixing)
 
@@ -148,13 +154,12 @@ All four Lua / Scripting issues are marked fixed.
 | #876 | MQTT connection creating malformed packets | ⏳ |
 | #747 | MQTT streamer only subscribes to single topic | ⏳ |
 
-### Plugin bugs — ZMQ (3)
+### Plugin bugs — ZMQ (2 waiting of 3)
 
 | # | Title | Status |
 |---|---|---|
 | #1126 | ZMQ Subscriber lacks option to specify Protobuf Paths | ⏳ |
 | #941 | Extraneous suffixes added to ZMQ IPC endpoints | ⏳ |
-| #705 | ZeroMQ Subscriber filter | ⏳ |
 
 ### Plugin bugs — Parquet (0 waiting of 2) ✅
 All two Parquet-category issues are marked fixed.
@@ -214,9 +219,9 @@ Waiting (in issue-number order):
 
 ## Next up — Parquet plugin complete
 
-Plugin-category progress: `#863` by the new BYTE_ARRAY → StringSeries path in `dataload_parquet.cpp` (plus the earlier `900557e0` TIMESTAMP fix), `#862` by administrative close citing commit `00b94253`'s Conan/Arrow Windows CI work, and `#839` (UDP layout-persistence) closed administratively as systemic-not-UDP-specific. Four plugin categories are fully closed — **CSV (8/8)**, **MCAP (5/5)**, **Lua (4/4)**, **Parquet (2/2)** — plus UDP (1/1 via administrative close). **20 plugin issues closed of 49 total.**
+Plugin-category progress: `#863` by the new BYTE_ARRAY → StringSeries path in `dataload_parquet.cpp` (plus the earlier `900557e0` TIMESTAMP fix), `#862` by administrative close citing commit `00b94253`'s Conan/Arrow Windows CI work, `#839` (UDP layout-persistence) closed administratively as systemic-not-UDP-specific, and `#705` (ZMQ topic filter) closed administratively via upstream PR #730 / `db90f70a`. Four plugin categories fully closed — **CSV (8/8)**, **MCAP (5/5)**, **Lua (4/4)**, **Parquet (2/2)** — plus UDP (1/1 administrative) and partial ZMQ (1/3 so far). **21 plugin issues closed of 49 total.**
 
-Remaining plugin categories (29 waiting): ROS/ROS2 (18), MQTT (3), ZMQ (3), ULog (2), Protobuf / FFT / Quaternion (1 each).
+Remaining plugin categories (28 waiting): ROS/ROS2 (18), MQTT (3), ZMQ (2), ULog (2), Protobuf / FFT / Quaternion (1 each).
 
 ### Suggested next target
 - **#537** (ROS/ROS2, rosout dark-theme invisible debug messages): tiniest scope, pure stylesheet. Good warm-up.

--- a/plotjuggler_app/main.cpp
+++ b/plotjuggler_app/main.cpp
@@ -273,6 +273,10 @@ int main(int argc, char* argv[])
                                   "window_title");
   parser.addOption(window_title);
 
+  QCommandLineOption auto_prefix_option("auto-prefix",
+                                        "Automatically prefix each data file with its filename");
+  parser.addOption(auto_prefix_option);
+
   parser.process(*qApp);
 
   if (parser.isSet(publish_option) && !parser.isSet(layout_option))

--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -331,7 +331,8 @@ MainWindow::MainWindow(const QCommandLineParser& commandline_parser, QWidget* pa
   if (commandline_parser.isSet("datafile"))
   {
     QStringList datafiles = commandline_parser.values("datafile");
-    file_loaded = loadDataFromFiles(datafiles);
+    const bool auto_prefix = commandline_parser.isSet("auto-prefix");
+    file_loaded = loadDataFromFiles(datafiles, auto_prefix);
   }
   if (commandline_parser.isSet("layout"))
   {
@@ -1341,14 +1342,23 @@ bool MainWindow::isStreamingActive() const
   return !ui->buttonStreamingPause->isChecked() && _active_streamer_plugin;
 }
 
-bool MainWindow::loadDataFromFiles(QStringList filenames)
+bool MainWindow::loadDataFromFiles(QStringList filenames, bool auto_prefix)
 {
   filenames.sort();
   std::map<QString, QString> filename_prefix;
 
-  const bool add_prefix = ui->checkBoxAddPrefix->isChecked();
-  const bool merge_data = ui->checkBoxMergeData->isChecked();
-  if (add_prefix)
+  bool has_prefix = false;
+
+  if (auto_prefix)
+  {
+    // CLI --auto-prefix: use each file's basename, skip the dialog.
+    for (const auto& file : filenames)
+    {
+      filename_prefix[file] = QFileInfo(file).baseName();
+    }
+    has_prefix = true;
+  }
+  else if (ui->checkBoxAddPrefix->isChecked())
   {
     DialogMultifilePrefix dialog(filenames, this);
     int ret = dialog.exec();
@@ -1357,7 +1367,10 @@ bool MainWindow::loadDataFromFiles(QStringList filenames)
       return false;
     }
     filename_prefix = dialog.getPrefixes();
+    has_prefix = true;
   }
+
+  const bool merge_data = ui->checkBoxMergeData->isChecked();
 
   std::unordered_set<std::string> previous_names = _mapped_plot_data.getAllNames();
 
@@ -1389,7 +1402,7 @@ bool MainWindow::loadDataFromFiles(QStringList filenames)
   {
     data_replaced_entirely = true;
   }
-  else if (!add_prefix)
+  else if (!has_prefix)
   {
     QMessageBox::StandardButton reply;
     reply = QMessageBox::question(

--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -14,6 +14,7 @@
 #include <QCommandLineParser>
 #include <QDebug>
 #include <QDesktopServices>
+#include <QDirIterator>
 #include <QDomDocument>
 #include <QDoubleSpinBox>
 #include <QElapsedTimer>
@@ -331,8 +332,32 @@ MainWindow::MainWindow(const QCommandLineParser& commandline_parser, QWidget* pa
   if (commandline_parser.isSet("datafile"))
   {
     QStringList datafiles = commandline_parser.values("datafile");
+
+    // Expand directories into their file contents (recursive).
+    QStringList expanded;
+    for (const auto& path : datafiles)
+    {
+      QFileInfo finfo(path);
+      if (finfo.isDir())
+      {
+        QDirIterator it(path, QDirIterator::Subdirectories);
+        while (it.hasNext())
+        {
+          it.next();
+          if (it.fileInfo().isFile())
+          {
+            expanded.push_back(it.filePath());
+          }
+        }
+      }
+      else
+      {
+        expanded.push_back(path);
+      }
+    }
+
     const bool auto_prefix = commandline_parser.isSet("auto-prefix");
-    file_loaded = loadDataFromFiles(datafiles, auto_prefix);
+    file_loaded = loadDataFromFiles(expanded, auto_prefix);
   }
   if (commandline_parser.isSet("layout"))
   {
@@ -1860,6 +1885,7 @@ void MainWindow::dragEnterEvent(QDragEnterEvent* event)
 void MainWindow::dropEvent(QDropEvent* event)
 {
   QStringList file_names;
+  bool has_directory = false;
   const auto urls = event->mimeData()->urls();
 
   for (const auto& url : urls)
@@ -1871,6 +1897,19 @@ void MainWindow::dropEvent(QDropEvent* event)
     {
       file_names << QDir::toNativeSeparators(local_file);
     }
+    else if (fileinfo.exists() && fileinfo.isDir())
+    {
+      has_directory = true;
+      QDirIterator it(local_file, QDirIterator::Subdirectories);
+      while (it.hasNext())
+      {
+        it.next();
+        if (it.fileInfo().isFile())
+        {
+          file_names << QDir::toNativeSeparators(it.filePath());
+        }
+      }
+    }
     else
     {
       QMessageBox::warning(
@@ -1879,7 +1918,7 @@ void MainWindow::dropEvent(QDropEvent* event)
     }
   }
 
-  loadDataFromFiles(file_names);
+  loadDataFromFiles(file_names, has_directory);
 }
 
 void MainWindow::on_stylesheetChanged(QString theme)

--- a/plotjuggler_app/mainwindow.h
+++ b/plotjuggler_app/mainwindow.h
@@ -48,7 +48,7 @@ public:
   ~MainWindow();
 
   bool loadLayoutFromFile(QString filename, bool load_datafiles = true);
-  bool loadDataFromFiles(QStringList filenames);
+  bool loadDataFromFiles(QStringList filenames, bool auto_prefix = false);
   std::unordered_set<std::string> loadDataFromFile(const FileLoadInfo& info, bool merge_files);
 
   void stopStreamingPlugin();

--- a/plotjuggler_app/resources/default.snippets.xml
+++ b/plotjuggler_app/resources/default.snippets.xml
@@ -93,7 +93,8 @@ return value - first_value</function>
 
   <snippet name="quat_to_roll">
     <global></global>
-    <function>w = value
+    <function>local atan2 = math.atan2 or math.atan
+w = value
 x = v1
 y = v2
 z = v3
@@ -101,7 +102,7 @@ z = v3
 dcm21 = 2 * (w * x + y * z)
 dcm22 = w*w - x*x - y*y + z*z
 
-roll = math.atan2(dcm21, dcm22)
+roll = atan2(dcm21, dcm22)
 
 return roll</function>
     <linkedSource></linkedSource>
@@ -124,7 +125,8 @@ return pitch</function>
 
     <snippet name="quat_to_yaw">
     <global></global>
-    <function>w = value
+    <function>local atan2 = math.atan2 or math.atan
+w = value
 x = v1
 y = v2
 z = v3
@@ -132,7 +134,7 @@ z = v3
 dcm10 = 2 * (x * y + w * z)
 dcm00 = w*w + x*x - y*y - z*z
 
-yaw = math.atan2(dcm10, dcm00)
+yaw = atan2(dcm10, dcm00)
 
 return yaw</function>
     <linkedSource></linkedSource>

--- a/plotjuggler_base/include/PlotJuggler/reactive_function.h
+++ b/plotjuggler_base/include/PlotJuggler/reactive_function.h
@@ -27,6 +27,8 @@ struct TimeseriesRef
 
   double atTime(double t) const;
 
+  int getIndexAtTime(double t) const;
+
   unsigned size() const;
 
   void clear() const;

--- a/plotjuggler_base/include/PlotJuggler/reactive_function.h
+++ b/plotjuggler_base/include/PlotJuggler/reactive_function.h
@@ -115,6 +115,7 @@ protected:
   void prepareLua();
 
   double _tracker_value = 0;
+  bool _disabled_after_error = false;
   std::string _global_code;
   std::string _function_code;
   std::string _library_code;

--- a/plotjuggler_base/src/reactive_function.cpp
+++ b/plotjuggler_base/src/reactive_function.cpp
@@ -114,6 +114,7 @@ void ReactiveLuaFunction::prepareLua()
   _timeseries_ref["at"] = &TimeseriesRef::at;
   _timeseries_ref["set"] = &TimeseriesRef::set;
   _timeseries_ref["atTime"] = &TimeseriesRef::atTime;
+  _timeseries_ref["getIndexAtTime"] = &TimeseriesRef::getIndexAtTime;
   _timeseries_ref["clear"] = &TimeseriesRef::clear;
 
   //---------------------------------------
@@ -188,6 +189,11 @@ double TimeseriesRef::atTime(double t) const
 {
   int i = _plot_data->getIndexFromX(t);
   return _plot_data->at(i).y;
+}
+
+int TimeseriesRef::getIndexAtTime(double t) const
+{
+  return _plot_data->getIndexFromX(t);
 }
 
 unsigned TimeseriesRef::size() const

--- a/plotjuggler_base/src/reactive_function.cpp
+++ b/plotjuggler_base/src/reactive_function.cpp
@@ -70,6 +70,10 @@ void ReactiveLuaFunction::setTimeTracker(double time_tracker_value)
 
 void ReactiveLuaFunction::calculate()
 {
+  if (_disabled_after_error)
+  {
+    return;
+  }
   try
   {
     auto result = _lua_function(_tracker_value);
@@ -81,7 +85,15 @@ void ReactiveLuaFunction::calculate()
   }
   catch (std::exception& err)
   {
-    QMessageBox::warning(nullptr, "Error in Reactive Script", QString(err.what()),
+    // Set the flag BEFORE the modal dialog: QMessageBox::warning enters a
+    // nested Qt event loop, so streaming/replot timers can re-enter
+    // calculate() while the dialog is visible. Setting the flag first makes
+    // those re-entrant calls short-circuit instead of queueing more dialogs.
+    _disabled_after_error = true;
+    QMessageBox::warning(nullptr, "Error in Reactive Script",
+                         QString("%1\n\nThe script has been disabled to prevent dialog spam. "
+                                 "Re-save it from the Script Editor to resume execution.")
+                             .arg(err.what()),
                          QMessageBox::Cancel);
   }
 }

--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.cpp
@@ -177,8 +177,15 @@ void DataLoadCSV::parseHeader(QFile& file, std::vector<std::string>& column_name
   _ui->listWidgetSeries->clear();
 
   QTextStream inA(&file);
-  // The first line should contain the header. If it contains a number, we will
-  // apply a name ourselves
+
+  // Skip metadata/comment lines before the header.
+  const int skip = _ui->rowBox->value();
+  for (int i = 0; i < skip && !inA.atEnd(); i++)
+  {
+    inA.readLine();
+  }
+
+  // The first non-skipped line should contain the header.
   QString first_line = inA.readLine();
 
   QString preview_lines = first_line + "\n";
@@ -297,6 +304,7 @@ int DataLoadCSV::launchDialog(QFile& file, std::vector<std::string>* column_name
   QSettings settings;
   _dialog->restoreGeometry(settings.value("DataLoadCSV.geometry").toByteArray());
 
+  _ui->rowBox->setValue(settings.value("DataLoadCSV.skipRows", 0).toInt());
   _ui->radioButtonIndex->setChecked(settings.value("DataLoadCSV.useIndex", false).toBool());
   bool use_custom_time = settings.value("DataLoadCSV.useDateFormat", false).toBool();
   if (use_custom_time)
@@ -310,10 +318,14 @@ int DataLoadCSV::launchDialog(QFile& file, std::vector<std::string>* column_name
   _ui->lineEditDateFormat->setText(
       settings.value("DataLoadCSV.dateFormat", "yyyy-MM-dd hh:mm:ss").toString());
 
-  // Auto-detect delimiter from the first line
+  // Auto-detect delimiter from the header line (after skipping metadata rows).
   {
     file.open(QFile::ReadOnly);
     QTextStream in(&file);
+    for (int i = 0; i < _ui->rowBox->value() && !in.atEnd(); i++)
+    {
+      in.readLine();
+    }
     QString first_line = in.readLine();
     file.close();
 
@@ -356,6 +368,35 @@ int DataLoadCSV::launchDialog(QFile& file, std::vector<std::string>* column_name
                      parseHeader(file, *column_names);
                    });
 
+  QObject::connect(_ui->rowBox, qOverload<int>(&QSpinBox::valueChanged), context, [&](int) {
+    if (_ui->radioAutoTime->isChecked())
+    {
+      file.open(QFile::ReadOnly);
+      QTextStream in(&file);
+      for (int i = 0; i < _ui->rowBox->value() && !in.atEnd(); i++)
+      {
+        in.readLine();
+      }
+      QString header_line = in.readLine();
+      file.close();
+
+      _delimiter = DetectDelimiter(header_line);
+      _csvHighlighter.delimiter = _delimiter;
+
+      const std::array<char, 4> delimiters = { ',', ';', ' ', '\t' };
+      QSignalBlocker blocker(*_ui->comboBox);
+      for (int i = 0; i < 4; i++)
+      {
+        if (delimiters[i] == _delimiter)
+        {
+          _ui->comboBox->setCurrentIndex(i);
+          break;
+        }
+      }
+    }
+    parseHeader(file, *column_names);
+  });
+
   // parse the header once and launch the dialog
   parseHeader(file, *column_names);
 
@@ -372,6 +413,7 @@ int DataLoadCSV::launchDialog(QFile& file, std::vector<std::string>* column_name
   int res = _dialog->exec();
 
   settings.setValue("DataLoadCSV.geometry", _dialog->saveGeometry());
+  settings.setValue("DataLoadCSV.skipRows", _ui->rowBox->value());
   settings.setValue("DataLoadCSV.useIndex", _ui->radioButtonIndex->isChecked());
   settings.setValue("DataLoadCSV.useDateFormat", _ui->radioCustomTime->isChecked());
   settings.setValue("DataLoadCSV.dateFormat", _ui->lineEditDateFormat->text());
@@ -475,6 +517,7 @@ bool DataLoadCSV::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_data
   {
     config.custom_time_format = _ui->lineEditDateFormat->text().toStdString();
   }
+  config.skip_rows = _ui->rowBox->value();
 
   //--- Count lines for progress ---
   {
@@ -645,8 +688,8 @@ bool DataLoadCSV::xmlSaveState(QDomDocument& doc, QDomElement& parent_element) c
   QDomElement elem = doc.createElement("parameters");
   elem.setAttribute("time_axis", _default_time_axis.c_str());
   elem.setAttribute("delimiter", _ui->comboBox->currentIndex());
+  elem.setAttribute("skip_rows", _ui->rowBox->value());
 
-  QString date_format;
   if (_ui->radioCustomTime->isChecked())
   {
     elem.setAttribute("date_format", _ui->lineEditDateFormat->text());
@@ -686,6 +729,10 @@ bool DataLoadCSV::xmlLoadState(const QDomElement& parent_element)
         _delimiter = '\t';
         break;
     }
+  }
+  if (elem.hasAttribute("skip_rows"))
+  {
+    _ui->rowBox->setValue(elem.attribute("skip_rows").toInt());
   }
   if (elem.hasAttribute("date_format"))
   {

--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.ui
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.ui
@@ -130,7 +130,7 @@
          <item>
           <widget class="QLabel" name="label_4">
            <property name="text">
-            <string>Skipped rows:</string>
+            <string>Skip lines before header:</string>
            </property>
           </widget>
          </item>

--- a/plotjuggler_plugins/DataLoadCSV/dataload_csv.ui
+++ b/plotjuggler_plugins/DataLoadCSV/dataload_csv.ui
@@ -127,6 +127,16 @@
            </property>
           </spacer>
          </item>
+         <item>
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>Skipped rows:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="rowBox"/>
+         </item>
         </layout>
        </item>
        <item>

--- a/plotjuggler_plugins/DataLoadParquet/dataload_parquet.cpp
+++ b/plotjuggler_plugins/DataLoadParquet/dataload_parquet.cpp
@@ -226,7 +226,8 @@ bool DataLoadParquet::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_
   {
     std::string name;
     arrow::Type::type arrow_type;
-    PlotData* plot_data = nullptr;
+    PlotData* numeric_data = nullptr;
+    StringSeries* string_data = nullptr;
     size_t column_index = 0;
   };
 
@@ -249,8 +250,8 @@ bool DataLoadParquet::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_
     info.arrow_type = field->type()->id();
     info.column_index = col;
 
-    // Check if this is a numeric type we can handle
-    const bool is_valid =
+    // Numeric columns can be plotted directly and are offered as timestamp candidates.
+    const bool is_numeric =
         (info.arrow_type == arrow::Type::BOOL || info.arrow_type == arrow::Type::INT8 ||
          info.arrow_type == arrow::Type::INT16 || info.arrow_type == arrow::Type::INT32 ||
          info.arrow_type == arrow::Type::INT64 || info.arrow_type == arrow::Type::UINT8 ||
@@ -258,11 +259,22 @@ bool DataLoadParquet::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_
          info.arrow_type == arrow::Type::UINT64 || info.arrow_type == arrow::Type::FLOAT ||
          info.arrow_type == arrow::Type::TIMESTAMP || info.arrow_type == arrow::Type::DOUBLE);
 
-    if (is_valid)
+    // Parquet BYTE_ARRAY columns (string/binary) land in Arrow as one of these.
+    const bool is_string =
+        (info.arrow_type == arrow::Type::STRING || info.arrow_type == arrow::Type::LARGE_STRING ||
+         info.arrow_type == arrow::Type::BINARY);
+
+    if (is_numeric)
     {
-      info.plot_data = &plot_data.getOrCreateNumeric(info.name, nullptr);
+      info.numeric_data = &plot_data.getOrCreateNumeric(info.name, nullptr);
       columns_info.push_back(info);
       selectable_columns.push_back(QString::fromStdString(info.name));
+    }
+    else if (is_string)
+    {
+      info.string_data = &plot_data.getOrCreateStringSeries(info.name, nullptr);
+      columns_info.push_back(info);
+      // String columns are loaded but not offered as a timestamp axis.
     }
   }
 
@@ -390,10 +402,43 @@ bool DataLoadParquet::readDataFromFile(FileLoadInfo* info, PlotDataMapRef& plot_
           timestamp = timestamp_to_row_index[row].first;
           ordered_row = timestamp_to_row_index[row].second;
         }
-        double value = get_arrow_value(values_array, ordered_row, info.arrow_type);
-        if (!std::isnan(value))
+
+        if (info.numeric_data)
         {
-          info.plot_data->pushBack({ timestamp, value });
+          double value = get_arrow_value(values_array, ordered_row, info.arrow_type);
+          if (!std::isnan(value))
+          {
+            info.numeric_data->pushBack({ timestamp, value });
+          }
+        }
+        else if (info.string_data)
+        {
+          if (values_array->IsNull(ordered_row))
+          {
+            continue;
+          }
+          std::string_view view;
+          switch (info.arrow_type)
+          {
+            case arrow::Type::STRING:
+              view =
+                  std::static_pointer_cast<arrow::StringArray>(values_array)->GetView(ordered_row);
+              break;
+            case arrow::Type::LARGE_STRING:
+              view = std::static_pointer_cast<arrow::LargeStringArray>(values_array)
+                         ->GetView(ordered_row);
+              break;
+            case arrow::Type::BINARY:
+              view =
+                  std::static_pointer_cast<arrow::BinaryArray>(values_array)->GetView(ordered_row);
+              break;
+            default:
+              break;
+          }
+          if (!view.empty())
+          {
+            info.string_data->pushBack({ timestamp, StringRef(view) });
+          }
         }
       }
 

--- a/plotjuggler_plugins/DataStreamZMQ/datastream_zmq.cpp
+++ b/plotjuggler_plugins/DataStreamZMQ/datastream_zmq.cpp
@@ -112,6 +112,17 @@ bool DataStreamZMQ::start(QStringList*)
   dialog->ui->lineEditPort->setText(QString::number(port));
   dialog->ui->lineEditTopics->setText(topics);
 
+  // IPC endpoints are filesystem paths; no port applies. Disable the port
+  // field when ipc:// is selected so the user doesn't type a value that
+  // would be silently ignored.
+  auto updatePortEnabled = [dialog]() {
+    const bool use_port = dialog->ui->comboBox->currentText() != "ipc://";
+    dialog->ui->lineEditPort->setEnabled(use_port);
+  };
+  connect(dialog->ui->comboBox, qOverload<const QString&>(&QComboBox::currentIndexChanged), dialog,
+          [updatePortEnabled](const QString&) { updatePortEnabled(); });
+  updatePortEnabled();
+
   connect(dialog->ui->comboBoxProtocol, qOverload<const QString&>(&QComboBox::currentIndexChanged),
           this, [this, dialog](const QString& selected_protocol) {
             if (_parser_creator)
@@ -150,7 +161,17 @@ bool DataStreamZMQ::start(QStringList*)
   settings.setValue("ZMQ_Subscriber::topics", topics);
   settings.setValue("ZMQ_Subscriber::is_connect", _is_connect);
 
-  QString addr = dialog->ui->comboBox->currentText() + address + ":" + QString::number(port);
+  const QString endpoint_protocol = dialog->ui->comboBox->currentText();
+  QString addr;
+  if (endpoint_protocol == "ipc://")
+  {
+    // IPC endpoints are filesystem paths; no port suffix.
+    addr = endpoint_protocol + address;
+  }
+  else
+  {
+    addr = endpoint_protocol + address + ":" + QString::number(port);
+  }
   _socket_address = addr.toStdString();
   if (_is_connect)
   {

--- a/plotjuggler_plugins/ToolboxCSV/toolbox_csv.cpp
+++ b/plotjuggler_plugins/ToolboxCSV/toolbox_csv.cpp
@@ -50,7 +50,7 @@ ToolboxCSV::ToolboxCSV()
     updateTimeRange();
   });
 
-  // Add all topics of the data
+  // Add all topics of the data (numeric + string series).
   connect(&_ui, &ToolBoxUI::addAllRequested, this, [this]() {
     if (!_plot_data)
     {
@@ -58,9 +58,13 @@ ToolboxCSV::ToolboxCSV()
     }
 
     std::vector<std::string> topics;
-    topics.reserve(_plot_data->numeric.size());
+    topics.reserve(_plot_data->numeric.size() + _plot_data->strings.size());
 
     for (const auto& [name, _] : _plot_data->numeric)
+    {
+      topics.push_back(name);
+    }
+    for (const auto& [name, _] : _plot_data->strings)
     {
       topics.push_back(name);
     }
@@ -107,7 +111,8 @@ bool ToolboxCSV::onShowWidget()
 
 bool ToolboxCSV::serializeTable(const ExportTable& table, const QString& path, bool is_csv)
 {
-  if (path.isEmpty() || table.time.empty() || table.cols.size() != table.names.size())
+  if (path.isEmpty() || table.time.empty() || table.cols.size() != table.names.size() ||
+      table.string_cols.size() != table.string_names.size())
   {
     return false;
   }
@@ -169,19 +174,36 @@ void ToolboxCSV::onExportMultipleFiles(bool is_csv, QDir dir, QString prefix)
 
   const QString ext = is_csv ? "csv" : "parquet";
 
-  // Group selected topics by their PlotGroup name.
+  // Group selected topics by their PlotGroup name (check numeric, then string).
   std::map<std::string, std::vector<std::string>> groups;
 
   for (const auto& topic_name : selected_topics)
   {
-    auto it = _plot_data->numeric.find(topic_name);
-    if (it == _plot_data->numeric.end())
+    std::string group_name = "ungrouped";
+
+    auto it_num = _plot_data->numeric.find(topic_name);
+    if (it_num != _plot_data->numeric.end())
     {
-      continue;
+      const auto& gp = it_num->second.group();
+      if (gp)
+      {
+        group_name = gp->name();
+      }
+    }
+    else
+    {
+      auto it_str = _plot_data->strings.find(topic_name);
+      if (it_str == _plot_data->strings.end())
+      {
+        continue;  // topic not found in either map
+      }
+      const auto& gp = it_str->second.group();
+      if (gp)
+      {
+        group_name = gp->name();
+      }
     }
 
-    const auto& group_ptr = it->second.group();
-    std::string group_name = group_ptr ? group_ptr->name() : "ungrouped";
     groups[group_name].push_back(topic_name);
   }
 
@@ -196,19 +218,23 @@ void ToolboxCSV::onExportMultipleFiles(bool is_csv, QDir dir, QString prefix)
     }
 
     // Strip group prefix from column names (e.g. "/robot/imu/accel" -> "accel").
-    for (auto& col_name : table.names)
-    {
-      if (col_name.size() > group_name.size() &&
-          col_name.compare(0, group_name.size(), group_name) == 0)
+    auto strip_prefix = [&group_name](std::vector<std::string>& names) {
+      for (auto& col_name : names)
       {
-        size_t start = group_name.size();
-        if (start < col_name.size() && col_name[start] == '/')
+        if (col_name.size() > group_name.size() &&
+            col_name.compare(0, group_name.size(), group_name) == 0)
         {
-          start++;
+          size_t start = group_name.size();
+          if (start < col_name.size() && col_name[start] == '/')
+          {
+            start++;
+          }
+          col_name.erase(0, start);
         }
-        col_name.erase(0, start);
       }
-    }
+    };
+    strip_prefix(table.names);
+    strip_prefix(table.string_names);
 
     // Sanitize group name for use in filename.
     QString safe_group = QString::fromStdString(group_name);
@@ -252,30 +278,15 @@ void ToolboxCSV::onClosed()
   emit closed();
 }
 
-// Compute global [tmin, tmax] across selected numeric topics.
+// Compute global [tmin, tmax] across selected topics (numeric + string).
 bool ToolboxCSV::getTimeRange(double& tmin, double& tmax) const
 {
   bool any = false;
 
   const auto topics = _ui.getSelectedTopics();
 
-  for (const auto& name : topics)
-  {
-    auto it = _plot_data->numeric.find(name);
-    if (it == _plot_data->numeric.end())
-    {
-      continue;
-    }
-
-    const auto& plot = it->second;
-    if (plot.size() == 0)
-    {
-      continue;
-    }
-
-    const double front_time = plot.front().x;
-    const double back_time = plot.back().x;
-
+  // Helper to update bounds from a single series.
+  auto update_bounds = [&](double front_time, double back_time) {
     if (!any)
     {
       tmin = front_time;
@@ -286,6 +297,24 @@ bool ToolboxCSV::getTimeRange(double& tmin, double& tmax) const
     {
       tmin = std::min(tmin, front_time);
       tmax = std::max(tmax, back_time);
+    }
+  };
+
+  for (const auto& name : topics)
+  {
+    // Check numeric series.
+    auto it_num = _plot_data->numeric.find(name);
+    if (it_num != _plot_data->numeric.end() && it_num->second.size() > 0)
+    {
+      update_bounds(it_num->second.front().x, it_num->second.back().x);
+      continue;
+    }
+
+    // Check string series.
+    auto it_str = _plot_data->strings.find(name);
+    if (it_str != _plot_data->strings.end() && it_str->second.size() > 0)
+    {
+      update_bounds(it_str->second.front().x, it_str->second.back().x);
     }
   }
 
@@ -311,7 +340,8 @@ void ToolboxCSV::updateTimeRange()
 }
 
 // Estimate local minimum dt to derive adaptive merge tolerance.
-double ToolboxCSV::estimateMinDt(const PJ::PlotData& plot, size_t start_idx, double t_end)
+template <typename TSeries>
+double ToolboxCSV::estimateMinDt(const TSeries& plot, size_t start_idx, double t_end)
 {
   if (plot.size() < 2 || start_idx + 1 >= plot.size())
   {
@@ -343,6 +373,10 @@ double ToolboxCSV::estimateMinDt(const PJ::PlotData& plot, size_t start_idx, dou
   return min_dt;
 }
 
+template double ToolboxCSV::estimateMinDt<PJ::PlotData>(const PJ::PlotData&, size_t, double);
+template double ToolboxCSV::estimateMinDt<PJ::StringSeries>(const PJ::StringSeries&, size_t,
+                                                            double);
+
 // Merge multiple time series into a row-aligned table using adaptive tolerance.
 ToolboxCSV::ExportTable ToolboxCSV::buildExportTable(const std::vector<std::string>& topics,
                                                      double t_start, double t_end) const
@@ -357,6 +391,14 @@ ToolboxCSV::ExportTable ToolboxCSV::buildExportTable(const std::vector<std::stri
     size_t idx;
   };
 
+  struct StringSeriesRef
+  {
+    std::string name;
+    const PJ::StringSeries* plot;
+    size_t idx;
+  };
+
+  // Collect numeric series.
   std::vector<SeriesRef> series;
   series.reserve(topics.size());
 
@@ -383,16 +425,50 @@ ToolboxCSV::ExportTable ToolboxCSV::buildExportTable(const std::vector<std::stri
     series.push_back({ name, &plot, static_cast<size_t>(index) });
   }
 
-  if (series.empty())
+  // Collect string series.
+  std::vector<StringSeriesRef> str_series;
+
+  for (const auto& name : topics)
+  {
+    auto it = _plot_data->strings.find(name);
+    if (it == _plot_data->strings.end())
+    {
+      continue;
+    }
+
+    const auto& plot = it->second;
+    if (plot.size() == 0 || plot.front().x > t_end || plot.back().x < t_start)
+    {
+      continue;
+    }
+
+    int index = plot.getIndexFromX(t_start);
+    if (index < 0)
+    {
+      continue;
+    }
+
+    str_series.push_back({ name, &plot, static_cast<size_t>(index) });
+  }
+
+  if (series.empty() && str_series.empty())
   {
     return table;
   }
 
-  // Compute tolerance from the minimum observed sample period.
+  // Compute tolerance from the minimum observed sample period across both types.
   double min_dt = 0.0;
   {
     double best = std::numeric_limits<double>::max();
     for (const auto& sr : series)
+    {
+      double dt = estimateMinDt(*sr.plot, sr.idx, t_end);
+      if (dt > 0.0 && dt < best)
+      {
+        best = dt;
+      }
+    }
+    for (const auto& sr : str_series)
     {
       double dt = estimateMinDt(*sr.plot, sr.idx, t_end);
       if (dt > 0.0 && dt < best)
@@ -410,6 +486,9 @@ ToolboxCSV::ExportTable ToolboxCSV::buildExportTable(const std::vector<std::stri
   const double tol = (min_dt > 0.0) ? (0.5 * min_dt) : 0.0;
 
   const size_t N = series.size();
+  const size_t S = str_series.size();
+
+  // Initialize numeric columns.
   table.names.reserve(N);
   table.cols.assign(N, {});
   table.has_value.assign(N, {});
@@ -418,15 +497,25 @@ ToolboxCSV::ExportTable ToolboxCSV::buildExportTable(const std::vector<std::stri
     table.names.push_back(sr.name);
   }
 
+  // Initialize string columns.
+  table.string_names.reserve(S);
+  table.string_cols.assign(S, {});
+  table.string_has_value.assign(S, {});
+  for (const auto& sr : str_series)
+  {
+    table.string_names.push_back(sr.name);
+  }
+
   const auto NaN = std::numeric_limits<double>::quiet_NaN();
   std::vector<double> row_values(N, NaN);
-
-  // Track sample presence separately from numeric value (handles NaN correctly).
   std::vector<bool> row_used(N, false);
+
+  std::vector<std::string> str_row_values(S);
+  std::vector<bool> str_row_used(S, false);
 
   while (true)
   {
-    // Find next row time as the minimum current timestamp among series.
+    // Find next row time as the minimum current timestamp among all series.
     bool done = true;
     double min_time = std::numeric_limits<double>::max();
 
@@ -451,15 +540,38 @@ ToolboxCSV::ExportTable ToolboxCSV::buildExportTable(const std::vector<std::stri
       }
     }
 
+    for (size_t col = 0; col < S; col++)
+    {
+      auto& sr = str_series[col];
+      if (sr.idx >= sr.plot->size())
+      {
+        continue;
+      }
+
+      const auto& point = sr.plot->at(sr.idx);
+      if (point.x > t_end)
+      {
+        continue;
+      }
+
+      done = false;
+      if (point.x < min_time)
+      {
+        min_time = point.x;
+      }
+    }
+
     if (done || min_time > t_end)
     {
       break;
     }
 
+    // Reset row buffers.
     std::fill(row_values.begin(), row_values.end(), NaN);
     std::fill(row_used.begin(), row_used.end(), false);
+    std::fill(str_row_used.begin(), str_row_used.end(), false);
 
-    // Fill values for this row (within tolerance), then advance only the series that contributed.
+    // Fill numeric values within tolerance.
     for (size_t col = 0; col < N; col++)
     {
       auto& sr = series[col];
@@ -474,25 +586,42 @@ ToolboxCSV::ExportTable ToolboxCSV::buildExportTable(const std::vector<std::stri
         continue;
       }
 
-      if (tol == 0.0)
+      const bool match =
+          (tol == 0.0) ? (point.x == min_time) : (std::abs(point.x - min_time) <= tol);
+      if (match)
       {
-        if (point.x == min_time)
-        {
-          row_values[col] = point.y;
-          row_used[col] = true;
-        }
-      }
-      else
-      {
-        if (std::abs(point.x - min_time) <= tol)
-        {
-          row_values[col] = point.y;
-          row_used[col] = true;
-        }
+        row_values[col] = point.y;
+        row_used[col] = true;
       }
     }
 
+    // Fill string values within tolerance.
+    for (size_t col = 0; col < S; col++)
+    {
+      auto& sr = str_series[col];
+      if (sr.idx >= sr.plot->size())
+      {
+        continue;
+      }
+
+      const auto& point = sr.plot->at(sr.idx);
+      if (point.x > t_end)
+      {
+        continue;
+      }
+
+      const bool match =
+          (tol == 0.0) ? (point.x == min_time) : (std::abs(point.x - min_time) <= tol);
+      if (match)
+      {
+        str_row_values[col] = std::string(sr.plot->getString(point.y));
+        str_row_used[col] = true;
+      }
+    }
+
+    // Append row to table.
     table.time.push_back(min_time);
+
     for (size_t col = 0; col < N; col++)
     {
       table.cols[col].push_back(row_values[col]);
@@ -502,13 +631,23 @@ ToolboxCSV::ExportTable ToolboxCSV::buildExportTable(const std::vector<std::stri
         series[col].idx++;
       }
     }
+
+    for (size_t col = 0; col < S; col++)
+    {
+      table.string_cols[col].push_back(str_row_used[col] ? str_row_values[col] : std::string());
+      table.string_has_value[col].push_back(str_row_used[col] ? 1 : 0);
+      if (str_row_used[col])
+      {
+        str_series[col].idx++;
+      }
+    }
   }
 
   return table;
 }
 
 // Serialize ExportTable to a plain CSV file.
-// Layout: first column "time", followed by one column per topic.
+// Layout: first column "time", then numeric columns, then string columns.
 bool ToolboxCSV::serializeCSV(const ToolboxCSV::ExportTable& export_table, const QString& path)
 {
   QFile file(path);
@@ -520,8 +659,13 @@ bool ToolboxCSV::serializeCSV(const ToolboxCSV::ExportTable& export_table, const
   QTextStream out(&file);
   out.setCodec("UTF-8");
 
+  // Header: time, numeric columns, string columns.
   out << "time";
   for (const auto& col_name : export_table.names)
+  {
+    out << "," << QString::fromStdString(col_name);
+  }
+  for (const auto& col_name : export_table.string_names)
   {
     out << "," << QString::fromStdString(col_name);
   }
@@ -532,11 +676,13 @@ bool ToolboxCSV::serializeCSV(const ToolboxCSV::ExportTable& export_table, const
 
   const int num_rows = static_cast<int>(export_table.time.size());
   const int num_cols = static_cast<int>(export_table.names.size());
+  const int num_str_cols = static_cast<int>(export_table.string_names.size());
 
   for (int row = 0; row < num_rows; row++)
   {
     out << QString::number(export_table.time[row], 'f', time_decimals);
 
+    // Numeric columns.
     for (int col = 0; col < num_cols; col++)
     {
       out << ",";
@@ -561,6 +707,27 @@ bool ToolboxCSV::serializeCSV(const ToolboxCSV::ExportTable& export_table, const
         }
       }
     }
+
+    // String columns with RFC 4180 quoting.
+    for (int col = 0; col < num_str_cols; col++)
+    {
+      out << ",";
+      if (export_table.string_has_value[col][row] != 0)
+      {
+        const QString val = QString::fromStdString(export_table.string_cols[col][row]);
+        if (val.contains(',') || val.contains('"') || val.contains('\n') || val.contains('\r'))
+        {
+          QString escaped = val;
+          escaped.replace('"', "\"\"");
+          out << '"' << escaped << '"';
+        }
+        else
+        {
+          out << val;
+        }
+      }
+    }
+
     out << "\n";
   }
 
@@ -598,8 +765,35 @@ makeDoubleArray(const std::vector<double>& values, const std::vector<uint8_t>& p
   return arr;
 }
 
+// Build an Arrow UTF-8 string array. NULL represents missing sample.
+static arrow::Result<std::shared_ptr<arrow::Array>>
+makeStringArray(const std::vector<std::string>& values, const std::vector<uint8_t>& present)
+{
+  arrow::StringBuilder builder;
+  ARROW_RETURN_NOT_OK(builder.Reserve(static_cast<int64_t>(values.size())));
+
+  if (present.size() != values.size())
+  {
+    return arrow::Status::Invalid("size mismatch");
+  }
+
+  for (size_t idx = 0; idx < values.size(); idx++)
+  {
+    if (!present[idx])
+    {
+      ARROW_RETURN_NOT_OK(builder.AppendNull());
+      continue;
+    }
+    ARROW_RETURN_NOT_OK(builder.Append(values[idx]));
+  }
+
+  std::shared_ptr<arrow::Array> arr;
+  ARROW_RETURN_NOT_OK(builder.Finish(&arr));
+  return arr;
+}
+
 // Serialize the merged ExportTable to a Parquet file using Arrow.
-// Each column is stored as Float64.
+// Numeric columns as Float64, string columns as UTF-8.
 bool ToolboxCSV::serializeParquet(const ToolboxCSV::ExportTable& export_table, const QString& path)
 {
   std::vector<std::shared_ptr<arrow::Field>> fields;
@@ -619,6 +813,19 @@ bool ToolboxCSV::serializeParquet(const ToolboxCSV::ExportTable& export_table, c
   {
     fields.push_back(arrow::field(export_table.names[col], arrow::float64()));
     auto arr_res = makeDoubleArray(export_table.cols[col], export_table.has_value[col]);
+    if (!arr_res.ok())
+    {
+      return false;
+    }
+    arrays.push_back(*arr_res);
+  }
+
+  // String columns as UTF-8.
+  for (size_t col = 0; col < export_table.string_names.size(); col++)
+  {
+    fields.push_back(arrow::field(export_table.string_names[col], arrow::utf8()));
+    auto arr_res =
+        makeStringArray(export_table.string_cols[col], export_table.string_has_value[col]);
     if (!arr_res.ok())
     {
       return false;

--- a/plotjuggler_plugins/ToolboxCSV/toolbox_csv.h
+++ b/plotjuggler_plugins/ToolboxCSV/toolbox_csv.h
@@ -6,6 +6,7 @@
 #include <QtPlugin>
 #include "PlotJuggler/toolbox_base.h"
 #include "PlotJuggler/plotwidget_base.h"
+#include "PlotJuggler/stringseries.h"
 #include "toolbox_ui.h"
 
 // Toolbox plugin to export selected PlotJuggler topics to CSV (extensible to other formats)
@@ -55,17 +56,24 @@ private:
 
   void updateTimeRange();
 
-  // Generic table representation for exporters (time + N columns)
+  // Generic table representation for exporters (time + N numeric + S string columns)
   struct ExportTable
   {
+    // Numeric columns
     std::vector<std::string> names;               // column names
-    std::vector<double> time;                     // time axis
+    std::vector<double> time;                     // shared time axis
     std::vector<std::vector<double>> cols;        // per-topic values
-    std::vector<std::vector<uint8_t>> has_value;  // Values checker
+    std::vector<std::vector<uint8_t>> has_value;  // presence flags
+
+    // String columns (parallel structure, same time axis)
+    std::vector<std::string> string_names;
+    std::vector<std::vector<std::string>> string_cols;
+    std::vector<std::vector<uint8_t>> string_has_value;
   };
 
-  // Tolerance helper
-  static double estimateMinDt(const PJ::PlotData& plot, size_t start_idx, double t_end);
+  // Tolerance helper (works with PlotData and StringSeries — both have .size() and .at().x)
+  template <typename TSeries>
+  static double estimateMinDt(const TSeries& plot, size_t start_idx, double t_end);
 
   // Build a time-aligned export table from selected topics
   ExportTable buildExportTable(const std::vector<std::string>& topics, double t_start,


### PR DESCRIPTION
  - **#850** — Add "Skip lines before header" spinbox to CSV load dialog. Wires the existing `skip_rows` backend to the UI with live preview, delimiter 
  re-detection, and persistence.
  - **#1000** — Add `--auto-prefix` CLI flag. Each file loaded with `-d` gets its basename as prefix, avoiding series name collisions.                  
  - **#987** — Allow `-d` to accept directories (recursive file discovery). Drag-and-drop folders also supported, with auto-prefix enabled              
  automatically.                                                                                                                                       