### PR TITLE
Add Windows portable packaging script and integrate Windows release b…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,111 @@
+name: Release AppImage
+
+# Builds the portable Linux AppImage and, on a version tag, attaches it to the
+# GitHub Release. Modeled on PlotJuggler 3's ubuntu.yaml release job, adapted to
+# PJ4's heavier setup (Qt from aqt into ./.qt, deps from Conan) — so it reuses
+# the same Qt/Conan/ccache caching that linux-ci.yml relies on.
+#
+# Triggers:
+#   - push of a `v*` tag  -> build + publish the AppImage to that tag's Release
+#   - workflow_dispatch   -> build an AppImage from any branch (artifact only, no
+#                            Release upload) for smoke-testing the packaging
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write   # softprops/action-gh-release needs write to create/update the Release
+
+jobs:
+  appimage:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Use HTTPS for github.com submodules
+        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0   # tags/describe need full history
+
+      - uses: conan-io/setup-conan@v1
+        with:
+          cache_packages: false
+
+      - name: Cache Conan packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.conan2
+          # Keyed on the dependency manifests; partial reuse via the prefix.
+          key: conan-appimage-${{ hashFiles('**/conanfile.txt') }}
+          restore-keys: conan-appimage-
+
+      - name: Cache Qt 6.11.1
+        id: qt-cache
+        uses: actions/cache@v5
+        with:
+          path: .qt
+          key: qt-6.11.1-linux
+
+      - name: Install Qt 6.11.1 via aqt
+        if: steps.qt-cache.outputs.cache-hit != 'true'
+        run: ./install_qt6.sh   # installs into ./.qt; no-ops if already present
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          # libva-dev / libdrm-dev: required by the FFmpeg Conan build (VAAPI).
+          # imagemagick: `convert` rasterizes the app icon in build_appimage.sh.
+          # wget/file: linuxdeploy fetch + ELF inspection.
+          # unzip: --plugins-registry unpacks the downloaded plugin zips (python3
+          #        + sha256sum for registry parse/verify are already on the runner).
+          sudo apt-get install -y --no-install-recommends \
+            libva-dev libdrm-dev \
+            imagemagick wget file unzip ccache zstd
+
+      - name: Configure ccache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ccache
+          key: ccache-appimage-${{ github.sha }}
+          restore-keys: ccache-appimage-
+
+      - name: Build plotjuggler4
+        run: ./build.sh
+
+      - name: Build AppImage
+        env:
+          # The linuxdeploy tools are themselves AppImages; ubuntu-22.04 runners no
+          # longer ship libfuse2, so run them extracted instead of FUSE-mounted.
+          APPIMAGE_EXTRACT_AND_RUN: '1'
+        run: |
+          set -euo pipefail
+          # --plugins-registry: download the curated official plugin set (BUNDLE_IDS)
+          # from pj-plugin-registry (main), verify checksums, unpack into the bundle.
+          # Fails the release if any curated plugin can't be resolved/downloaded.
+          bash appimage/build_appimage.sh --plugins-registry
+          # Stamp the artifact with the tag (or short sha for manual runs). The
+          # script emits PlotJuggler-<version>-x86_64.AppImage into appimage/.
+          ref="${GITHUB_REF_NAME:-$(git rev-parse --short HEAD)}"
+          safe="${ref//\//-}"
+          src="$(ls appimage/PlotJuggler-*-x86_64.AppImage)"
+          dest="appimage/PlotJuggler-${safe}-x86_64.AppImage"
+          [ "${src}" = "${dest}" ] || mv "${src}" "${dest}"
+          echo "APPIMAGE=${dest}" >> "${GITHUB_ENV}"
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ format('PlotJuggler-{0}-x86_64.AppImage', github.ref_name) }}
+          path: ${{ env.APPIMAGE }}
+          if-no-files-found: error
+
+      - name: Attach AppImage to the GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v3
+        with:
+          files: ${{ env.APPIMAGE }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/appimage/.gitignore
+++ b/appimage/.gitignore
@@ -1,6 +1,6 @@
 # linuxdeploy tooling fetched on demand by build_appimage.sh
 linuxdeploy*.AppImage
 # Icon rasterized from resources/svg/plotjuggler.svg at build time
-pj_app.png
+plotjuggler4.png
 # Build output
 PlotJuggler-*.AppImage

--- a/appimage/.gitignore
+++ b/appimage/.gitignore
@@ -1,0 +1,6 @@
+# linuxdeploy tooling fetched on demand by build_appimage.sh
+linuxdeploy*.AppImage
+# Icon rasterized from resources/svg/plotjuggler.svg at build time
+pj_app.png
+# Build output
+PlotJuggler-*.AppImage

--- a/appimage/AppRun.sh
+++ b/appimage/AppRun.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Custom AppRun for the PlotJuggler 4 AppImage.
+#
+# Replaces linuxdeploy's generated launcher so we can inject --plugin-dir,
+# pointing pj_app at the plugins baked into the image. The library/Qt
+# environment that the stock AppRun would set is reproduced here.
+set -e
+
+# $APPDIR is set by the AppImage runtime when mounted; fall back to this
+# script's location for `--appimage-extract`ed / manual runs.
+HERE="$(dirname "$(readlink -f "${0}")")"
+APPDIR="${APPDIR:-${HERE}}"
+
+export LD_LIBRARY_PATH="${APPDIR}/usr/lib:${LD_LIBRARY_PATH:-}"
+export QT_PLUGIN_PATH="${APPDIR}/usr/plugins:${QT_PLUGIN_PATH:-}"
+export XDG_DATA_DIRS="${APPDIR}/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+
+# IBus input-context module loaded from a system/older Qt segfaults under the
+# bundled Qt 6.11 runtime (same reason run.sh unsets it for dev runs).
+unset QT_IM_MODULE
+
+# Bundled plugins. The dir is read-only inside the mounted image, so the
+# marketplace cannot install here — see KNOWN LIMITATION in build_appimage.sh.
+PJ_PLUGINS="${APPDIR}/usr/share/pj_app/plugins"
+
+# Don't double up if the user passes their own --plugin-dir.
+for arg in "$@"; do
+  case "${arg}" in
+    --plugin-dir|--plugin-dir=*) exec "${APPDIR}/usr/bin/pj_app" "$@" ;;
+  esac
+done
+
+exec "${APPDIR}/usr/bin/pj_app" --plugin-dir "${PJ_PLUGINS}" "$@"

--- a/appimage/AppRun.sh
+++ b/appimage/AppRun.sh
@@ -2,9 +2,11 @@
 #
 # Custom AppRun for the PlotJuggler 4 AppImage.
 #
