### PR TITLE
feat(app): show loaded log file(s) in the window title

### DIFF
--- a/plotjuggler_app/mainwindow.cpp
+++ b/plotjuggler_app/mainwindow.cpp
@@ -228,6 +228,9 @@ MainWindow::MainWindow(const QCommandLineParser& commandline_parser, QWidget* pa
     }
   }
 
+  // Remember the startup title; loaded file names are appended to it later.
+  _base_window_title = windowTitle();
+
   QSettings settings;
 
   if (commandline_parser.isSet("buffer_size"))
@@ -1328,6 +1331,7 @@ void MainWindow::deleteAllData()
   _transform_functions.clear();
   _curvelist_widget->clear();
   _loaded_datafiles_history.clear();
+  updateWindowTitle();
   _undo_states.clear();
   _redo_states.clear();
 
@@ -1489,10 +1493,30 @@ bool MainWindow::loadDataFromFiles(QStringList filenames, bool auto_prefix)
   if (loaded_filenames.size() > 0)
   {
     updateRecentDataMenu(loaded_filenames);
+    updateWindowTitle();
     linkedZoomOut();
     return true;
   }
   return false;
+}
+
+void MainWindow::updateWindowTitle()
+{
+  if (_loaded_datafiles_history.empty())
+  {
+    setWindowTitle(_base_window_title);
+    return;
+  }
+
+  const QString first = QFileInfo(_loaded_datafiles_history.front().filename).fileName();
+  QString window_title = QString("%1 - %2").arg(_base_window_title, first);
+
+  const int others = static_cast<int>(_loaded_datafiles_history.size()) - 1;
+  if (others > 0)
+  {
+    window_title += QString(" (+%1)").arg(others);
+  }
+  setWindowTitle(window_title);
 }
 
 std::unordered_set<std::string> MainWindow::loadDataFromFile(const FileLoadInfo& info,
@@ -2172,6 +2196,7 @@ bool MainWindow::loadLayoutFromFile(QString filename, bool load_datafiles)
       datafile_elem = datafile_elem.nextSiblingElement("fileInfo");
     }
   }
+  updateWindowTitle();
 
   QDomElement previous_streamer = root.firstChildElement("previouslyLoaded_Streamer");
   if (!previous_streamer.isNull())
@@ -3723,6 +3748,7 @@ void MainWindow::on_buttonReloadData_clicked()
     loadDataFromFile(info, false);
   }
   ui->buttonReloadData->setEnabled(!_loaded_datafiles_previous.empty());
+  updateWindowTitle();
 }
 
 void MainWindow::on_buttonCloseStatus_clicked()

--- a/plotjuggler_app/mainwindow.h
+++ b/plotjuggler_app/mainwindow.h
@@ -182,6 +182,7 @@ private:
   QMenu* _recent_layout_files;
 
   QString _skin_path;
+  QString _base_window_title;
 
   // Toast notification manager
   ToastManager* _toast_manager;
@@ -237,6 +238,7 @@ private:
 
   void updateRecentDataMenu(QStringList new_filenames);
   void updateRecentLayoutMenu(QStringList new_filenames);
+  void updateWindowTitle();
 
   void updatedDisplayTime();
 


### PR DESCRIPTION
I regularly have several PlotJuggler windows open at once, each with a different (but similar-looking) log. Until now they all shared the same title, so it was hard to tell which window held which log.
This PR aims to fix this issue by showing which file(s) are loaded by updating the window title, e.g. `Plotjuggler - log1.ulg (+2)`.

The base title is captured once at startup so any skin or --window_title customization is preserved. Additionally, no title change is done when streaming, as different streams are almost always easily distinguishable.