### PR TITLE
Show JointState message values when names are absent

### DIFF
--- a/plotjuggler_plugins/ParserROS/ros_parser.cpp
+++ b/plotjuggler_plugins/ParserROS/ros_parser.cpp
@@ -463,19 +463,40 @@ void ParserROS::parseJointStateMsg(const std::string& prefix, double& timestamp)
   }
   //---------------------------
   std::string series_name;
-  for (size_t i = 0; i < std::min(name_size, pos_size); i++)
+  for (size_t i = 0; i < pos_size; i++)
   {
-    series_name = fmt::format("{}/{}/position", _topic, msg.name[i]);
+    if (i < name_size)
+    {
+      series_name = fmt::format("{}/{}/position", _topic, msg.name[i]);
+    }
+    else
+    {
+      series_name = fmt::format("{}/[{}]/position", _topic, i);
+    }
     getSeries(series_name).pushBack({ timestamp, msg.position[i] });
   }
-  for (size_t i = 0; i < std::min(name_size, vel_size); i++)
+  for (size_t i = 0; i < vel_size; i++)
   {
-    series_name = fmt::format("{}/{}/velocity", _topic, msg.name[i]);
+    if (i < name_size)
+    {
+      series_name = fmt::format("{}/{}/velocity", _topic, msg.name[i]);
+    }
+    else
+    {
+      series_name = fmt::format("{}/[{}]/velocity", _topic, i);
+    }
     getSeries(series_name).pushBack({ timestamp, msg.velocity[i] });
   }
-  for (size_t i = 0; i < std::min(name_size, eff_size); i++)
+  for (size_t i = 0; i < eff_size; i++)
   {
-    series_name = fmt::format("{}/{}/effort", _topic, msg.name[i]);
+    if (i < name_size)
+    {
+      series_name = fmt::format("{}/{}/effort", _topic, msg.name[i]);
+    }
+    else
+    {
+      series_name = fmt::format("{}/[{}]/effort", _topic, i);
+    }
     getSeries(series_name).pushBack({ timestamp, msg.effort[i] });
   }
 }


### PR DESCRIPTION
This is to support the usage when the name array in JointState messages is empty in order to avoid sending duplicate joint names and save bandwidth budget. Currently if the name array is empty, the position, velocity and effort arrays are not displayed at all.

A basic test shows serialized JointState message with 7 joints:
```
Serialized size with names:    356 bytes
Serialized size without names: 212 bytes
Name field overhead:           144 bytes
```