-# Replaces linuxdeploy's generated launcher so we can inject --plugin-dir,
-# pointing pj_app at the plugins baked into the image. The library/Qt
-# environment that the stock AppRun would set is reproduced here.
+# Replaces linuxdeploy's generated launcher purely to reproduce the library/Qt
+# environment the stock AppRun would set. It does NOT inject --plugin-dir: the
+# app auto-discovers the bundled plugins at <prefix>/lib/plotjuggler/plugins
+# (usr/bin/plotjuggler4 -> ../lib/plotjuggler/plugins), so --plugin-dir stays a
+# user-facing option — anything the user passes is forwarded verbatim via "$@".
 set -e
 
 # $APPDIR is set by the AppImage runtime when mounted; fall back to this
@@ -20,15 +22,4 @@ export XDG_DATA_DIRS="${APPDIR}/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr
 # bundled Qt 6.11 runtime (same reason run.sh unsets it for dev runs).
 unset QT_IM_MODULE
 
-# Bundled plugins. The dir is read-only inside the mounted image, so the
-# marketplace cannot install here — see KNOWN LIMITATION in build_appimage.sh.
-PJ_PLUGINS="${APPDIR}/usr/share/pj_app/plugins"
-
-# Don't double up if the user passes their own --plugin-dir.
-for arg in "$@"; do
-  case "${arg}" in
-    --plugin-dir|--plugin-dir=*) exec "${APPDIR}/usr/bin/pj_app" "$@" ;;
-  esac
-done
-
-exec "${APPDIR}/usr/bin/pj_app" --plugin-dir "${PJ_PLUGINS}" "$@"
+exec "${APPDIR}/usr/bin/plotjuggler4" "$@"

--- a/appimage/README.md
+++ b/appimage/README.md
@@ -1,18 +1,111 @@
-# PlotJuggler 4 — AppImage packaging (first draft)
+# PlotJuggler 4 — AppImage packaging
 
 Builds a single relocatable `PlotJuggler-<version>-x86_64.AppImage` bundling the
-`pj_app` shell, its Qt 6 + Conan runtime, and a fixed set of plugins.
+`plotjuggler4` shell, its Qt 6 + Conan runtime, and (optionally) a set of plugins.
 
 ## Build
 
 ```bash
 ./install_qt6.sh        # once: Qt into ./.qt
-./build.sh              # builds build/pj_app/pj_app + Conan runtime env
-# build the plugin .so files (see plotjuggler_sdk/pj_ported_plugins/)
-appimage/build_appimage.sh
+./build.sh              # builds build/pj_app/plotjuggler4 + Conan runtime env
+
+appimage/build_appimage.sh                       # app-only AppImage
+appimage/build_appimage.sh --plugins-dir <path>  # bundle a local plugin folder
+appimage/build_appimage.sh --plugins-registry    # bundle the official set (CI default)
 ```
 
 Output lands at `appimage/PlotJuggler-<version>-x86_64.AppImage`.
