### PR TITLE
Fix: Curve reading from layout xml file now works correctly such that all curves are found

### DIFF
--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -3574,28 +3574,29 @@ QStringList MainWindow::readAllCurvesFromXML(QDomElement root_node)
 {
   QStringList curves;
 
-  QStringList level_names = { "tabbed_widget", "Tab",  "Container", "DockSplitter",
-                              "DockArea",      "plot", "curve" };
-
-  std::function<void(int, QDomElement)> recursiveXmlStream;
-  recursiveXmlStream = [&](int level, QDomElement parent_elem) {
-    QString level_name = level_names[level];
-    for (auto elem = parent_elem.firstChildElement(level_name); elem.isNull() == false;
-         elem = elem.nextSiblingElement(level_name))
+  // Recursively find all <curve> elements regardless of nesting
+  std::function<void(QDomElement)> findCurves;
+  findCurves = [&](QDomElement elem) {
+    // Check if this element is a curve
+    if (elem.tagName() == "curve")
     {
-      if (level_name == "curve")
+      QString name = elem.attribute("name");
+      if (!name.isEmpty())
       {
-        curves.push_back(elem.attribute("name"));
+        curves.push_back(name);
       }
-      else
-      {
-        recursiveXmlStream(level + 1, elem);
-      }
+      return;  // curves don't have child curves
+    }
+
+    // Recursively process all child elements
+    for (QDomElement child = elem.firstChildElement(); !child.isNull();
+         child = child.nextSiblingElement())
+    {
+      findCurves(child);
     }
   };
 
-  // start recursion
-  recursiveXmlStream(0, root_node);
+  findCurves(root_node);
 
   return curves;
 }


### PR DESCRIPTION
I had the issue that saving a layout and the loading it gave me an error that not all curves could be found. The respective curves were not added to the saved layout and I had to do it manually again. This was annoying and this PR should fix this. At least it does so for my saved XML with UDP server and protobuf. 
Are there more test cases that I should check? 

A simple way to reproduce the issue would be to try to load the layout from the following xml file: 

[plotjuggler_layout.xml](https://github.com/user-attachments/files/26784585/plotjuggler_layout.xml)

using plotjuggler -l plotjuggler_layout.xml