### PR TITLE
fix(plot): restore Y range envelope for constant-valued series

### DIFF
--- a/plotjuggler_base/src/plotwidget_base.cpp
+++ b/plotjuggler_base/src/plotwidget_base.cpp
@@ -271,7 +271,25 @@ Range PlotWidgetBase::getVisualizationRangeY(Range range_X) const
     top = 1.0;
   }
 
-  double margin = (top - bottom) * 0.025;
+  double margin;
+  if (top - bottom > std::numeric_limits<double>::epsilon())
+  {
+    margin = (top - bottom) * 0.025;
+  }
+  else
+  {
+    // Constant series: top == bottom would collapse the Y axis to zero height
+    // and hide the curve. Give it a visible envelope proportional to the value,
+    // falling back to 1.0 when the value itself is ~0.
+    if (std::fabs(top) > std::numeric_limits<double>::epsilon())
+    {
+      margin = std::fabs(top) * 0.05;
+    }
+    else
+    {
+      margin = 1.0;
+    }
+  }
 
   top += margin;
   bottom -= margin;


### PR DESCRIPTION
## Summary

A curve whose Y values are all the same constant currently does not render — the plot looks empty after dropping the series in.

## Problem

`PlotWidgetBase::getVisualizationRangeY` computes `margin = (top - bottom) * 0.025`. When every sample equals some constant `K`, `top == bottom == K`, so the margin is `0` and the returned Y range collapses to `{K, K}`. This zero-height range is then handed to `setAxisScale(yLeft, K, K)` (via `updateMaximumZoomArea` / `resetZoom`), and the curve becomes invisible.

The regression was introduced in e4ee6288 ("Fix #1080: vertical zoom no longer stuck on max 0.1"), which removed the previous `margin = 0.1` fallback. That commit fixed the empty-data case but didn't account for the constant-data case.

## Solution

When `top - bottom` is below epsilon, fall back to an envelope proportional to the value (`5% of |K|`), or `+/-1.0` when the constant itself is approximately zero. The empty-data branch (`bottom > top`) is untouched and still defaults to `+/-1.0`, so the #1080 behavior is preserved.

**Sponsored by ARK Electronics**