+
+## Plugins
+
+Plugins are **not** part of this repo. They are built and published separately by
+[`pj-official-plugins`](https://github.com/PlotJuggler/pj-official-plugins) as
+self-contained, per-extension marketplace zips (each = the plugin `.so` + its
+`manifest.json`, with heavy dependencies static-linked), and indexed for download
+by the [`pj-plugin-registry`](https://github.com/PlotJuggler/pj-plugin-registry).
+Because the `.so`s are self-contained, bundling is just *copy/unpack* — no
+dependency deployment.
+
+There are two ways to bundle them (and a no-plugin default):
+
+- **`--plugins-dir <path>`** — copy a folder you curated, verbatim, into
+  `usr/lib/plotjuggler/plugins/`. Use this for local/offline builds; the folder
+  must contain ready-to-run (self-contained) plugins, e.g. unpacked marketplace
+  zips, each in its own subdirectory.
+- **`--plugins-registry [url]`** — download the curated set (`BUNDLE_IDS` in
+  `build_appimage.sh`) from the plugin registry, verify each `sha256` checksum,
+  and unpack into `usr/lib/plotjuggler/plugins/<id>/`. Defaults to the registry's
+  `main`; pass a URL to pin a specific ref. This is what CI uses.
+- **(no flag)** — app-only AppImage. Users add plugins later via the in-app
+  marketplace or `--plugin-dir`.
+
+### Curated set (`--plugins-registry`)
+
+The registry lists every official extension; the AppImage bundles this subset
+(`BUNDLE_IDS`):
+
+`csv-loader`, `mcap-loader`, `parquet-loader`, `dummy-streamer`,
+`foxglove-bridge`, `plotjuggler-bridge`, `ros-parser`, `protobuf-parser`,
+`json-parser`, `toolbox-quaternion`.
+
+Not bundled: `ros2-stream`, `toolbox-mosaico`, `toolbox-transform-editor` (not
+published to the registry — ROS 2 streaming needs a host ROS install, so it is
+installed by the user, not baked in); `toolbox-colormap`,
+`toolbox-reactive-scripts-editor` (excluded by request).
+
+### Where plugins live, and why
+
+Bundled plugins go under `usr/lib/plotjuggler/plugins/<id>/` — the FHS-correct
+bucket for arch-dependent `.so` code, and the exact path the installed
+`plotjuggler4` auto-discovers relative to itself (`usr/bin/plotjuggler4` →
+`../lib/plotjuggler/plugins`). Kept out of `usr/plugins/` so the recursive plugin
+scanner does not collide with Qt's own platform plugins that
+`linuxdeploy-plugin-qt` deploys there. `AppRun.sh` therefore does **not** pass
+`--plugin-dir`; that flag stays a user-facing option, forwarded verbatim if the
+user supplies one. Marketplace installs land in the writable per-user extensions
+dir, which the app also scans — so installing from within the AppImage works,
+separately from the read-only bundle.
+
+## CI
+
+`.github/workflows/release.yml` builds the AppImage with `--plugins-registry` and,
+on a `v*` tag, attaches it to the GitHub Release (`workflow_dispatch` builds an
+artifact only). It reuses the Qt/Conan/ccache caching from `linux-ci.yml`.
+
+## Follow-up: multi-distro ROS 2
+
+The goal is for a **single AppImage to support multiple ROS 2 distros**
+(humble / iron / jazzy / rolling). `pj-official-plugins` already builds this as
+one `linux-x86_64` zip: a distro-agnostic **proxy** (`libros2_stream_plugin.so`,
+links no ROS) plus per-distro inner libraries under `dist/<distro>/`. At runtime
+the proxy detects the user's distro (`$ROS_DISTRO` → `/opt/ros/<distro>` →
+`$CONDA_PREFIX/share/<distro>`) and `dlopen`s the matching inner, which binds to
+the user's **sourced system ROS** (the inners are intentionally *not*
+self-contained — they must speak to the live ROS graph).
+
+The AppImage needs **no special handling** for this: registry-mode already
+unpacks any zip into `usr/lib/plotjuggler/plugins/<id>/` verbatim, preserving the
+`dist/<distro>/` layout the proxy resolves relative to itself. The blockers are
+in other repos.
+
+**To enable it (other repos, not this one):**
+
+0. **`pj-official-plugins` — proxy must be self-describing for discovery**
+   ([PR #169](https://github.com/PlotJuggler/pj-official-plugins/pull/169)). The
+   proxy now returns a *static* vtable carrying its embedded manifest, so the
+   host plugin scanner can discover and catalog the extension on a machine with
+   **no ROS installed** (the per-distro inner is `dlopen`-ed lazily, only when a
+   source is instantiated). Without this, installing/bundling the plugin on a
+   non-ROS machine fails discovery ("not a valid plugin"). Prerequisite for
+   marketplace/registry/AppImage distribution.
+1. **`pj-official-plugins`** — in `ci-ros2.yml`, attach `ros2_subscriber-linux-x86_64.zip`
+   to a GitHub Release on tag (as `build-release.yml` does for the other
+   extensions), so it has a stable `releases/download/...` URL.
+2. **`pj-plugin-registry`** — add a `ros2-stream` extension entry whose
+   `platforms.linux-x86_64.url` + `checksum` point at that release asset.
+
+Then, here: uncomment `ros2-stream` in `BUNDLE_IDS` (see `build_appimage.sh`).
+No other change — the proxy+inners flow through registry-mode unchanged.
 
 ## How it differs from PlotJuggler 3
 
@@ -21,45 +114,9 @@ PJ4 links Qt from `./.qt` and most external dependencies from Conan, so the buil
 script points `linuxdeploy` at both (`QMAKE`, `PATH`, and sourcing
 `build/conanrun.sh` for the Conan library closure).
 
-## Plugins in this release
+## Known limitations
 
-Baked in (the required set):
-
-| Source dir | `.so` |
-|---|---|
-| data_load_MCAP | libmcap_source_plugin.so |
-| data_load_CSV | libcsv_source_plugin.so |
-| data_load_parquet | libparquet_source_plugin.so |
-| data_stream_dummy | libdummy_stream_plugin.so |
-| data_stream_ros2 | libros2_stream_plugin.so (+ per-distro inners) |
-| data_stream_foxglove_bridge | libfoxglove_source_plugin.so |
-| data_stream_pj_bridge | libpj_bridge_source_plugin.so |
-| parser_ros | libparser_ros_plugin.so |
-| parser_protobuf | libparser_protobuf_plugin.so |
-| parser_json | libparser_json_plugin.so |
-| toolbox_mosaico | libtoolbox_mosaico_plugin.so |
-| toolbox_quaternion | libtoolbox_quaternion_plugin.so |
-| toolbox_transform_editor | libtoolbox_transform_editor_plugin.so |
-
-Deliberately excluded: `toolbox_colormap`, `toolbox_reactive_scripts_editor`.
-
-App plugins are placed under `usr/share/pj_app/plugins/<source-dir>/` — kept out
-of `usr/plugins/` so the recursive plugin scanner does not collide with Qt's own
-platform plugins that `linuxdeploy-plugin-qt` deploys there. `AppRun.sh` points
-`pj_app` at this directory via `--plugin-dir`.
-
-## Known limitations (first draft)
-
-1. **Marketplace install is inert inside the AppImage.** `--plugin-dir` is both
-   the scan dir and the marketplace install target, and the bundled dir is
-   read-only when the image is mounted. The fix is to seed the bundled plugins
-   into the writable `AppDataLocation` on first run and let the default path
-   handle installs; not yet done.
-2. **ROS 2 plugins need a ROS install on the user's machine.** The bundled proxy
-   detects `ROS_DISTRO` / `/opt/ros/*` and `dlopen`s a per-distro inner. The
-   inner libraries are bundled but resolve `rclcpp` against the user's ROS at
-   runtime — they are not self-contained.
-3. **Qt-module coverage for app plugins is not separately analyzed.** The Qt
-   plugin deploys modules based on `pj_app`; a plugin needing a Qt module that
-   `pj_app` does not pull would be missed. None observed yet; revisit if a
-   plugin fails to load with a missing-`libQt6*` error.
+1. **Qt-module coverage for plugins is not separately analyzed.** The Qt plugin
+   deploys modules based on `plotjuggler4`; a plugin needing a Qt module that the
+   app does not pull would be missed. None observed yet; revisit if a plugin
+   fails to load with a missing-`libQt6*` error.

--- a/appimage/README.md
+++ b/appimage/README.md
@@ -1,0 +1,65 @@
+# PlotJuggler 4 — AppImage packaging (first draft)
+
+Builds a single relocatable `PlotJuggler-<version>-x86_64.AppImage` bundling the
+`pj_app` shell, its Qt 6 + Conan runtime, and a fixed set of plugins.
+
+## Build
+
+```bash
+./install_qt6.sh        # once: Qt into ./.qt
+./build.sh              # builds build/pj_app/pj_app + Conan runtime env
+# build the plugin .so files (see plotjuggler_sdk/pj_ported_plugins/)
+appimage/build_appimage.sh
+```
+
+Output lands at `appimage/PlotJuggler-<version>-x86_64.AppImage`.
+
+## How it differs from PlotJuggler 3
+
+PJ3 linked the system Qt 5, so `linuxdeploy-plugin-qt` found Qt on system paths.
+PJ4 links Qt from `./.qt` and most external dependencies from Conan, so the build
+script points `linuxdeploy` at both (`QMAKE`, `PATH`, and sourcing
+`build/conanrun.sh` for the Conan library closure).
+
+## Plugins in this release
+
+Baked in (the required set):
+
+| Source dir | `.so` |
+|---|---|
+| data_load_MCAP | libmcap_source_plugin.so |
+| data_load_CSV | libcsv_source_plugin.so |
+| data_load_parquet | libparquet_source_plugin.so |
+| data_stream_dummy | libdummy_stream_plugin.so |
+| data_stream_ros2 | libros2_stream_plugin.so (+ per-distro inners) |
+| data_stream_foxglove_bridge | libfoxglove_source_plugin.so |
+| data_stream_pj_bridge | libpj_bridge_source_plugin.so |
+| parser_ros | libparser_ros_plugin.so |
+| parser_protobuf | libparser_protobuf_plugin.so |
+| parser_json | libparser_json_plugin.so |
+| toolbox_mosaico | libtoolbox_mosaico_plugin.so |
+| toolbox_quaternion | libtoolbox_quaternion_plugin.so |
+| toolbox_transform_editor | libtoolbox_transform_editor_plugin.so |
+
+Deliberately excluded: `toolbox_colormap`, `toolbox_reactive_scripts_editor`.
+
+App plugins are placed under `usr/share/pj_app/plugins/<source-dir>/` — kept out
+of `usr/plugins/` so the recursive plugin scanner does not collide with Qt's own
+platform plugins that `linuxdeploy-plugin-qt` deploys there. `AppRun.sh` points
+`pj_app` at this directory via `--plugin-dir`.
+
+## Known limitations (first draft)
+
+1. **Marketplace install is inert inside the AppImage.** `--plugin-dir` is both
+   the scan dir and the marketplace install target, and the bundled dir is
+   read-only when the image is mounted. The fix is to seed the bundled plugins
+   into the writable `AppDataLocation` on first run and let the default path
+   handle installs; not yet done.
+2. **ROS 2 plugins need a ROS install on the user's machine.** The bundled proxy
+   detects `ROS_DISTRO` / `/opt/ros/*` and `dlopen`s a per-distro inner. The
+   inner libraries are bundled but resolve `rclcpp` against the user's ROS at
+   runtime — they are not self-contained.
+3. **Qt-module coverage for app plugins is not separately analyzed.** The Qt
+   plugin deploys modules based on `pj_app`; a plugin needing a Qt module that
+   `pj_app` does not pull would be missed. None observed yet; revisit if a
+   plugin fails to load with a missing-`libQt6*` error.

--- a/appimage/build_appimage.sh
+++ b/appimage/build_appimage.sh
@@ -2,68 +2,112 @@
 #
 # Build a relocatable PlotJuggler 4 AppImage.
 #
-# FIRST DRAFT. Bundles the pj_app shell, its Qt 6 + Conan runtime, and a fixed
-# allow-list of plugins (see RELEASE_PLUGINS below) into a single self-contained
-# AppImage. Unlike PJ3 (system Qt 5), PJ4 links Qt from ./.qt and most external
-# deps from Conan, so linuxdeploy must be pointed at both — that is the bulk of
-# the env setup here.
+# Bundles the plotjuggler4 shell and its Qt 6 + Conan runtime into a single
+# self-contained AppImage. Unlike PJ3 (system Qt 5), PJ4 links Qt from ./.qt and
+# most external deps from Conan, so linuxdeploy must be pointed at both — that is
+# the bulk of the env setup here.
 #
 # Prerequisites (run these first, they are NOT done here):
-#   ./install_qt6.sh                         # Qt into ./.qt/<ver>/gcc_64
-#   ./build.sh                               # builds build/pj_app/pj_app + Conan env
-#   the plugin .so files must already be built under plotjuggler_sdk/pj_ported_plugins/
-#   (see that module's build.sh / rebuild_all_and_gather.sh)
+#   ./install_qt6.sh      # Qt into ./.qt/<ver>/gcc_64
+#   ./build.sh            # builds build/pj_app/plotjuggler4 + Conan env
 #
-# Usage:
-#   appimage/build_appimage.sh            # -> PlotJuggler-4.0.0-dev-x86_64.AppImage
+# Plugins are NOT part of this repo — they are built and published separately by
+# pj-official-plugins (per-extension marketplace zips) and indexed by the
+# pj-plugin-registry. There are two ways to bundle them (and a no-plugin default):
 #
-# KNOWN LIMITATION (first draft): the bundled plugin directory lives inside the
-# read-only AppImage and is passed to pj_app via --plugin-dir, which is ALSO the
-# directory the marketplace would install into. Marketplace install is therefore
-# inert from within the AppImage. Making installs work means seeding the bundled
-# plugins into the writable AppDataLocation on first run instead; deferred.
+#   appimage/build_appimage.sh                       # app-only AppImage
+#   appimage/build_appimage.sh --plugins-dir <path>  # LOCAL: copy a folder you
+#                                                    #   curated, verbatim, into
+#                                                    #   usr/lib/plotjuggler/plugins
+#   appimage/build_appimage.sh --plugins-registry [url]
+#                                                    # REGISTRY: download the
+#                                                    #   curated set (BUNDLE_IDS)
+#                                                    #   from the plugin registry,
+#                                                    #   verify checksums, unpack
+#
+# Bundled plugins land at usr/lib/plotjuggler/plugins, which the app auto-discovers
+# as a built-in search path (no --plugin-dir needed). Marketplace installs go to
+# the writable per-user extensions dir, which the app also scans — so installing
+# from within the AppImage works and is kept separate from the read-only bundle.
 set -euo pipefail
 
 ARCH="x86_64"
 QT_VERSION="6.11.1"
+PLATFORM="linux-${ARCH}"   # registry artifact key (registry.json platforms.<key>)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 BUILD="${ROOT}/build"
 QT_DIR="${ROOT}/.qt/${QT_VERSION}/gcc_64"
-PLUGINS_BUILD="${ROOT}/plotjuggler_sdk/pj_ported_plugins"
 APPDIR="${BUILD}/AppDir"
 VERSION="4.0.0-dev"   # keep in sync with pj_app/src/main.cpp setApplicationVersion()
 
-# --- Plugins that MUST ship in the release. Values are the built .so basenames.
-#     ROS source/parser plugins are distro-agnostic proxies (no rclcpp link); the
-#     per-distro inner .so files are bundled separately below.
-declare -A RELEASE_PLUGINS=(
-  [data_load_MCAP]=libmcap_source_plugin.so
-  [data_load_CSV]=libcsv_source_plugin.so
-  [data_load_parquet]=libparquet_source_plugin.so
-  [data_stream_dummy]=libdummy_stream_plugin.so
-  [data_stream_ros2]=libros2_stream_plugin.so
-  [data_stream_foxglove_bridge]=libfoxglove_source_plugin.so
-  [data_stream_pj_bridge]=libpj_bridge_source_plugin.so
-  [parser_ros]=libparser_ros_plugin.so
-  [parser_protobuf]=libparser_protobuf_plugin.so
-  [parser_json]=libparser_json_plugin.so
-  [toolbox_mosaico]=libtoolbox_mosaico_plugin.so
-  [toolbox_quaternion]=libtoolbox_quaternion_plugin.so
-  [toolbox_transform_editor]=libtoolbox_transform_editor_plugin.so
+# Bundled plugins go where the installed app looks by default: <prefix>/lib/
+# plotjuggler/plugins, which plotjuggler4 resolves relative to itself (usr/bin ->
+# ../lib/plotjuggler/plugins). Kept OUT of usr/plugins on purpose —
+# linuxdeploy-plugin-qt deploys Qt's own platform/imageformat plugins there, and
+# the app's plugin scanner must never try to dlopen those as PlotJuggler plugins.
+PJ_PLUGINS_REL="usr/lib/plotjuggler/plugins"
+
+# The plugin registry to resolve --plugins-registry against. Tracks main (latest
+# published plugin versions); override with the optional --plugins-registry <url>
+# argument to pin a specific ref.
+REGISTRY_URL="https://raw.githubusercontent.com/PlotJuggler/pj-plugin-registry/main/registry.json"
+
+# Curated set of registry extension ids bundled by --plugins-registry. The
+# registry lists every official extension; this is the subset that ships in the
+# AppImage. Excluded by request: toolbox-colormap, toolbox-reactive-scripts-editor.
+# Not yet bundle-able (absent from the registry): toolbox-mosaico,
+# toolbox-transform-editor.
+BUNDLE_IDS=(
+  csv-loader
+  mcap-loader
+  parquet-loader
+  dummy-streamer
+  foxglove-bridge
+  plotjuggler-bridge
+  ros-parser
+  protobuf-parser
+  json-parser
+  toolbox-quaternion
+  # ros2-stream  # <-- multi-distro ROS 2 subscriber. Uncomment once it is
+  #                 published to a release + indexed in pj-plugin-registry (see
+  #                 "Follow-up: multi-distro ROS 2" in README.md). The single
+  #                 linux-x86_64 zip carries the distro-agnostic proxy + per-distro
+  #                 inners under dist/<distro>/; registry-mode unpacks it verbatim,
+  #                 so no special handling is needed here once the entry exists.
 )
-# Explicitly excluded by request (documented so a future "bundle everything"
-# sweep does not silently pull them back in):
-#   toolbox_colormap, toolbox_reactive_scripts_editor
+
+PLUGINS_MODE="none"        # none | local | registry
+PLUGINS_LOCAL_DIR=""
+
+usage() {
+  sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --plugins-dir)
+      PLUGINS_MODE="local"; PLUGINS_LOCAL_DIR="${2:?--plugins-dir needs a path}"; shift 2 ;;
+    --plugins-registry)
+      PLUGINS_MODE="registry"
+      # Optional URL argument (anything not starting with '-').
+      if [[ -n "${2:-}" && "${2}" != -* ]]; then REGISTRY_URL="$2"; shift; fi
+      shift ;;
+    -h | --help)
+      usage; exit 0 ;;
+    *)
+      echo "build_appimage: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
 
 # ---------------------------------------------------------------------------
 # 0. Sanity checks
 # ---------------------------------------------------------------------------
