### PR TITLE
fix(mosaico): force static Arrow/Flight linkage to fix Windows build

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -43,6 +43,13 @@ jobs:
         run: |
           conan install . -of build --build=missing -pr:b=default -s build_type=Release -s compiler.cppstd=17
 
+      - name: Trim Conan cache before save
+        # Drop build trees, extracted sources and tempdirs to keep the saved
+        # cache small (consumers only need ~/.conan2/p/<id>/p). Without this
+        # the post-job actions/cache save can exceed the 10 GB soft cap.
+        run: |
+          conan cache clean "*" --build --source --temp
+
       - name: Install and cache Homebrew tools
         uses: tecolicom/actions-use-homebrew-tools@v1
         with:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -55,6 +55,14 @@ jobs:
         run: |
           conan install . -of build --build=missing -pr:b=default -s build_type=Release -s compiler.cppstd=17
 
+      - name: Trim Conan cache before save
+        shell: pwsh
+        # Drop build trees, extracted sources and tempdirs to keep the saved
+        # cache small (consumers only need ~/.conan2/p/<id>/p). Without this
+        # the post-job actions/cache save can exceed the 10 GB soft cap.
+        run: |
+          conan cache clean "*" --build --source --temp
+
       - name: Build Plotjuggler
         shell: pwsh
         run: |

--- a/plotjuggler_plugins/ToolboxMosaico/3rdparty/mosaico_sdk/src/CMakeLists.txt
+++ b/plotjuggler_plugins/ToolboxMosaico/3rdparty/mosaico_sdk/src/CMakeLists.txt
@@ -11,20 +11,14 @@ target_include_directories(mosaico_sdk PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-set(MOSAICO_SDK_ARROW_FLIGHT_TARGET "")
-foreach(candidate ArrowFlight::arrow_flight_static ArrowFlight::arrow_flight_shared)
-    if(TARGET ${candidate})
-        set(MOSAICO_SDK_ARROW_FLIGHT_TARGET ${candidate})
-        break()
-    endif()
-endforeach()
-if(NOT MOSAICO_SDK_ARROW_FLIGHT_TARGET)
-    message(FATAL_ERROR "[MosaicoSDK] Arrow Flight target not found.")
+# Plugins always link Arrow Flight statically.
+if(NOT TARGET ArrowFlight::arrow_flight_static)
+    message(FATAL_ERROR "[MosaicoSDK] ArrowFlight::arrow_flight_static target not found.")
 endif()
 
 target_link_libraries(mosaico_sdk PUBLIC
     arrow::arrow
-    ${MOSAICO_SDK_ARROW_FLIGHT_TARGET}
+    ArrowFlight::arrow_flight_static
     nlohmann_json::nlohmann_json
 )
 

--- a/plotjuggler_plugins/ToolboxMosaico/CMakeLists.txt
+++ b/plotjuggler_plugins/ToolboxMosaico/CMakeLists.txt
@@ -1,40 +1,29 @@
 find_package(Arrow QUIET CONFIG)
-if(NOT TARGET ArrowFlight::arrow_flight_static AND NOT TARGET ArrowFlight::arrow_flight_shared)
+if(NOT TARGET ArrowFlight::arrow_flight_static)
     find_package(ArrowFlight QUIET CONFIG)
 endif()
 
-set(MOSAICO_ARROW_FLIGHT_TARGET "")
-foreach(candidate ArrowFlight::arrow_flight_static ArrowFlight::arrow_flight_shared)
-    if(TARGET ${candidate})
-        set(MOSAICO_ARROW_FLIGHT_TARGET ${candidate})
-        break()
-    endif()
-endforeach()
+# Plugins always link Arrow/Flight statically (see CLAUDE / project policy).
+set(MOSAICO_ARROW_FLIGHT_TARGET ArrowFlight::arrow_flight_static)
+set(MOSAICO_ARROW_TARGET Arrow::arrow_static)
 
-if(NOT Arrow_FOUND OR NOT MOSAICO_ARROW_FLIGHT_TARGET)
-    message("[ToolboxMosaico] Arrow/Flight not found. Skipping plugin.")
+if(NOT Arrow_FOUND OR NOT TARGET ${MOSAICO_ARROW_FLIGHT_TARGET} OR NOT TARGET ${MOSAICO_ARROW_TARGET})
+    message("[ToolboxMosaico] Arrow/Flight static targets not found. Skipping plugin.")
     return()
 endif()
 
-# The SDK uses Arrow Flight symbols. Keep Arrow and Flight as explicit
-# targets so the final plugin link line includes both static libraries.
+# Combine Arrow + Flight as a single propagated target. ARROW_STATIC /
+# ARROW_FLIGHT_STATIC are required so MSVC headers don't decorate symbols
+# with __declspec(dllimport): without them the static archive cannot
+# satisfy implicit members (LNK2019 / LNK4217 on inline ctor/dtor/copy).
 if(NOT TARGET arrow::arrow)
-    set(MOSAICO_ARROW_TARGET "")
-    foreach(candidate Arrow::arrow_static Arrow::arrow_shared)
-        if(TARGET ${candidate})
-            set(MOSAICO_ARROW_TARGET ${candidate})
-            break()
-        endif()
-    endforeach()
-    if(NOT MOSAICO_ARROW_TARGET)
-        message("[ToolboxMosaico] Arrow target not found. Skipping plugin.")
-        return()
-    endif()
-
     add_library(arrow_combined INTERFACE)
     target_link_libraries(arrow_combined INTERFACE
         ${MOSAICO_ARROW_TARGET}
         ${MOSAICO_ARROW_FLIGHT_TARGET})
+    target_compile_definitions(arrow_combined INTERFACE
+        ARROW_STATIC
+        ARROW_FLIGHT_STATIC)
     add_library(arrow::arrow ALIAS arrow_combined)
 endif()
 


### PR DESCRIPTION
## Summary
- Fix 12 `LNK2019` + ~15 `LNK4217` errors building `ToolboxMosaico.dll` on Windows (regression caught on the 3.17.0 release CI).
- Drop `_shared` fallback paths in `ToolboxMosaico` and `mosaico_sdk` CMake — per project policy plugins always link Arrow/Flight statically.
- Add `ARROW_STATIC` / `ARROW_FLIGHT_STATIC` compile definitions to the `arrow_combined` INTERFACE library; they propagate through `arrow::arrow` → `mosaico_sdk` (PUBLIC) → `ToolboxMosaico`.

## Root cause
Conan's CMakeDeps for `arrow/21.0.0` (with `arrow/*:shared=False`) does not propagate `ARROW_STATIC` / `ARROW_FLIGHT_STATIC` on `ArrowFlight::arrow_flight_static` / `Arrow::arrow_static`. On MSVC, Arrow headers therefore default `ARROW_FLIGHT_EXPORT` to `__declspec(dllimport)`. Implicit/inline members (default ctors, dtors, copy ctors) are not synthesized by MSVC for dllimport-marked classes, and the static archive has no `__imp_*` thunks for them — hence the link failures. The `LNK4217` warnings on resolved symbols (`...defined in arrow_flight_static.lib...is imported by mosaico_sdk.lib...`) confirmed the diagnosis.

## Test plan
- [ ] `windows` CI green
- [ ] `ubuntu` CI green
- [ ] `debian` CI green
- [ ] `macos` CI green (notarize gate skipped on non-tag branches — expected)
- [ ] `ros2-humble` / `ros2-jazzy` / `ros2-rolling` CI green
- [ ] `snap_core22` / `snap_core24` CI green
- [x] Local Linux configure + `cmake --build build --target ToolboxMosaico` succeeds (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)