### PR TITLE
fix(mosaico): preserve sequence selection on lazy load

### DIFF
--- a/plotjuggler_plugins/ToolboxMosaico/src/ui/main_window.cpp
+++ b/plotjuggler_plugins/ToolboxMosaico/src/ui/main_window.cpp
@@ -398,7 +398,6 @@ void MainWindow::onSequencesReady(const std::vector<SequenceInfo>& sequences)
 
     all_sequences_ = sequences;
     sequence_panel_->setLoading(false);
-    sequence_panel_->populateSequences(sequences);
     connect_button_->setEnabled(true);
     connect_button_->setText("Connect");
     refresh_button_->setEnabled(true);

--- a/plotjuggler_plugins/ToolboxMosaico/src/ui/sequence/sequence_panel.cpp
+++ b/plotjuggler_plugins/ToolboxMosaico/src/ui/sequence/sequence_panel.cpp
@@ -200,6 +200,18 @@ void SequencePanel::updateHeader()
 
 void SequencePanel::populateSequences(const std::vector<SequenceInfo>& sequences)
 {
+  // Snapshot the user's selection by name — setRowCount(0) below removes all
+  // rows from the model and the QItemSelectionModel drops the now-invalid
+  // index. Restored after rebuild if the same name still exists.
+  QString prev_selected;
+  if (const int cur_row = table_->currentRow(); cur_row >= 0)
+  {
+    if (auto* item = table_->item(cur_row, kColName))
+    {
+      prev_selected = item->text();
+    }
+  }
+
   sequence_list_populated_ = true;
   all_sequences_ = sequences;
   total_count_ = static_cast<int>(sequences.size());
@@ -227,6 +239,14 @@ void SequencePanel::populateSequences(const std::vector<SequenceInfo>& sequences
 
   table_->setSortingEnabled(true);
   applyFilter();
+
+  if (!prev_selected.isEmpty())
+  {
+    if (const int row = findRowByName(prev_selected); row >= 0)
+    {
+      table_->setCurrentCell(row, kColName);
+    }
+  }
 }
 
 void SequencePanel::updateSequence(const SequenceInfo& sequence)


### PR DESCRIPTION
## Summary
- After incremental sequence loading (commit 2bce987) the table populated twice: once from `sequenceListStarted` + per-sequence `sequenceInfoReady`, and again from `sequencesReady`. The second pass calls `populateSequences` which does `setRowCount(0)`, dropping any selection the user had made while the metadata scan was still running.
- Fix A: `MainWindow::onSequencesReady` no longer calls `populateSequences` — the table is already fully populated incrementally.
- Fix B: `SequencePanel::populateSequences` now snapshots the selected row's name and re-selects it after the rebuild, so any future caller doesn't reintroduce the regression.

## Test plan
- [ ] Connect to a Mosaico server with many sequences (so metadata loading is visibly progressive).
- [ ] While the header still reads `loading details N/M`, click a row.
- [ ] Confirm the row stays highlighted when the count reaches `M/M`.
- [ ] Confirm the topic panel for the selected sequence continues to load normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)