### PR TITLE
DataLoadULog: fix loading of ULog files larger than 2 GB (#672)

### DIFF
--- a/plotjuggler_plugins/DataLoadULog/dataload_ulog.cpp
+++ b/plotjuggler_plugins/DataLoadULog/dataload_ulog.cpp
@@ -38,8 +38,15 @@ bool DataLoadULog::readDataFromFile(FileLoadInfo* fileload_info, PlotDataMapRef&
   {
     throw std::runtime_error("ULog: Failed to open file");
   }
-  QByteArray file_array = file.readAll();
-  ULogParser::DataStream datastream(file_array.data(), file_array.size());
+  const qint64 file_size = file.size();
+  uchar* mapped = file.map(0, file_size);
+  if (!mapped)
+  {
+    throw std::runtime_error(std::string("ULog: failed to memory-map file: ") +
+                             file.errorString().toStdString());
+  }
+  ULogParser::DataStream datastream(reinterpret_cast<char*>(mapped),
+                                    static_cast<size_t>(file_size));
 
   ULogParser parser(datastream);
 

--- a/plotjuggler_plugins/DataLoadULog/ulog_parser.h
+++ b/plotjuggler_plugins/DataLoadULog/ulog_parser.h
@@ -33,11 +33,11 @@ public:
     const size_t _length;
     size_t offset;
 
-    DataStream(char* data, int len) : _data(data), _length(len), offset(0)
+    DataStream(char* data, size_t len) : _data(data), _length(len), offset(0)
     {
     }
 
-    void read(char* dst, int len)
+    void read(char* dst, size_t len)
     {
       memcpy(dst, &_data[offset], len);
       offset += len;


### PR DESCRIPTION
Fixes #672.
                                                                                                        
  `QFile::readAll()` returns a `QByteArray`, whose size is `int` — so ULog
  files ≥ 2 GB overflowed and failed to load.                                                           
                                             
  - `dataload_ulog.cpp`: use `QFile::map()` instead of `readAll()`. Removes                             
    the 2 GB limit (`map()` takes `qint64`) and avoids duplicating the file                             
    in RAM.                                                                                             
  - `ulog_parser.h`: widen `DataStream` ctor and `read()` from `int` to                                 
    `size_t` to match the existing `_length` / `offset` members.  