### PR TITLE
fix(appimage): HiDPI scaling + theme isolation on GNOME

### DIFF
--- a/appimage/AppImage.sh
+++ b/appimage/AppImage.sh
@@ -14,4 +14,26 @@ fi
 
 
 
-./linuxdeploy-x86_64.AppImage  --appimage-extract-and-run --appdir $APPDIRPATH -d ../io.plotjuggler.PlotJuggler.desktop -i ../plotjuggler.png --plugin qt --output appimage
+# Populate AppDir with Qt libraries / plugins. No --output yet: we need
+# to patch the auto-generated apprun-hooks/linuxdeploy-plugin-qt-hook.sh
+# before packaging.
+./linuxdeploy-x86_64.AppImage --appimage-extract-and-run \
+    --appdir "$APPDIRPATH" \
+    -d ../io.plotjuggler.PlotJuggler.desktop \
+    -i ../plotjuggler.png \
+    --plugin qt \
+    || { echo "ERROR: linuxdeploy Qt deploy stage failed" >&2; exit 1; }
+
+# linuxdeploy-plugin-qt auto-injects `export QT_QPA_PLATFORMTHEME=gtk2`
+# on GNOME/XFCE for "native look" — but we don't bundle a gtk2
+# platformtheme plugin, so Qt silently falls back and fonts/icons
+# break. Fusion is already forced from main.cpp; drop just that line.
+sed -i '/QT_QPA_PLATFORMTHEME/d' \
+    "$APPDIRPATH/apprun-hooks/linuxdeploy-plugin-qt-hook.sh" \
+    || { echo "ERROR: failed to patch linuxdeploy-plugin-qt hook" >&2; exit 1; }
+
+# Now package the patched AppDir into an AppImage.
+./linuxdeploy-x86_64.AppImage --appimage-extract-and-run \
+    --appdir "$APPDIRPATH" \
+    --output appimage \
+    || { echo "ERROR: AppImage packaging stage failed" >&2; exit 1; }

--- a/plotjuggler_app/main.cpp
+++ b/plotjuggler_app/main.cpp
@@ -23,6 +23,7 @@
 #include <QHostInfo>
 #include <QSslConfiguration>
 #include <QSslSocket>
+#include <QStyleFactory>
 
 #include "PlotJuggler/transform_function.h"
 #include "transforms/binary_filter.h"
@@ -164,7 +165,23 @@ int main(int argc, char* argv[])
     new_argv.push_back(args[i].data());
   }
 
+  // Must be set before QApplication is constructed. Tells Qt to scale
+  // widget metrics and QSS pixel values by the screen's scale factor,
+  // so XWayland (which reports DPI=N*96 with dpr=1) renders identically
+  // to native Wayland (DPI=96 dpr=N). Without this, Fusion metrics
+  // auto-scale by DPI but QSS hardcoded `px` values don't, causing
+  // inconsistent widget sizing in the AppImage.
+  QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+  QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+
   QApplication app(new_argc, new_argv.data());
+
+  // Pin the Qt base style so the app's QSS paints on top of a known
+  // palette. Without this, the AppImage inherits the host's Qt platform
+  // theme (e.g. GTK3 dark on Ubuntu), causing unstyled widgets like the
+  // menu bar to render with system-dark colors while QSS-covered widgets
+  // stay light — the mixed-theme look users report.
+  QApplication::setStyle(QStyleFactory::create("Fusion"));
 
   //-------------------------
 


### PR DESCRIPTION
On HiDPI GNOME hosts the AppImage rendered with mixed widget sizes (Fusion scales by DPI, QSS px values don't) and mixed-theme colors (linuxdeploy-plugin-qt injects QT_QPA_PLATFORMTHEME=gtk2 but the gtk2 plugin isn't bundled, so Qt silently falls back and loses fonts/icons).

- main.cpp: AA_EnableHighDpiScaling + AA_UseHighDpiPixmaps before QApplication; pin Fusion style so QSS paints on a known palette.
- appimage/AppImage.sh: split linuxdeploy into two passes and sed the QT_QPA_PLATFORMTHEME line out of the auto-generated Qt hook between them. Exit-code checks on each stage.