-[[ -d "${QT_DIR}" ]]            || { echo "Qt not found at ${QT_DIR}. Run ./install_qt6.sh"; exit 1; }
-[[ -x "${BUILD}/pj_app/pj_app" ]] || { echo "pj_app not built. Run ./build.sh"; exit 1; }
-[[ -f "${BUILD}/conanrun.sh" ]] || { echo "build/conanrun.sh missing. Run ./build.sh"; exit 1; }
-command -v wget >/dev/null     || { echo "wget required"; exit 1; }
+[[ -d "${QT_DIR}" ]]                    || { echo "Qt not found at ${QT_DIR}. Run ./install_qt6.sh"; exit 1; }
+[[ -x "${BUILD}/pj_app/plotjuggler4" ]] || { echo "plotjuggler4 not built. Run ./build.sh"; exit 1; }
+[[ -f "${BUILD}/conanrun.sh" ]]         || { echo "build/conanrun.sh missing. Run ./build.sh"; exit 1; }
+command -v wget >/dev/null              || { echo "wget required"; exit 1; }
 
 # ---------------------------------------------------------------------------
 # 1. linuxdeploy + its Qt plugin (themselves AppImages, fetched once)
@@ -78,17 +122,13 @@ chmod +x "${LD}" "${LDQT}"
 # ---------------------------------------------------------------------------
 # 2. Assemble the AppDir skeleton
 # ---------------------------------------------------------------------------
