### PR TITLE
CI: install missing jazzy typesupport implementations

### DIFF
--- a/.github/workflows/ros2-jazzy.yaml
+++ b/.github/workflows/ros2-jazzy.yaml
@@ -27,6 +27,11 @@ jobs:
         with:
           required-ros-distributions: jazzy
 
+      # jazzy's ros-base does not always pull in typesupport implementations,
+      # causing "No 'rosidl_typesupport_c' found" at CMake configure time.
+      - name: Install missing jazzy typesupport
+        run: sudo apt-get install -y ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-introspection-cpp
+
       # Run ROS CI
       - uses: ros-tooling/action-ros-ci@v0.4
         with:


### PR DESCRIPTION
ros-jazzy-ros-base does not guarantee that rosidl typesupport implementations are pulled in, causing CMake to fail with "No 'rosidl_typesupport_c' found" when configuring rclcpp. Explicitly install introspection-based typesupports as a fix.

Mirrors the earlier rolling fix in d00d8a6f.