### PR TITLE
fix(ulog): bounds-check DataStream::read to handle truncated logs

### DIFF
--- a/plotjuggler_plugins/DataLoadULog/ulog_parser.cpp
+++ b/plotjuggler_plugins/DataLoadULog/ulog_parser.cpp
@@ -29,9 +29,20 @@ ULogParser::ULogParser(DataStream& datastream) : _file_start_time(0)
     ulog_message_header_s message_header;
     datastream.read((char*)&message_header, ULOG_MSG_HEADER_LEN);
 
+    if (!datastream)
+    {
+      break;
+    }
+
     _read_buffer.reserve(message_header.msg_size + 1);
     char* message = (char*)_read_buffer.data();
     datastream.read(message, message_header.msg_size);
+
+    if (!datastream)
+    {
+      break;
+    }
+
     message[message_header.msg_size] = '\0';
 
     switch (message_header.msg_type)

--- a/plotjuggler_plugins/DataLoadULog/ulog_parser.h
+++ b/plotjuggler_plugins/DataLoadULog/ulog_parser.h
@@ -39,6 +39,11 @@ public:
 
     void read(char* dst, size_t len)
     {
+      if (len > _length - offset)
+      {
+        offset = _length;
+        return;
+      }
       memcpy(dst, &_data[offset], len);
       offset += len;
     }


### PR DESCRIPTION
## Summary

Prevent a segfault in `DataLoadULog` when loading a ULog whose tail is truncated mid-message. Such logs are common with PX4 `SDLOG_MODE=2` ("log from boot") when power is cut before the file is closed.

## Problem

`ULogParser::DataStream::read` does a raw `memcpy` from the mmap'd file with no bounds check. If a partial header at the tail yields a `msg_size` that pushes `offset + len` past `_length`, the memcpy walks off the mapped region and the process dies with SIGSEGV inside `__memcpy_avx512_unaligned_erms`. Existing call sites already follow `read()` with `if (!datastream)` (where `operator bool` is `offset < _length`), but the crash happens inside `read` before that guard is ever reached.

## Solution

Bounds-check inside `DataStream::read`: if the requested length would overrun the buffer, skip the `memcpy` and saturate `offset` to `_length`. Every existing `!datastream` / `while(datastream)` guard then bails out gracefully, surfacing whatever data was readable up to the truncation point. The main parse loop in `ULogParser::ULogParser` also gets two explicit `if (!datastream) break;` checks (after the header read and after the body read) to match the pattern already used in `readFileDefinitions` and avoid interpreting an uninitialized header when the file ends exactly at a message boundary.

**Sponsored by ARK Electronics**