-# App plugins live OUTSIDE usr/plugins on purpose: linuxdeploy-plugin-qt deploys
-# Qt's own platform/imageformat plugins into usr/plugins, and pj_app's recursive
-# .so scanner would otherwise try to dlopen those as PlotJuggler plugins.
-PJ_PLUGINS_REL="usr/share/pj_app/plugins"
 rm -rf "${APPDIR}"
 mkdir -p "${APPDIR}/usr/bin" "${APPDIR}/${PJ_PLUGINS_REL}"
-# pj_app itself is installed by linuxdeploy via --executable below (it copies the
-# binary into usr/bin and deploys its Qt + Conan dependency closure).
+# plotjuggler4 itself is installed by linuxdeploy via --executable below (it copies
+# the binary into usr/bin and deploys its Qt + Conan dependency closure).
 
 # Icon: rasterize the app SVG (linuxdeploy wants a PNG named like the desktop Icon=).
-ICON_PNG="${SCRIPT_DIR}/pj_app.png"
+ICON_PNG="${SCRIPT_DIR}/plotjuggler4.png"
 if [[ ! -f "${ICON_PNG}" ]]; then
   if command -v convert >/dev/null; then
     convert -background none -resize 256x256 "${ROOT}/resources/svg/plotjuggler.svg" "${ICON_PNG}"
