### PR TITLE
fix(mqtt): guard MQTT_Dialog dtor against Qt static teardown

### DIFF
--- a/plotjuggler_plugins/DataStreamMQTT/mqtt_dialog.cpp
+++ b/plotjuggler_plugins/DataStreamMQTT/mqtt_dialog.cpp
@@ -1,4 +1,5 @@
 #include "mqtt_dialog.h"
+#include <QCoreApplication>
 #include <QFileDialog>
 #include "PlotJuggler/svg_util.h"
 
@@ -141,6 +142,18 @@ void MQTT_Dialog::saveSettings()
 
 MQTT_Dialog::~MQTT_Dialog()
 {
+  // When the destructor runs from static teardown (e.g. __cxa_finalize_ranges
+  // after exit()), QtCore globals (QLocale, QSettings, QCoreApplication) are
+  // already destroyed. Any Qt operation here would dereference freed memory.
+  // Bail out and let the OS reclaim memory; the process is exiting anyway.
+  if (!QCoreApplication::instance())
+  {
+    return;
+  }
+
+  // The widgets in layoutOptions are borrowed from parser factories that own
+  // them. Detach them from this dialog before destruction so Qt's parent
+  // ownership does not delete factory-owned widgets.
   while (ui->layoutOptions->count() > 0)
   {
     auto item = ui->layoutOptions->takeAt(0);


### PR DESCRIPTION
## Problem
On macOS, closing PlotJuggler with the MQTT plugin loaded causes a SIGBUS during exit. The signal handler from backward-cpp catches it and prints:

```
exit() → __cxa_finalize_ranges → ~DataStreamMQTT → ~MQTT_Dialog →
  QWidget::setParent → QLocale::QLocale() → fault
```

(or, depending on the path through the destructor, a similar fault inside `QSettings` via `saveSettings()` → `QCoreApplication::organizationDomain()`.)

## Root cause
`~DataStreamMQTT` runs from `__cxa_finalize_ranges`, i.e. **after** `main` has returned and after `QCoreApplication` has been destroyed. By that point QtCore globals (`QLocale`, `QCoreApplication`, the `QSettings` format registry) are already torn down, so any Qt API used in the plugin's destructors dereferences freed memory.

This is a static destruction order issue between the plugin object's storage and QtCore — not specific to MQTT, but `~MQTT_Dialog` happens to be the first plugin destructor that calls into QtCore heavily (it reparents borrowed widgets via `QWidget::setParent`, then constructs a `QSettings`).

## Why not just remove the offending calls
- The reparenting loop is **not redundant**: `layoutOptions` holds widgets borrowed from parser factories (added in `DataStreamMQTT::start`), which the factories own. Without the loop, Qt's parent-child ownership would delete those factory-owned widgets when the dialog dies — leaving the factories with dangling pointers.
- The `saveSettings()` call persists the most recent form values on exit (the only other call site is `onButtonConnect`, which only fires if the user actually connects).

Both are correct behavior during normal lifecycle.

## Fix
Bail out of `~MQTT_Dialog` when `QCoreApplication::instance()` is null, i.e. when we're in static teardown. The process is exiting anyway, so leaking the (small) UI memory is preferable to crashing on freed Qt globals. The original cleanup logic runs unchanged in all other cases — e.g. when the plugin is unloaded mid-session.

## Testing
Tested on macOS 26.4 (Apple Silicon), Qt 5.15.18, Apple Clang 21:
- Launch and immediately close → exits cleanly (was crashing before).
- Open the MQTT dialog (which adds borrowed widgets to `layoutOptions`), dismiss it, then close PlotJuggler → exits cleanly (would have double-freed under a naive "just remove the loop" fix).