### PR TITLE
DataStreamMQTT: default empty Topics filter to "#" (#876, #1148)

### DIFF
--- a/plotjuggler_plugins/DataStreamMQTT/mqtt_dialog.cpp
+++ b/plotjuggler_plugins/DataStreamMQTT/mqtt_dialog.cpp
@@ -165,10 +165,7 @@ void MQTT_Dialog::onButtonConnect()
   config.host = ui->lineEditHost->text().toStdString();
   config.port = ui->lineEditPort->text().toInt();
   config.topics.clear();
-  // Guard against empty Topics filter: MQTT 3.1.1 / 5 §3.8.3 forbid zero-length
-  // topic filters, and brokers drop the connection on a malformed SUBSCRIBE
-  // (the root cause of #876 half 1 and #1148). Fall back to the "#" wildcard
-  // that matches the field's placeholder when the user leaves it blank.
+  // MQTT §3.8.3 forbids zero-length topic filters; default to "#".
   QString topic_filter = ui->lineEditTopicFilter->text();
   if (topic_filter.isEmpty())
   {

--- a/plotjuggler_plugins/DataStreamMQTT/mqtt_dialog.cpp
+++ b/plotjuggler_plugins/DataStreamMQTT/mqtt_dialog.cpp
@@ -165,7 +165,16 @@ void MQTT_Dialog::onButtonConnect()
   config.host = ui->lineEditHost->text().toStdString();
   config.port = ui->lineEditPort->text().toInt();
   config.topics.clear();
-  config.topics.push_back(ui->lineEditTopicFilter->text().toStdString());
+  // Guard against empty Topics filter: MQTT 3.1.1 / 5 §3.8.3 forbid zero-length
+  // topic filters, and brokers drop the connection on a malformed SUBSCRIBE
+  // (the root cause of #876 half 1 and #1148). Fall back to the "#" wildcard
+  // that matches the field's placeholder when the user leaves it blank.
+  QString topic_filter = ui->lineEditTopicFilter->text();
+  if (topic_filter.isEmpty())
+  {
+    topic_filter = "#";
+  }
+  config.topics.push_back(topic_filter.toStdString());
   config.username = ui->lineEditUsername->text().toStdString();
   config.password = ui->lineEditPassword->text().toStdString();
   config.qos = ui->comboBoxQoS->currentIndex();


### PR DESCRIPTION
Fixes #876, #1148.                                                                                    
                                                                                                        
  Connecting with an empty "Topics filter" sent a zero-length subscription
  to the broker. MQTT §3.8.3 forbids this, so the broker rejected the                                   
  connection and nothing could be plotted.                           
                                                                                                        
  - `mqtt_dialog.cpp`: if the filter field is empty, substitute `"#"`                                   
    (MQTT wildcard = subscribe to everything). Non-empty input is passed                                
    through unchanged. 