@@ -98,46 +138,67 @@ if [[ ! -f "${ICON_PNG}" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 3. Collect the allow-listed plugins (.so + sidecar manifest) into per-id
-#    subdirs of usr/plugins. pj_app scans this tree recursively.
+# 3. Bundle plugins (per the selected mode) into per-id subdirs of
+#    ${PJ_PLUGINS_REL}. The app scans this tree recursively. Published plugins
+#    are self-contained (heavy deps static-linked), so no dependency deployment
+#    is needed — a plain copy/unpack is the install.
 # ---------------------------------------------------------------------------
-find_plugin_so() {  # echoes the first matching built .so path, or nothing
-  find "${PLUGINS_BUILD}" -path '*/Release/bin/*' -name "$1" -print 2>/dev/null | head -1
+collect_plugins_local() {
+  [[ -d "${PLUGINS_LOCAL_DIR}" ]] || { echo "ERROR: --plugins-dir '${PLUGINS_LOCAL_DIR}' is not a directory"; exit 1; }
+  echo "Plugins: copying local folder '${PLUGINS_LOCAL_DIR}' -> ${PJ_PLUGINS_REL}"
+  cp -a "${PLUGINS_LOCAL_DIR}/." "${APPDIR}/${PJ_PLUGINS_REL}/"
 }
 
-PLUGIN_EXEC_ARGS=()
-for name in "${!RELEASE_PLUGINS[@]}"; do
-  so_name="${RELEASE_PLUGINS[$name]}"
-  so_path="$(find_plugin_so "${so_name}")"
-  if [[ -z "${so_path}" ]]; then
-    echo "ERROR: required plugin '${name}' (${so_name}) not built — build it first."; exit 1
-  fi
-  dest="${APPDIR}/${PJ_PLUGINS_REL}/${name}"
-  mkdir -p "${dest}"
-  cp -v "${so_path}" "${dest}/"
-  # Sidecar manifest sits next to the .so in the build tree.
-  manifest="$(dirname "${so_path}")/$(basename "${so_name}" .so | sed 's/^lib//').pjmanifest.json"
-  [[ -f "${manifest}" ]] && cp -v "${manifest}" "${dest}/"
-  # --deploy-deps-only: pull each plugin's own NEEDED libs (mcap, arrow,
-  # protobuf, …) into usr/lib but leave the .so where we placed it.
-  PLUGIN_EXEC_ARGS+=(--deploy-deps-only "${dest}/${so_name}")
-done
+collect_plugins_registry() {
+  command -v python3   >/dev/null || { echo "python3 required for --plugins-registry"; exit 1; }
+  command -v unzip     >/dev/null || { echo "unzip required for --plugins-registry"; exit 1; }
+  command -v sha256sum >/dev/null || { echo "sha256sum required for --plugins-registry"; exit 1; }
 
-# ROS 2 per-distro inner libraries. The proxy resolves its inner via dladdr at
-# the fixed path dist/<distro>/libros2_stream_plugin-<distro>.so relative to
-# itself, so the layout is mandatory — a flat copy makes the proxy return a null
-# vtable and the plugin never registers. Each inner resolves rclcpp against the
-# user's sourced ROS install at runtime; non-matching distros simply fail to
-# dlopen and are skipped by the per-file-tolerant scanner.
-ROS2_DEST="${APPDIR}/${PJ_PLUGINS_REL}/data_stream_ros2"
-while IFS= read -r inner; do
-  [[ -z "${inner}" ]] && continue
-  base="$(basename "${inner}")"                    # libros2_stream_plugin-humble.so
-  distro="${base#libros2_stream_plugin-}"          # humble.so
-  distro="${distro%.so}"                           # humble
-  mkdir -p "${ROS2_DEST}/dist/${distro}"
-  cp -v "${inner}" "${ROS2_DEST}/dist/${distro}/"
-done < <(find "${PLUGINS_BUILD}" -name 'libros2_stream_plugin-*.so' -path '*/Release/bin/*' 2>/dev/null | sort -u)
+  local registry_json; registry_json="$(mktemp)"
+  echo "Plugins: fetching registry ${REGISTRY_URL}"
+  wget -qO "${registry_json}" "${REGISTRY_URL}" || { echo "ERROR: failed to download registry"; exit 1; }
+
+  local id url checksum want got zip dest
+  for id in "${BUNDLE_IDS[@]}"; do
+    # Resolve this extension's url + checksum for our platform from the registry.
+    read -r url checksum < <(python3 - "${registry_json}" "${id}" "${PLATFORM}" <<'PY'
+import json, sys
+reg, want_id, plat = sys.argv[1], sys.argv[2], sys.argv[3]
+data = json.load(open(reg))
+for ext in data.get("extensions", []):
+    if ext.get("id") == want_id:
+        p = ext.get("platforms", {}).get(plat)
+        if p:
+            print(p.get("url", ""), p.get("checksum", ""))
+        break
+PY
+)
+    [[ -n "${url}" ]] || { echo "ERROR: registry has no '${id}' for ${PLATFORM}"; exit 1; }
+
+    zip="$(mktemp --suffix=.zip)"
+    echo "  ${id}: ${url}"
+    wget -qO "${zip}" "${url}" || { echo "ERROR: download failed for '${id}'"; exit 1; }
+
+    want="${checksum#sha256:}"   # registry value is 'sha256:<hex>'
+    if [[ -n "${want}" ]]; then
+      got="$(sha256sum "${zip}" | awk '{print $1}')"
+      [[ "${got}" == "${want}" ]] || { echo "ERROR: checksum mismatch for '${id}' (want ${want}, got ${got})"; exit 1; }
+    fi
+
+    dest="${APPDIR}/${PJ_PLUGINS_REL}/${id}"
+    mkdir -p "${dest}"
+    unzip -oq "${zip}" -d "${dest}"
+    rm -f "${zip}"
+  done
+  rm -f "${registry_json}"
+  echo "Plugins: bundled ${#BUNDLE_IDS[@]} extension(s) from the registry for ${PLATFORM}"
+}
+
+case "${PLUGINS_MODE}" in
+  local)    collect_plugins_local ;;
+  registry) collect_plugins_registry ;;
+  none)     echo "Plugins: none (app-only AppImage; pass --plugins-dir or --plugins-registry to bundle)" ;;
+esac
 
 # ---------------------------------------------------------------------------
 # 4. Runtime env so linuxdeploy resolves Qt (from ./.qt) and Conan deps.
@@ -151,15 +212,16 @@ export PATH="${QT_DIR}/bin:${PATH}"
 export LD_LIBRARY_PATH="${QT_DIR}/lib:${LD_LIBRARY_PATH:-}"
 
 # ---------------------------------------------------------------------------
-# 5. Package
+# 5. Package. Bundled plugins are self-contained, so they are not handed to
+#    linuxdeploy (no --deploy-deps-only) — it would otherwise try to process the
+#    .so closures and could collide with Qt's own deployed plugins.
 # ---------------------------------------------------------------------------
 cd "${SCRIPT_DIR}"
 OUTPUT="PlotJuggler-${VERSION}-${ARCH}.AppImage" \
   "./${LD}" \
     --appdir "${APPDIR}" \
-    --executable "${BUILD}/pj_app/pj_app" \
-    "${PLUGIN_EXEC_ARGS[@]}" \
-    --desktop-file "${SCRIPT_DIR}/pj_app.desktop" \
+    --executable "${BUILD}/pj_app/plotjuggler4" \
+    --desktop-file "${SCRIPT_DIR}/plotjuggler4.desktop" \
     --icon-file "${ICON_PNG}" \
     --custom-apprun "${SCRIPT_DIR}/AppRun.sh" \
     --plugin qt \

