### PR TITLE
Allow timezone override using TZ env variable

### DIFF
--- a/plotjuggler_app/plotwidget.cpp
+++ b/plotjuggler_app/plotwidget.cpp
@@ -59,7 +59,8 @@ class TimeScaleDraw : public QwtScaleDraw
 {
   virtual QwtText label(double v) const
   {
-    QDateTime dt = QDateTime::fromMSecsSinceEpoch((qint64)(v * 1000), Qt::UTC);
+    const auto tz = QTimeZone(qEnvironmentVariable("TZ", "UTC").toUtf8());
+    QDateTime dt = QDateTime::fromMSecsSinceEpoch((qint64)(v * 1000), tz);
     if (dt.date().year() == 1970 && dt.date().month() == 1 && dt.date().day() == 1)
     {
       return dt.toString("hh:mm:ss.z");


### PR DESCRIPTION
For some uses cases, we want to set a specific timezone for the loaded data.
For this, we re-use the standard TZ variable that is used on posix systems for this. If the env variable is not set, we default to the UTC timezone as before.

Previously, this feature used to work out-of-the-box, but commit c0707de forced a UTC timezone, which broke the functionality.

Fixes #570
Related #1251, #1291