--- a/appimage/build_appimage.sh
+++ b/appimage/build_appimage.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# Build a relocatable PlotJuggler 4 AppImage.
+#
+# FIRST DRAFT. Bundles the pj_app shell, its Qt 6 + Conan runtime, and a fixed
+# allow-list of plugins (see RELEASE_PLUGINS below) into a single self-contained
+# AppImage. Unlike PJ3 (system Qt 5), PJ4 links Qt from ./.qt and most external
+# deps from Conan, so linuxdeploy must be pointed at both — that is the bulk of
+# the env setup here.
+#
+# Prerequisites (run these first, they are NOT done here):
+#   ./install_qt6.sh                         # Qt into ./.qt/<ver>/gcc_64
+#   ./build.sh                               # builds build/pj_app/pj_app + Conan env
+#   the plugin .so files must already be built under plotjuggler_sdk/pj_ported_plugins/
+#   (see that module's build.sh / rebuild_all_and_gather.sh)
+#
+# Usage:
+#   appimage/build_appimage.sh            # -> PlotJuggler-4.0.0-dev-x86_64.AppImage
+#
+# KNOWN LIMITATION (first draft): the bundled plugin directory lives inside the
+# read-only AppImage and is passed to pj_app via --plugin-dir, which is ALSO the
+# directory the marketplace would install into. Marketplace install is therefore
+# inert from within the AppImage. Making installs work means seeding the bundled
+# plugins into the writable AppDataLocation on first run instead; deferred.
+set -euo pipefail
+
+ARCH="x86_64"
+QT_VERSION="6.11.1"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUILD="${ROOT}/build"
+QT_DIR="${ROOT}/.qt/${QT_VERSION}/gcc_64"
+PLUGINS_BUILD="${ROOT}/plotjuggler_sdk/pj_ported_plugins"
+APPDIR="${BUILD}/AppDir"
+VERSION="4.0.0-dev"   # keep in sync with pj_app/src/main.cpp setApplicationVersion()
+
+# --- Plugins that MUST ship in the release. Values are the built .so basenames.
+#     ROS source/parser plugins are distro-agnostic proxies (no rclcpp link); the
+#     per-distro inner .so files are bundled separately below.
+declare -A RELEASE_PLUGINS=(
+  [data_load_MCAP]=libmcap_source_plugin.so
+  [data_load_CSV]=libcsv_source_plugin.so
+  [data_load_parquet]=libparquet_source_plugin.so
+  [data_stream_dummy]=libdummy_stream_plugin.so
+  [data_stream_ros2]=libros2_stream_plugin.so
+  [data_stream_foxglove_bridge]=libfoxglove_source_plugin.so
+  [data_stream_pj_bridge]=libpj_bridge_source_plugin.so
+  [parser_ros]=libparser_ros_plugin.so
+  [parser_protobuf]=libparser_protobuf_plugin.so
+  [parser_json]=libparser_json_plugin.so
+  [toolbox_mosaico]=libtoolbox_mosaico_plugin.so
+  [toolbox_quaternion]=libtoolbox_quaternion_plugin.so
+  [toolbox_transform_editor]=libtoolbox_transform_editor_plugin.so
+)
+# Explicitly excluded by request (documented so a future "bundle everything"
+# sweep does not silently pull them back in):
+#   toolbox_colormap, toolbox_reactive_scripts_editor
+
+# ---------------------------------------------------------------------------
+# 0. Sanity checks
+# ---------------------------------------------------------------------------
+[[ -d "${QT_DIR}" ]]            || { echo "Qt not found at ${QT_DIR}. Run ./install_qt6.sh"; exit 1; }
+[[ -x "${BUILD}/pj_app/pj_app" ]] || { echo "pj_app not built. Run ./build.sh"; exit 1; }
+[[ -f "${BUILD}/conanrun.sh" ]] || { echo "build/conanrun.sh missing. Run ./build.sh"; exit 1; }
+command -v wget >/dev/null     || { echo "wget required"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 1. linuxdeploy + its Qt plugin (themselves AppImages, fetched once)
+# ---------------------------------------------------------------------------
+cd "${SCRIPT_DIR}"
+LD="linuxdeploy-${ARCH}.AppImage"
+LDQT="linuxdeploy-plugin-qt-${ARCH}.AppImage"
+[[ -f "${LD}" ]]   || wget -q "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/${LD}"
+[[ -f "${LDQT}" ]] || wget -q "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/${LDQT}"
+chmod +x "${LD}" "${LDQT}"
+
+# ---------------------------------------------------------------------------
+# 2. Assemble the AppDir skeleton
+# ---------------------------------------------------------------------------
+# App plugins live OUTSIDE usr/plugins on purpose: linuxdeploy-plugin-qt deploys
+# Qt's own platform/imageformat plugins into usr/plugins, and pj_app's recursive
+# .so scanner would otherwise try to dlopen those as PlotJuggler plugins.
+PJ_PLUGINS_REL="usr/share/pj_app/plugins"
+rm -rf "${APPDIR}"
+mkdir -p "${APPDIR}/usr/bin" "${APPDIR}/${PJ_PLUGINS_REL}"
+# pj_app itself is installed by linuxdeploy via --executable below (it copies the
+# binary into usr/bin and deploys its Qt + Conan dependency closure).
+
+# Icon: rasterize the app SVG (linuxdeploy wants a PNG named like the desktop Icon=).
+ICON_PNG="${SCRIPT_DIR}/pj_app.png"
+if [[ ! -f "${ICON_PNG}" ]]; then
+  if command -v convert >/dev/null; then
+    convert -background none -resize 256x256 "${ROOT}/resources/svg/plotjuggler.svg" "${ICON_PNG}"
+  else
+    echo "WARNING: 'convert' not found and ${ICON_PNG} missing — provide an icon manually."; exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Collect the allow-listed plugins (.so + sidecar manifest) into per-id
+#    subdirs of usr/plugins. pj_app scans this tree recursively.
+# ---------------------------------------------------------------------------
+find_plugin_so() {  # echoes the first matching built .so path, or nothing
+  find "${PLUGINS_BUILD}" -path '*/Release/bin/*' -name "$1" -print 2>/dev/null | head -1
+}
+
+PLUGIN_EXEC_ARGS=()
+for name in "${!RELEASE_PLUGINS[@]}"; do
+  so_name="${RELEASE_PLUGINS[$name]}"
+  so_path="$(find_plugin_so "${so_name}")"
+  if [[ -z "${so_path}" ]]; then
+    echo "ERROR: required plugin '${name}' (${so_name}) not built — build it first."; exit 1
+  fi
+  dest="${APPDIR}/${PJ_PLUGINS_REL}/${name}"
+  mkdir -p "${dest}"
+  cp -v "${so_path}" "${dest}/"
+  # Sidecar manifest sits next to the .so in the build tree.
+  manifest="$(dirname "${so_path}")/$(basename "${so_name}" .so | sed 's/^lib//').pjmanifest.json"
+  [[ -f "${manifest}" ]] && cp -v "${manifest}" "${dest}/"
+  # --deploy-deps-only: pull each plugin's own NEEDED libs (mcap, arrow,
+  # protobuf, …) into usr/lib but leave the .so where we placed it.
+  PLUGIN_EXEC_ARGS+=(--deploy-deps-only "${dest}/${so_name}")
+done
+
+# ROS 2 per-distro inner libraries. The proxy resolves its inner via dladdr at
+# the fixed path dist/<distro>/libros2_stream_plugin-<distro>.so relative to
+# itself, so the layout is mandatory — a flat copy makes the proxy return a null
+# vtable and the plugin never registers. Each inner resolves rclcpp against the
+# user's sourced ROS install at runtime; non-matching distros simply fail to
+# dlopen and are skipped by the per-file-tolerant scanner.
+ROS2_DEST="${APPDIR}/${PJ_PLUGINS_REL}/data_stream_ros2"
+while IFS= read -r inner; do
+  [[ -z "${inner}" ]] && continue
+  base="$(basename "${inner}")"                    # libros2_stream_plugin-humble.so
+  distro="${base#libros2_stream_plugin-}"          # humble.so
+  distro="${distro%.so}"                           # humble
+  mkdir -p "${ROS2_DEST}/dist/${distro}"
+  cp -v "${inner}" "${ROS2_DEST}/dist/${distro}/"
+done < <(find "${PLUGINS_BUILD}" -name 'libros2_stream_plugin-*.so' -path '*/Release/bin/*' 2>/dev/null | sort -u)
+
+# ---------------------------------------------------------------------------
+# 4. Runtime env so linuxdeploy resolves Qt (from ./.qt) and Conan deps.
+#    conanrun.sh exports LD_LIBRARY_PATH covering every Conan package this build
+#    links (FFmpeg, cloudini, …); without it linuxdeploy drops those libs.
+# ---------------------------------------------------------------------------
+# shellcheck disable=SC1091
+source "${BUILD}/conanrun.sh"
+export QMAKE="${QT_DIR}/bin/qmake6"
+export PATH="${QT_DIR}/bin:${PATH}"
+export LD_LIBRARY_PATH="${QT_DIR}/lib:${LD_LIBRARY_PATH:-}"
+
+# ---------------------------------------------------------------------------
+# 5. Package
+# ---------------------------------------------------------------------------
+cd "${SCRIPT_DIR}"
+OUTPUT="PlotJuggler-${VERSION}-${ARCH}.AppImage" \
+  "./${LD}" \
+    --appdir "${APPDIR}" \
+    --executable "${BUILD}/pj_app/pj_app" \
+    "${PLUGIN_EXEC_ARGS[@]}" \
+    --desktop-file "${SCRIPT_DIR}/pj_app.desktop" \
+    --icon-file "${ICON_PNG}" \
+    --custom-apprun "${SCRIPT_DIR}/AppRun.sh" \
+    --plugin qt \
+    --output appimage
+
+echo ""
+echo "Done: ${SCRIPT_DIR}/PlotJuggler-${VERSION}-${ARCH}.AppImage"

--- a/appimage/pj_app.desktop
+++ b/appimage/pj_app.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=PlotJuggler 4
+GenericName=Timeseries Visualization
+Exec=pj_app
+Icon=pj_app
+Comment=Visualize timeseries like a pro
+Terminal=false
+Categories=Development;Science;Utility;
+Keywords=plot;timeseries;ros;mcap;telemetry;

--- a/appimage/plotjuggler4.desktop
+++ b/appimage/plotjuggler4.desktop
@@ -2,8 +2,8 @@
 Type=Application
 Name=PlotJuggler 4
 GenericName=Timeseries Visualization
-Exec=pj_app
-Icon=pj_app
+Exec=plotjuggler4
+Icon=plotjuggler4
 Comment=Visualize timeseries like a pro
 Terminal=false
 Categories=Development;Science;Utility;

--- a/pj_app/CMakeLists.txt
+++ b/pj_app/CMakeLists.txt
@@ -78,6 +78,10 @@ add_executable(pj_app
 )
 
 set_target_properties(pj_app PROPERTIES
+    # The CMake target id stays `pj_app` (internal module name), but the installed
+    # binary is `plotjuggler4` — the user-facing command and what packaging ships
+    # (e.g. /usr/bin/plotjuggler4). Keeps the source module rename a separate concern.
+    OUTPUT_NAME plotjuggler4
     AUTOMOC ON
     AUTORCC ON
     AUTOUIC ON

--- a/pj_runtime/src/ExtensionCatalogService.cpp
+++ b/pj_runtime/src/ExtensionCatalogService.cpp
@@ -28,8 +28,15 @@ QString defaultPendingDir() {
 // User-managed extra plugin folders (Preferences page). QStringList.
 constexpr auto kCustomPluginFoldersKey = "Preferences::plugin_folders";
 
-QString executablePluginsDir() {
-  return QCoreApplication::applicationDirPath() + QStringLiteral("/plugins");
+// Plugins bundled with an installed build. Per the FHS bin/lib split (the binary
+// installs to <prefix>/bin, arch-dependent code to <prefix>/lib), the bundled
+// plugins live at <prefix>/lib/plotjuggler/plugins, resolved relative to the
+// executable so the install stays relocatable — the same path works under /usr,
+// /usr/local, or a mounted AppImage. A dev build tree has no such directory, so
+// it is simply skipped (buildScanHierarchy drops folders that don't exist);
+// developers point at their freshly built plugins with --plugin-dir instead.
+QString bundledPluginsDir() {
+  return QDir::cleanPath(QCoreApplication::applicationDirPath() + QStringLiteral("/../lib/plotjuggler/plugins"));
 }
 }  // namespace
 
@@ -81,7 +88,7 @@ QStringList ExtensionCatalogService::builtinPluginFolders() const {
   if (marketplace != extensions_dir_) {
     folders << marketplace;
   }
-  folders << executablePluginsDir();
+  folders << bundledPluginsDir();
   return folders;
 }
 

--- a/pj_runtime/tests/app_session_test.cpp
+++ b/pj_runtime/tests/app_session_test.cpp
@@ -57,11 +57,12 @@ TEST(AppSessionTest, BuiltinPluginFoldersOrderedWithPluginDirOverride) {
   PJ::AppSession session(dir.path());
 
   const QStringList builtins = session.extensionCatalog().builtinPluginFolders();
-  // Built-in scan order: install dir (= override) > marketplace dir > <exe>/plugins.
+  // Built-in scan order: install dir (= override) > marketplace dir >
+  // <prefix>/lib/plotjuggler/plugins (bundled, FHS-relative to the executable).
   ASSERT_EQ(builtins.size(), 3);
   EXPECT_EQ(builtins.at(0), dir.path());
   EXPECT_NE(builtins.at(1), dir.path());  // marketplace location, distinct from the override
-  EXPECT_TRUE(builtins.at(2).endsWith(QStringLiteral("/plugins")));
+  EXPECT_TRUE(builtins.at(2).endsWith(QStringLiteral("/lib/plotjuggler/plugins")));
 }
 
 TEST(AppSessionTest, InvalidExtensionDirectoryReportsDiagnostic) {

--- a/run.sh
+++ b/run.sh
@@ -17,7 +17,7 @@ export QT_IM_MODULE=""
 # HTTPS traffic breaks — including the marketplace registry fetch.
 export QT_PLUGIN_PATH="${SCRIPT_DIR}/.qt/6.11.1/gcc_64/plugins"
 
-BIN="${SCRIPT_DIR}/build/pj_app/pj_app"
+BIN="${SCRIPT_DIR}/build/pj_app/plotjuggler4"
 
 # --apitrace: launch under apitrace to capture a GL call trace (a smoke-test for
 # redundant per-frame GL work — shader recompiles, full-cloud re-uploads, etc.).


### PR DESCRIPTION
This PR adds support for building and packaging a portable Windows release (`.zip`) using GitHub Actions.             
                                                                                         
# Changes                                                              

* Added packaging script (`scripts/package_windows.ps1`)
* Updated release workflow (`.github/workflows/release.yml`)
  
